### PR TITLE
implement 1-on-1 WebRTC audio calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+.claude/settings.local.json

--- a/Zyna.xcodeproj/project.pbxproj
+++ b/Zyna.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		322E77762DB083AE003921EC /* AsyncDisplayKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 322E76D72DADAA72003921EC /* AsyncDisplayKit.xcframework */; };
 		322E77772DB083AE003921EC /* AsyncDisplayKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 322E76D72DADAA72003921EC /* AsyncDisplayKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		326865392E17643900A407FD /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 326865382E17643900A407FD /* GRDB */; };
+		32ED2F0E2F59FA7E0080ED2A /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = 32ED2F0D2F59FA7E0080ED2A /* WebRTC */; };
 		32F7D3022E3D59B3009282C3 /* MatrixRustSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 32F7D3012E3D59B3009282C3 /* MatrixRustSDK */; };
 		32F7D31A2E3EE41A009282C3 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 32F7D3192E3EE41A009282C3 /* KeychainAccess */; };
 /* End PBXBuildFile section */
@@ -80,6 +81,7 @@
 				322E76DF2DADAA8B003921EC /* PINOperation.xcframework in Frameworks */,
 				32F7D31A2E3EE41A009282C3 /* KeychainAccess in Frameworks */,
 				326865392E17643900A407FD /* GRDB in Frameworks */,
+				32ED2F0E2F59FA7E0080ED2A /* WebRTC in Frameworks */,
 				322E76E22DADAA97003921EC /* PINRemoteImage.xcframework in Frameworks */,
 				32F7D3022E3D59B3009282C3 /* MatrixRustSDK in Frameworks */,
 			);
@@ -150,6 +152,7 @@
 				326865382E17643900A407FD /* GRDB */,
 				32F7D3012E3D59B3009282C3 /* MatrixRustSDK */,
 				32F7D3192E3EE41A009282C3 /* KeychainAccess */,
+				32ED2F0D2F59FA7E0080ED2A /* WebRTC */,
 			);
 			productName = Zyna;
 			productReference = 324E19562DAD578A00CB5769 /* Zyna.app */;
@@ -185,6 +188,7 @@
 				32F7D2FC2E3D35AC009282C3 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				32F7D3002E3D59B3009282C3 /* XCRemoteSwiftPackageReference "matrix-rust-components-swift" */,
 				32F7D3182E3EE41A009282C3 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
+				32ED2F0C2F59FA7E0080ED2A /* XCRemoteSwiftPackageReference "WebRTC" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 324E19572DAD578A00CB5769 /* Products */;
@@ -444,6 +448,14 @@
 				version = 7.5.0;
 			};
 		};
+		32ED2F0C2F59FA7E0080ED2A /* XCRemoteSwiftPackageReference "WebRTC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stasel/WebRTC/";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 138.0.0;
+			};
+		};
 		32F7D2FC2E3D35AC009282C3 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
@@ -475,6 +487,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 326865372E17643900A407FD /* XCRemoteSwiftPackageReference "GRDB.swift" */;
 			productName = GRDB;
+		};
+		32ED2F0D2F59FA7E0080ED2A /* WebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32ED2F0C2F59FA7E0080ED2A /* XCRemoteSwiftPackageReference "WebRTC" */;
+			productName = WebRTC;
 		};
 		32F7D2FE2E3D3EDD009282C3 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Zyna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Zyna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "36ee814ede9b1ffc26382d56dc364f4cecc6bcbe53c540d885952aff173f10f2",
+  "originHash" : "89612ead5b0b57fd2262676e010dfb2859231a0a11210d2eb580529239163ed2",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "8545ddf4de043e6f2051c5cf204f39ef778ebf6b",
         "version" : "0.59.1"
+      }
+    },
+    {
+      "identity" : "webrtc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stasel/WebRTC/",
+      "state" : {
+        "revision" : "820d216010b6bb5695139852ec6740edd6f790ff",
+        "version" : "138.0.0"
       }
     }
   ],

--- a/Zyna/Application/Info.plist
+++ b/Zyna/Application/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Zyna needs access to your microphone for voice calls.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -4,11 +4,13 @@
 //
 
 import AsyncDisplayKit
+import Combine
 import MatrixRustSDK
 
 final class ChatsCoordinator {
 
     let navigationController = ASDKNavigationController()
+    private var cancellables = Set<AnyCancellable>()
 
     func start() {
         let vc = RoomsViewController()
@@ -16,6 +18,19 @@ final class ChatsCoordinator {
             self?.showChat(room)
         }
         navigationController.setViewControllers([vc], animated: false)
+        observeIncomingCalls()
+    }
+
+    private func observeIncomingCalls() {
+        CallService.shared.stateSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard case .incomingRinging(_, _, let callerName) = state else { return }
+                // Don't present if already showing a call screen
+                guard self?.navigationController.presentedViewController == nil else { return }
+                self?.presentCallScreen(roomName: callerName ?? "Incoming Call")
+            }
+            .store(in: &cancellables)
     }
 
     private func showChat(_ room: Room) {
@@ -24,6 +39,24 @@ final class ChatsCoordinator {
         vc.onBack = { [weak self] in
             self?.navigationController.popViewController(animated: true)
         }
+        vc.onCallTapped = { [weak self] in
+            self?.startCall(in: room, timelineService: viewModel.timelineService)
+        }
         navigationController.pushViewController(vc, animated: true)
+    }
+
+    // MARK: - Calls
+
+    private func startCall(in room: Room, timelineService: TimelineService) {
+        CallService.shared.startCall(room: room, timelineService: timelineService)
+        presentCallScreen(roomName: room.displayName() ?? "Call")
+    }
+
+    func presentCallScreen(roomName: String) {
+        let callVC = CallViewController(roomName: roomName)
+        callVC.onDismiss = { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        }
+        navigationController.present(callVC, animated: true)
     }
 }

--- a/Zyna/Screens/Call/CallNode.swift
+++ b/Zyna/Screens/Call/CallNode.swift
@@ -1,0 +1,146 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+// MARK: - Call Node
+
+final class CallNode: ASDisplayNode {
+
+    let nameLabel = ASTextNode()
+    let statusLabel = ASTextNode()
+    let avatarNode = ASDisplayNode()
+
+    let acceptButton = ASButtonNode()
+    let muteButton = ASButtonNode()
+    let speakerButton = ASButtonNode()
+    let endCallButton = ASButtonNode()
+
+    override init() {
+        super.init()
+        automaticallyManagesSubnodes = true
+        setupNodes()
+    }
+
+    private func setupNodes() {
+        // Avatar placeholder
+        avatarNode.style.preferredSize = CGSize(width: 100, height: 100)
+        avatarNode.cornerRadius = 50
+        avatarNode.backgroundColor = .systemGray4
+
+        // Name
+        nameLabel.maximumNumberOfLines = 1
+
+        // Status
+        statusLabel.maximumNumberOfLines = 1
+
+        // Accept button (hidden by default, shown for incoming calls)
+        acceptButton.setImage(Self.symbol("phone.fill", size: 24, color: .white), for: .normal)
+        acceptButton.style.preferredSize = CGSize(width: 70, height: 70)
+        acceptButton.cornerRadius = 35
+        acceptButton.backgroundColor = .systemGreen
+        acceptButton.isHidden = true
+
+        // Mute button
+        muteButton.setImage(Self.symbol("mic.fill", size: 24, color: .white), for: .normal)
+        muteButton.setImage(Self.symbol("mic.slash.fill", size: 24, color: .white), for: .selected)
+        muteButton.style.preferredSize = CGSize(width: 60, height: 60)
+        muteButton.cornerRadius = 30
+        muteButton.backgroundColor = .systemGray
+
+        // Speaker button
+        speakerButton.setImage(Self.symbol("speaker.wave.2.fill", size: 24, color: .white), for: .normal)
+        speakerButton.setImage(Self.symbol("speaker.wave.3.fill", size: 24, color: .white), for: .selected)
+        speakerButton.style.preferredSize = CGSize(width: 60, height: 60)
+        speakerButton.cornerRadius = 30
+        speakerButton.backgroundColor = .systemGray
+
+        // End call button
+        endCallButton.setImage(Self.symbol("phone.down.fill", size: 24, color: .white), for: .normal)
+        endCallButton.style.preferredSize = CGSize(width: 70, height: 70)
+        endCallButton.cornerRadius = 35
+        endCallButton.backgroundColor = .systemRed
+    }
+
+    // MARK: - Update
+
+    func updateName(_ name: String) {
+        nameLabel.attributedText = NSAttributedString(
+            string: name,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 28, weight: .semibold),
+                .foregroundColor: UIColor.label
+            ]
+        )
+    }
+
+    func updateStatus(_ status: String) {
+        statusLabel.attributedText = NSAttributedString(
+            string: status,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        )
+    }
+
+    // MARK: - Layout
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        // Top section: avatar + name + status
+        let topStack = ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 12,
+            justifyContent: .center,
+            alignItems: .center,
+            children: [avatarNode, nameLabel, statusLabel]
+        )
+
+        // Bottom section: action buttons
+        var buttons: [ASLayoutElement] = []
+        if !acceptButton.isHidden {
+            buttons = [endCallButton, acceptButton]
+        } else {
+            buttons = [muteButton, endCallButton, speakerButton]
+        }
+
+        let buttonsStack = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 32,
+            justifyContent: .center,
+            alignItems: .center,
+            children: buttons
+        )
+
+        // Spacer between top and bottom
+        let spacer = ASLayoutSpec()
+        spacer.style.flexGrow = 1
+
+        let mainStack = ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [topStack, spacer, buttonsStack]
+        )
+
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 80, left: 24, bottom: 60, right: 24),
+            child: mainStack
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func symbol(_ name: String, size: CGFloat, color: UIColor) -> UIImage? {
+        let config = UIImage.SymbolConfiguration(pointSize: size, weight: .medium)
+        guard let symbol = UIImage(systemName: name, withConfiguration: config) else { return nil }
+        let renderer = UIGraphicsImageRenderer(size: symbol.size)
+        return renderer.image { _ in
+            color.setFill()
+            symbol.withRenderingMode(.alwaysTemplate).draw(at: .zero)
+        }
+    }
+}

--- a/Zyna/Screens/Call/CallViewController.swift
+++ b/Zyna/Screens/Call/CallViewController.swift
@@ -1,0 +1,113 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import Combine
+
+// MARK: - Call View Controller
+
+final class CallViewController: ASDKViewController<CallNode> {
+
+    var onDismiss: (() -> Void)?
+
+    private let callService: CallService
+    private let roomName: String
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(roomName: String, callService: CallService = .shared) {
+        self.callService = callService
+        self.roomName = roomName
+        super.init(node: CallNode())
+        modalPresentationStyle = .fullScreen
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        node.backgroundColor = .systemBackground
+        node.updateName(roomName)
+
+        setupActions()
+        bindState()
+    }
+
+    // MARK: - Actions
+
+    private func setupActions() {
+        node.acceptButton.addTarget(self, action: #selector(acceptTapped), forControlEvents: .touchUpInside)
+        node.endCallButton.addTarget(self, action: #selector(endCallTapped), forControlEvents: .touchUpInside)
+        node.muteButton.addTarget(self, action: #selector(muteTapped), forControlEvents: .touchUpInside)
+        node.speakerButton.addTarget(self, action: #selector(speakerTapped), forControlEvents: .touchUpInside)
+    }
+
+    @objc private func acceptTapped() {
+        callService.acceptCall()
+    }
+
+    @objc private func endCallTapped() {
+        callService.endCall(reason: .userHangup)
+    }
+
+    @objc private func muteTapped() {
+        node.muteButton.isSelected.toggle()
+        // WebRTC will handle actual audio muting via CallServiceDelegate
+    }
+
+    @objc private func speakerTapped() {
+        node.speakerButton.isSelected.toggle()
+        // WebRTC will handle audio routing
+    }
+
+    // MARK: - State Binding
+
+    private func bindState() {
+        callService.stateSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.updateUI(for: state)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateUI(for state: CallState) {
+        let showAccept = {
+            if case .incomingRinging = state { return true }
+            return false
+        }()
+
+        node.acceptButton.isHidden = !showAccept
+        node.setNeedsLayout()
+
+        switch state {
+        case .idle:
+            break
+
+        case .outgoingRinging:
+            node.updateStatus("Calling...")
+
+        case .incomingRinging(_, _, let callerName):
+            node.updateStatus("Incoming call from \(callerName ?? "Unknown")")
+
+        case .connecting:
+            node.updateStatus("Connecting...")
+
+        case .connected:
+            node.updateStatus("Connected")
+
+        case .ended:
+            node.updateStatus("Call ended")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                self?.onDismiss?()
+            }
+        }
+    }
+}

--- a/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
+++ b/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
@@ -1,0 +1,208 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class ImageMessageCellNode: ASCellNode {
+
+    // MARK: - Subnodes
+
+    private let bubbleNode = ASDisplayNode()
+    private let imageNode = ASImageNode()
+    private let timeNode = ASTextNode()
+    private let timeBadgeNode = ASDisplayNode()
+    private let senderNameNode = ASTextNode()
+
+    // MARK: - State
+
+    private let isOutgoing: Bool
+    private let showSenderName: Bool
+    private let aspectRatio: CGFloat
+    private let mediaSource: MediaSource?
+
+    // MARK: - Constants
+
+    private static let maxBubbleWidthRatio: CGFloat = 0.75
+    private static let cellInsets = UIEdgeInsets(top: 1, left: 8, bottom: 1, right: 8)
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    private static let senderColors: [UIColor] = [
+        .systemRed, .systemBlue, .systemGreen, .systemOrange,
+        .systemPurple, .systemTeal, .systemIndigo, .systemPink
+    ]
+
+    // MARK: - Init
+
+    init(message: ChatMessage, isGroupChat: Bool = false) {
+        self.isOutgoing = message.isOutgoing
+        self.showSenderName = !message.isOutgoing && isGroupChat
+
+        var source: MediaSource?
+        var imageWidth: UInt64?
+        var imageHeight: UInt64?
+
+        if case .image(let src, let width, let height, _) = message.content {
+            source = src
+            imageWidth = width
+            imageHeight = height
+        }
+
+        self.mediaSource = source
+
+        if let width = imageWidth, let height = imageHeight, height > 0 {
+            self.aspectRatio = CGFloat(width) / CGFloat(height)
+        } else {
+            self.aspectRatio = 4.0 / 3.0
+        }
+
+        super.init()
+
+        automaticallyManagesSubnodes = true
+        selectionStyle = .none
+
+        // Image
+        imageNode.contentMode = .scaleAspectFill
+        imageNode.cornerRadius = 18
+        imageNode.clipsToBounds = true
+        imageNode.displaysAsynchronously = true
+
+        // Bubble
+        bubbleNode.backgroundColor = isOutgoing ? .systemBlue : .systemGray5
+        bubbleNode.cornerRadius = 18
+        bubbleNode.clipsToBounds = true
+
+        // Time badge
+        timeBadgeNode.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        timeBadgeNode.cornerRadius = 8
+
+        // Timestamp
+        timeNode.attributedText = NSAttributedString(
+            string: Self.timeFormatter.string(from: message.timestamp),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 11),
+                .foregroundColor: UIColor.white
+            ]
+        )
+
+        // Sender name
+        if showSenderName, let name = message.senderDisplayName {
+            let colorIndex = Self.stableHash(message.senderId) % Self.senderColors.count
+            senderNameNode.attributedText = NSAttributedString(
+                string: name,
+                attributes: [
+                    .font: UIFont.systemFont(ofSize: 13, weight: .semibold),
+                    .foregroundColor: Self.senderColors[colorIndex]
+                ]
+            )
+        }
+
+        // Load image: cache hit → instant, miss → async
+        if let source = mediaSource {
+            if let cached = MediaCache.shared.image(for: source) {
+                imageNode.image = cached
+            } else {
+                loadThumbnailAsync(source: source)
+            }
+        }
+    }
+
+    // MARK: - Async Loading
+
+    private func loadThumbnailAsync(source: MediaSource) {
+        let maxWidth = ScreenConstants.width * Self.maxBubbleWidthRatio
+        let thumbWidth = UInt64(maxWidth * UIScreen.main.scale)
+        let thumbHeight = UInt64(maxWidth / aspectRatio * UIScreen.main.scale)
+
+        Task {
+            guard let image = await MediaCache.shared.loadThumbnail(
+                source: source,
+                width: thumbWidth,
+                height: thumbHeight
+            ) else { return }
+            await MainActor.run {
+                self.imageNode.image = image
+            }
+        }
+    }
+
+    // MARK: - Layout
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let maxWidth = ScreenConstants.width * Self.maxBubbleWidthRatio
+        let imageHeight = maxWidth / aspectRatio
+
+        imageNode.style.preferredSize = CGSize(width: maxWidth, height: min(imageHeight, 400))
+
+        // Time badge with padding
+        let timePadded = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 2, left: 6, bottom: 2, right: 6),
+            child: timeNode
+        )
+        let timeBadge = ASBackgroundLayoutSpec(child: timePadded, background: timeBadgeNode)
+
+        // Time overlay at bottom-right
+        let timeOverlay = ASRelativeLayoutSpec(
+            horizontalPosition: .end,
+            verticalPosition: .end,
+            sizingOption: .minimumSize,
+            child: ASInsetLayoutSpec(
+                insets: UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 8),
+                child: timeBadge
+            )
+        )
+
+        let imageWithTime = ASOverlayLayoutSpec(child: imageNode, overlay: timeOverlay)
+
+        // Bubble behind image
+        let bubble = ASBackgroundLayoutSpec(child: imageWithTime, background: bubbleNode)
+
+        // Sender name above bubble
+        let bubbleWithName: ASLayoutElement
+        if showSenderName {
+            let nameInset = ASInsetLayoutSpec(
+                insets: UIEdgeInsets(top: 0, left: 12, bottom: 2, right: 0),
+                child: senderNameNode
+            )
+            bubbleWithName = ASStackLayoutSpec(
+                direction: .vertical,
+                spacing: 0,
+                justifyContent: .start,
+                alignItems: .start,
+                children: [nameInset, bubble]
+            )
+        } else {
+            bubbleWithName = bubble
+        }
+
+        // Spacer for alignment
+        let spacer = ASLayoutSpec()
+        spacer.style.flexGrow = 1
+
+        let hStack = ASStackLayoutSpec.horizontal()
+        hStack.spacing = 4
+        hStack.alignItems = .start
+        hStack.children = isOutgoing
+            ? [spacer, bubbleWithName]
+            : [bubbleWithName, spacer]
+
+        return ASInsetLayoutSpec(insets: Self.cellInsets, child: hStack)
+    }
+
+    // MARK: - Helpers
+
+    private static func stableHash(_ string: String) -> Int {
+        var hash: UInt64 = 5381
+        for byte in string.utf8 {
+            hash = hash &* 33 &+ UInt64(byte)
+        }
+        return Int(hash % UInt64(Int.max))
+    }
+}

--- a/Zyna/Screens/Chat/ChatMessage.swift
+++ b/Zyna/Screens/Chat/ChatMessage.swift
@@ -4,12 +4,13 @@
 //
 
 import Foundation
+import MatrixRustSDK
 
 // MARK: - Message Content
 
 enum ChatMessageContent {
     case text(body: String)
-    case image(width: UInt64?, height: UInt64?, caption: String?)
+    case image(source: MediaSource, width: UInt64?, height: UInt64?, caption: String?)
     case notice(body: String)
     case emote(body: String)
     case unsupported(typeName: String)

--- a/Zyna/Screens/Chat/ChatView.swift
+++ b/Zyna/Screens/Chat/ChatView.swift
@@ -35,6 +35,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         node.tableNode.delegate = self
         node.tableNode.view.separatorStyle = .none
         node.tableNode.view.keyboardDismissMode = .interactive
+        node.tableNode.view.contentInsetAdjustmentBehavior = .never
 
         setupNavigationBar()
         bindViewModel()
@@ -91,7 +92,12 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
         let message = viewModel.messages[indexPath.row]
         return {
-            TextMessageCellNode(message: message)
+            switch message.content {
+            case .image:
+                return ImageMessageCellNode(message: message)
+            default:
+                return TextMessageCellNode(message: message)
+            }
         }
     }
 

--- a/Zyna/Screens/Chat/ChatView.swift
+++ b/Zyna/Screens/Chat/ChatView.swift
@@ -9,6 +9,7 @@ import Combine
 final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource, ASTableDelegate {
 
     var onBack: (() -> Void)?
+    var onCallTapped: (() -> Void)?
 
     private let viewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -59,10 +60,20 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             target: self,
             action: #selector(backTapped)
         )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "phone.fill"),
+            style: .plain,
+            target: self,
+            action: #selector(callTapped)
+        )
     }
 
     @objc private func backTapped() {
         onBack?()
+    }
+
+    @objc private func callTapped() {
+        onCallTapped?()
     }
 
     // MARK: - Bindings

--- a/Zyna/Screens/Chat/ChatViewModel.swift
+++ b/Zyna/Screens/Chat/ChatViewModel.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-import Foundation
+import UIKit
 import Combine
 import MatrixRustSDK
 
@@ -31,7 +31,11 @@ final class ChatViewModel {
         timelineService.messagesSubject
             .map { $0.reversed() }
             .receive(on: DispatchQueue.main)
-            .assign(to: &$messages)
+            .sink { [weak self] messages in
+                Self.prefetchImages(messages)
+                self?.messages = messages
+            }
+            .store(in: &cancellables)
 
         timelineService.isPaginatingSubject
             .receive(on: DispatchQueue.main)
@@ -59,5 +63,22 @@ final class ChatViewModel {
 
     func cleanup() {
         timelineService.stopListening()
+    }
+
+    // MARK: - Prefetch
+
+    private static func prefetchImages(_ messages: [ChatMessage]) {
+        for message in messages {
+            guard case .image(let source, let width, let height, _) = message.content else { continue }
+            guard MediaCache.shared.image(for: source) == nil else { continue }
+            let thumbWidth = UInt64((ScreenConstants.width * 0.75) * UIScreen.main.scale)
+            let thumbHeight: UInt64
+            if let width, let height, height > 0 {
+                thumbHeight = UInt64(CGFloat(thumbWidth) / CGFloat(width) * CGFloat(height))
+            } else {
+                thumbHeight = thumbWidth * 3 / 4
+            }
+            Task { await MediaCache.shared.loadThumbnail(source: source, width: thumbWidth, height: thumbHeight) }
+        }
     }
 }

--- a/Zyna/Screens/Chat/ChatViewModel.swift
+++ b/Zyna/Screens/Chat/ChatViewModel.swift
@@ -21,7 +21,7 @@ final class ChatViewModel {
 
     // MARK: - Private
 
-    private let timelineService: TimelineService
+    let timelineService: TimelineService
     private var cancellables = Set<AnyCancellable>()
 
     init(room: Room) {

--- a/Zyna/Screens/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Screens/Chat/Nodes/ChatInputNode.swift
@@ -6,62 +6,61 @@
 import AsyncDisplayKit
 
 final class ChatInputNode: ASDisplayNode {
-
+    
     let textInputNode = ASEditableTextNode()
     let sendButtonNode = ASButtonNode()
     let attachButtonNode = ASButtonNode()
     private let separatorNode = ASDisplayNode()
-
+    
     var onSend: ((String) -> Void)?
-
+    
     override init() {
         super.init()
         automaticallyManagesSubnodes = true
         setupNodes()
     }
-
+    
     private func setupNodes() {
         separatorNode.style.height = ASDimension(unit: .points, value: 0.5)
         separatorNode.backgroundColor = .separator
-
+        
         textInputNode.textView.font = .systemFont(ofSize: 16)
         textInputNode.textContainerInset = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
         textInputNode.style.flexGrow = 1
+        textInputNode.style.flexShrink = 1
         textInputNode.style.minHeight = ASDimension(unit: .points, value: 36)
         textInputNode.style.maxHeight = ASDimension(unit: .points, value: 120)
         textInputNode.scrollEnabled = true
-
+        
         textInputNode.backgroundColor = .secondarySystemBackground
-        textInputNode.cornerRadius = 18
-
-        let attachConfig = UIImage.SymbolConfiguration(pointSize: 22)
+        
         attachButtonNode.setImage(
-            UIImage(systemName: "paperclip", withConfiguration: attachConfig),
+            Self.renderSymbol("paperclip", pointSize: 22, color: .gray),
             for: .normal
         )
         attachButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
-
-        let sendConfig = UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
+        
         sendButtonNode.setImage(
-            UIImage(systemName: "arrow.up.circle.fill", withConfiguration: sendConfig),
+            Self.renderSymbol("arrow.up.circle.fill", pointSize: 22, weight: .semibold, color: .systemBlue),
             for: .normal
         )
-        sendButtonNode.tintColor = .systemBlue
         sendButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
     }
-
+    
     // MARK: - didLoad
     // тут можно трогать .view
-
+    
     override func didLoad() {
         super.didLoad()
         backgroundColor = .systemBackground
         textInputNode.delegate = self
+        textInputNode.view.layer.cornerRadius = 18
+        textInputNode.view.clipsToBounds = true
         sendButtonNode.addTarget(self, action: #selector(sendTapped), forControlEvents: .touchUpInside)
     }
-
+    
     // MARK: - Layout
-
+    
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
         // Кнопки прижаты к низу (когда поле растягивается на несколько строк)
         let attachSpec = ASStackLayoutSpec(
@@ -78,7 +77,7 @@ final class ChatInputNode: ASDisplayNode {
             alignItems: .center,
             children: [sendButtonNode]
         )
-
+        
         // Горизонтальный стек: [attach] [input] [send]
         let inputRow = ASStackLayoutSpec(
             direction: .horizontal,
@@ -87,21 +86,38 @@ final class ChatInputNode: ASDisplayNode {
             alignItems: .end,
             children: [attachSpec, textInputNode, sendSpec]
         )
-
+        
         let paddedRow = ASInsetLayoutSpec(
             insets: UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8),
             child: inputRow
         )
-
+        
         // Separator + input row
         let fullStack = ASStackLayoutSpec.vertical()
         fullStack.children = [separatorNode, paddedRow]
-
+        
         return fullStack
     }
-
+    
+    // MARK: - Helpers
+    
+    private static func renderSymbol(
+        _ name: String,
+        pointSize: CGFloat,
+        weight: UIImage.SymbolWeight = .regular,
+        color: UIColor
+    ) -> UIImage? {
+        let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: weight)
+        guard let symbol = UIImage(systemName: name, withConfiguration: config) else { return nil }
+        let renderer = UIGraphicsImageRenderer(size: symbol.size)
+        return renderer.image { _ in
+            color.setFill()
+            symbol.withRenderingMode(.alwaysTemplate).draw(at: .zero)
+        }
+    }
+    
     // MARK: - Actions
-
+    
     @objc private func sendTapped() {
         let text = textInputNode.textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }

--- a/Zyna/Screens/Chat/Nodes/ChatNode.swift
+++ b/Zyna/Screens/Chat/Nodes/ChatNode.swift
@@ -12,6 +12,7 @@ final class ChatNode: ASDisplayNode {
     override init() {
         super.init()
         automaticallyManagesSubnodes = true
+        automaticallyRelayoutOnSafeAreaChanges = true
         tableNode.inverted = true
     }
 
@@ -19,12 +20,14 @@ final class ChatNode: ASDisplayNode {
         let tableSpec = ASWrapperLayoutSpec(layoutElement: tableNode)
         tableSpec.style.flexGrow = 1
 
-        let stack = ASStackLayoutSpec.vertical()
-        stack.children = [tableSpec, inputNode]
-
-        return ASInsetLayoutSpec(
+        let inputWithSafeArea = ASInsetLayoutSpec(
             insets: UIEdgeInsets(top: 0, left: 0, bottom: safeAreaInsets.bottom, right: 0),
-            child: stack
+            child: inputNode
         )
+
+        let stack = ASStackLayoutSpec.vertical()
+        stack.children = [tableSpec, inputWithSafeArea]
+
+        return stack
     }
 }

--- a/Zyna/Services/Call/CallKitService.swift
+++ b/Zyna/Services/Call/CallKitService.swift
@@ -1,0 +1,178 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import CallKit
+import AVFoundation
+
+private let callLog = ScopedLog(.call)
+
+// MARK: - CallKit Service
+
+final class CallKitService: NSObject {
+
+    // MARK: - Callbacks
+
+    var onAnswerCall: (() -> Void)?
+    var onEndCall: (() -> Void)?
+    var onMuteToggle: ((Bool) -> Void)?
+
+    // MARK: - Private
+
+    private let provider: CXProvider
+    private let callController = CXCallController()
+    private var currentCallUUID: UUID?
+
+    // MARK: - Init
+
+    override init() {
+        let config = CXProviderConfiguration()
+        config.supportsVideo = false
+        config.maximumCallsPerCallGroup = 1
+        config.supportedHandleTypes = [.generic]
+        config.iconTemplateImageData = nil // TODO: Set app icon
+
+        self.provider = CXProvider(configuration: config)
+        super.init()
+        provider.setDelegate(self, queue: .main)
+    }
+
+    // MARK: - Report Incoming Call
+
+    func reportIncomingCall(callId: String, handle: String) {
+        let uuid = UUID()
+        currentCallUUID = uuid
+
+        let update = CXCallUpdate()
+        update.remoteHandle = CXHandle(type: .generic, value: handle)
+        update.localizedCallerName = handle
+        update.hasVideo = false
+        update.supportsHolding = false
+        update.supportsGrouping = false
+        update.supportsUngrouping = false
+
+        provider.reportNewIncomingCall(with: uuid, update: update) { error in
+            if let error {
+                callLog("Failed to report incoming call: \(error)")
+            } else {
+                callLog("Reported incoming call to CallKit (uuid: \(uuid))")
+            }
+        }
+    }
+
+    // MARK: - Report Outgoing Call
+
+    func reportOutgoingCall(callId: String, handle: String) {
+        let uuid = UUID()
+        currentCallUUID = uuid
+
+        let handle = CXHandle(type: .generic, value: handle)
+        let startAction = CXStartCallAction(call: uuid, handle: handle)
+        startAction.isVideo = false
+
+        callController.request(CXTransaction(action: startAction)) { error in
+            if let error {
+                callLog("Failed to start outgoing call: \(error)")
+            } else {
+                callLog("Started outgoing call in CallKit (uuid: \(uuid))")
+            }
+        }
+
+        // Mark as connecting
+        provider.reportOutgoingCall(with: uuid, startedConnectingAt: Date())
+    }
+
+    // MARK: - Report Connected
+
+    func reportCallConnected() {
+        guard let uuid = currentCallUUID else { return }
+        provider.reportOutgoingCall(with: uuid, connectedAt: Date())
+    }
+
+    // MARK: - Report Ended
+
+    func reportCallEnded(reason: CallHangupReason) {
+        guard let uuid = currentCallUUID else { return }
+
+        let cxReason: CXCallEndedReason
+        switch reason {
+        case .normal, .userHangup:
+            cxReason = .remoteEnded
+        case .busy:
+            cxReason = .unanswered
+        case .timeout:
+            cxReason = .unanswered
+        case .declined:
+            cxReason = .declinedElsewhere
+        default:
+            cxReason = .failed
+        }
+
+        provider.reportCall(with: uuid, endedAt: Date(), reason: cxReason)
+        currentCallUUID = nil
+    }
+
+    // MARK: - Configure Audio Session
+
+    private func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth])
+            try session.setActive(true)
+            callLog("Audio session configured for voice call")
+        } catch {
+            callLog("Failed to configure audio session: \(error)")
+        }
+    }
+
+    private func deactivateAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            callLog("Failed to deactivate audio session: \(error)")
+        }
+    }
+}
+
+// MARK: - CXProviderDelegate
+
+extension CallKitService: CXProviderDelegate {
+
+    func providerDidReset(_ provider: CXProvider) {
+        callLog("CallKit provider did reset")
+        currentCallUUID = nil
+        deactivateAudioSession()
+    }
+
+    func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
+        callLog("CallKit: answer call")
+        configureAudioSession()
+        onAnswerCall?()
+        action.fulfill()
+    }
+
+    func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
+        callLog("CallKit: end call")
+        onEndCall?()
+        deactivateAudioSession()
+        currentCallUUID = nil
+        action.fulfill()
+    }
+
+    func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
+        callLog("CallKit: mute = \(action.isMuted)")
+        onMuteToggle?(action.isMuted)
+        action.fulfill()
+    }
+
+    func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
+        callLog("CallKit: audio session activated")
+    }
+
+    func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
+        callLog("CallKit: audio session deactivated")
+    }
+}

--- a/Zyna/Services/Call/CallModels.swift
+++ b/Zyna/Services/Call/CallModels.swift
@@ -1,0 +1,210 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+// MARK: - Call State
+
+enum CallState: Equatable {
+    case idle
+    case outgoingRinging(callId: String, roomId: String)
+    case incomingRinging(callId: String, roomId: String, callerName: String?)
+    case connecting(callId: String, roomId: String)
+    case connected(callId: String, roomId: String)
+    case ended(callId: String, reason: CallHangupReason)
+
+    var isActive: Bool {
+        switch self {
+        case .idle, .ended:
+            return false
+        default:
+            return true
+        }
+    }
+
+    var callId: String? {
+        switch self {
+        case .idle:
+            return nil
+        case .outgoingRinging(let callId, _),
+             .incomingRinging(let callId, _, _),
+             .connecting(let callId, _),
+             .connected(let callId, _),
+             .ended(let callId, _):
+            return callId
+        }
+    }
+
+    var roomId: String? {
+        switch self {
+        case .idle, .ended:
+            return nil
+        case .outgoingRinging(_, let roomId),
+             .incomingRinging(_, let roomId, _),
+             .connecting(_, let roomId),
+             .connected(_, let roomId):
+            return roomId
+        }
+    }
+}
+
+// MARK: - Call Hangup Reason
+
+enum CallHangupReason: String, Codable {
+    case normal = "normal"
+    case busy = "busy"
+    case timeout = "timeout"
+    case iceFailed = "ice_failed"
+    case userHangup = "user_hangup"
+    case remoteHangup = "remote_hangup"
+    case declined = "declined"
+}
+
+// MARK: - Call Direction
+
+enum CallDirection {
+    case outgoing
+    case incoming
+}
+
+// MARK: - Signaling Events
+
+enum CallSignalingEvent {
+    case invite(CallInviteContent)
+    case answer(CallAnswerContent)
+    case candidates(CallCandidatesContent)
+    case hangup(CallHangupContent)
+}
+
+// MARK: - m.call.invite
+
+struct CallInviteContent: Codable {
+    let callId: String
+    let version: Int
+    let lifetime: Int
+    let offer: SDPContent
+
+    enum CodingKeys: String, CodingKey {
+        case callId = "call_id"
+        case version, lifetime, offer
+    }
+
+    init(callId: String, sdp: String, lifetime: Int = 60000) {
+        self.callId = callId
+        self.version = 0
+        self.lifetime = lifetime
+        self.offer = SDPContent(type: "offer", sdp: sdp)
+    }
+}
+
+// MARK: - m.call.answer
+
+struct CallAnswerContent: Codable {
+    let callId: String
+    let version: Int
+    let answer: SDPContent
+
+    enum CodingKeys: String, CodingKey {
+        case callId = "call_id"
+        case version, answer
+    }
+
+    init(callId: String, sdp: String) {
+        self.callId = callId
+        self.version = 0
+        self.answer = SDPContent(type: "answer", sdp: sdp)
+    }
+}
+
+// MARK: - m.call.candidates
+
+struct CallCandidatesContent: Codable {
+    let callId: String
+    let version: Int
+    let candidates: [ICECandidate]
+
+    enum CodingKeys: String, CodingKey {
+        case callId = "call_id"
+        case version, candidates
+    }
+
+    init(callId: String, candidates: [ICECandidate]) {
+        self.callId = callId
+        self.version = 0
+        self.candidates = candidates
+    }
+}
+
+// MARK: - m.call.hangup
+
+struct CallHangupContent: Codable {
+    let callId: String
+    let version: Int
+    let reason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case callId = "call_id"
+        case version, reason
+    }
+
+    init(callId: String, reason: CallHangupReason = .userHangup) {
+        self.callId = callId
+        self.version = 0
+        self.reason = reason.rawValue
+    }
+}
+
+// MARK: - Shared Types
+
+struct SDPContent: Codable {
+    let type: String
+    let sdp: String
+}
+
+struct ICECandidate: Codable {
+    let candidate: String
+    let sdpMid: String?
+    let sdpMLineIndex: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case candidate
+        case sdpMid = "sdpMid"
+        case sdpMLineIndex = "sdpMLineIndex"
+    }
+}
+
+// MARK: - JSON Helpers
+
+enum CallEventJSON {
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = .sortedKeys
+        return e
+    }()
+
+    static func encode<T: Encodable>(_ value: T) -> String? {
+        guard let data = try? encoder.encode(value) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from jsonString: String) -> T? {
+        guard let data = jsonString.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    static func decode<T: Decodable>(_ type: T.Type, from dict: [String: Any]) -> T? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+}
+
+// MARK: - Call ID Generator
+
+enum CallIdGenerator {
+    static func generate() -> String {
+        UUID().uuidString.lowercased()
+    }
+}

--- a/Zyna/Services/Call/CallService.swift
+++ b/Zyna/Services/Call/CallService.swift
@@ -1,0 +1,297 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import MatrixRustSDK
+import AVFoundation
+
+private let callLog = ScopedLog(.call)
+
+// MARK: - Call Service Delegate (WebRTC integration point)
+
+protocol CallServiceDelegate: AnyObject {
+    /// Called when a remote SDP offer is received (incoming call).
+    func callService(_ service: CallService, didReceiveOffer sdp: String, callId: String)
+
+    /// Called when a remote SDP answer is received (outgoing call accepted).
+    func callService(_ service: CallService, didReceiveAnswer sdp: String, callId: String)
+
+    /// Called when remote ICE candidates are received.
+    func callService(_ service: CallService, didReceiveICECandidates candidates: [ICECandidate], callId: String)
+
+    /// Called when the call ends.
+    func callService(_ service: CallService, didEndCall callId: String, reason: CallHangupReason)
+}
+
+// MARK: - Call Service
+
+final class CallService {
+
+    static let shared = CallService()
+
+    // MARK: - State
+
+    let stateSubject = CurrentValueSubject<CallState, Never>(.idle)
+    var state: CallState { stateSubject.value }
+
+    // MARK: - Delegate
+
+    weak var delegate: CallServiceDelegate?
+
+    // MARK: - Private
+
+    private var signalingService: CallSignalingService?
+    private var cancellables = Set<AnyCancellable>()
+    private var ringTimeoutTask: Task<Void, Never>?
+
+    private let webRTCClient = WebRTCClient()
+
+    private init() {
+        self.delegate = webRTCClient
+        webRTCClient.callService = self
+        webRTCClient.observeCallState()
+    }
+
+    // MARK: - Start Outgoing Call
+
+    /// Initiates an outgoing call in a room.
+    /// After calling this, provide the SDP offer via `sendOffer(sdp:)`.
+    func startCall(room: Room, timelineService: TimelineService) {
+        guard !state.isActive else {
+            callLog("Cannot start call: already active")
+            return
+        }
+
+        let callId = CallIdGenerator.generate()
+        let ownUserId = (try? MatrixClientService.shared.client?.userId()) ?? ""
+
+        let signaling = CallSignalingService(room: room, ownUserId: ownUserId)
+        self.signalingService = signaling
+
+        subscribeToSignalingEvents(signaling)
+        signaling.subscribe(to: timelineService)
+
+        configureAudioSession()
+        stateSubject.send(.outgoingRinging(callId: callId, roomId: room.id()))
+        callLog("Starting outgoing call \(callId) in room \(room.id())")
+
+        startRingTimeout(callId: callId)
+    }
+
+    /// Send SDP offer to the remote peer (called by WebRTC layer after creating offer).
+    func sendOffer(sdp: String) async {
+        guard case .outgoingRinging(let callId, _) = state else {
+            callLog("Cannot send offer: not in outgoingRinging state")
+            return
+        }
+
+        let content = CallInviteContent(callId: callId, sdp: sdp)
+        do {
+            try await signalingService?.sendInvite(content)
+        } catch {
+            callLog("Failed to send offer: \(error)")
+            endCall(reason: .normal)
+        }
+    }
+
+    /// Send SDP answer to the remote peer (called by WebRTC layer after creating answer).
+    func sendAnswer(sdp: String) async {
+        guard let callId = state.callId else {
+            callLog("Cannot send answer: no active call")
+            return
+        }
+
+        let content = CallAnswerContent(callId: callId, sdp: sdp)
+        do {
+            try await signalingService?.sendAnswer(content)
+            if case .incomingRinging(let cid, let rid, _) = state {
+                stateSubject.send(.connecting(callId: cid, roomId: rid))
+            }
+        } catch {
+            callLog("Failed to send answer: \(error)")
+            endCall(reason: .normal)
+        }
+    }
+
+    /// Send ICE candidates to the remote peer.
+    func sendICECandidates(_ candidates: [ICECandidate]) async {
+        guard let callId = state.callId else { return }
+
+        let content = CallCandidatesContent(callId: callId, candidates: candidates)
+        do {
+            try await signalingService?.sendCandidates(content)
+        } catch {
+            callLog("Failed to send ICE candidates: \(error)")
+        }
+    }
+
+    /// Mark call as connected (called by WebRTC layer when peer connection is established).
+    func markConnected() {
+        guard let callId = state.callId, let roomId = state.roomId else { return }
+
+        cancelRingTimeout()
+        stateSubject.send(.connected(callId: callId, roomId: roomId))
+        callLog("Call \(callId) connected")
+    }
+
+    // MARK: - Accept Incoming Call
+
+    func acceptCall() {
+        guard case .incomingRinging(let callId, let roomId, _) = state else {
+            callLog("Cannot accept: not in incomingRinging state")
+            return
+        }
+
+        cancelRingTimeout()
+        configureAudioSession()
+        stateSubject.send(.connecting(callId: callId, roomId: roomId))
+        callLog("Accepted call \(callId)")
+    }
+
+    // MARK: - End Call
+
+    func endCall(reason: CallHangupReason = .userHangup) {
+        guard let callId = state.callId else {
+            stateSubject.send(.idle)
+            return
+        }
+
+        cancelRingTimeout()
+
+        Task {
+            let content = CallHangupContent(callId: callId, reason: reason)
+            try? await signalingService?.sendHangup(content)
+            signalingService?.stop()
+            signalingService = nil
+        }
+
+        delegate?.callService(self, didEndCall: callId, reason: reason)
+        deactivateAudioSession()
+
+        stateSubject.send(.ended(callId: callId, reason: reason))
+        callLog("Call \(callId) ended: \(reason.rawValue)")
+
+        // Reset to idle after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            if case .ended = self?.state {
+                self?.stateSubject.send(.idle)
+            }
+        }
+    }
+
+    // MARK: - Handle Incoming Call (called by TimelineService or push)
+
+    func handleIncomingCall(room: Room, callId: String, callerName: String?, offerSDP: String?, timelineService: TimelineService) {
+        guard !state.isActive else {
+            callLog("Ignoring incoming call: already active")
+            // TODO: Send busy hangup
+            return
+        }
+
+        let ownUserId = (try? MatrixClientService.shared.client?.userId()) ?? ""
+
+        let signaling = CallSignalingService(room: room, ownUserId: ownUserId)
+        self.signalingService = signaling
+
+        subscribeToSignalingEvents(signaling)
+        signaling.subscribe(to: timelineService)
+
+        stateSubject.send(.incomingRinging(callId: callId, roomId: room.id(), callerName: callerName))
+        callLog("Incoming call \(callId) from \(callerName ?? "unknown") in room \(room.id())")
+
+        // Deliver offer SDP directly — the invite event was already published
+        // before signaling subscribed (PassthroughSubject race condition)
+        if let sdp = offerSDP {
+            callLog("Delivering offer SDP directly (\(sdp.count) bytes)")
+            delegate?.callService(self, didReceiveOffer: sdp, callId: callId)
+        }
+
+        startRingTimeout(callId: callId)
+    }
+
+    // MARK: - Private — Signaling Events
+
+    private func subscribeToSignalingEvents(_ signaling: CallSignalingService) {
+        cancellables.removeAll()
+
+        signaling.incomingEventSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                self?.handleSignalingEvent(event)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleSignalingEvent(_ event: CallSignalingEvent) {
+        guard let callId = state.callId else { return }
+
+        switch event {
+        case .invite(let content):
+            guard content.callId == callId else { return }
+            delegate?.callService(self, didReceiveOffer: content.offer.sdp, callId: content.callId)
+
+        case .answer(let content):
+            guard content.callId == callId else { return }
+            cancelRingTimeout()
+            if case .outgoingRinging(_, let roomId) = state {
+                stateSubject.send(.connecting(callId: callId, roomId: roomId))
+            }
+            delegate?.callService(self, didReceiveAnswer: content.answer.sdp, callId: content.callId)
+
+        case .candidates(let content):
+            guard content.callId == callId else { return }
+            delegate?.callService(self, didReceiveICECandidates: content.candidates, callId: content.callId)
+
+        case .hangup(let content):
+            guard content.callId == callId else { return }
+            let reason = CallHangupReason(rawValue: content.reason ?? "remote_hangup") ?? .remoteHangup
+            endCall(reason: reason)
+        }
+    }
+
+    // MARK: - Ring Timeout
+
+    private func startRingTimeout(callId: String) {
+        ringTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 30_000_000_000) // 30 seconds
+            guard !Task.isCancelled else { return }
+            guard self?.state.callId == callId else { return }
+
+            await MainActor.run {
+                callLog("Call \(callId) timed out")
+                self?.endCall(reason: .timeout)
+            }
+        }
+    }
+
+    private func cancelRingTimeout() {
+        ringTimeoutTask?.cancel()
+        ringTimeoutTask = nil
+    }
+
+    // MARK: - Audio Session
+
+    private func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth])
+            try session.setActive(true)
+            callLog("Audio session configured")
+        } catch {
+            callLog("Failed to configure audio session: \(error)")
+        }
+    }
+
+    private func deactivateAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+            callLog("Audio session deactivated")
+        } catch {
+            callLog("Failed to deactivate audio session: \(error)")
+        }
+    }
+}

--- a/Zyna/Services/Call/CallSignalingService.swift
+++ b/Zyna/Services/Call/CallSignalingService.swift
@@ -1,0 +1,221 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import MatrixRustSDK
+
+private let callLog = ScopedLog(.call)
+
+// MARK: - Call Signaling Service
+
+/// Handles sending and receiving call signaling events for VoIP.
+/// Sends m.call.invite natively (SDK delivers it as .callInvite).
+/// Sends answer/candidates/hangup as text messages through the timeline's
+/// encrypted send pipeline, with a marker prefix for identification.
+/// Receives timeline items from TimelineService (not its own listener).
+final class CallSignalingService {
+
+    /// Prefix used to identify call signaling messages in text bodies.
+    static let signalingPrefix = "ZYNA_CALL:"
+
+    // MARK: - Incoming Events
+
+    let incomingEventSubject = PassthroughSubject<CallSignalingEvent, Never>()
+
+    // MARK: - Properties
+
+    let roomId: String
+    private let room: Room
+    private let ownUserId: String
+    private weak var timelineService: TimelineService?
+    private var processedEventIds = Set<String>()
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(room: Room, ownUserId: String) {
+        self.room = room
+        self.roomId = room.id()
+        self.ownUserId = ownUserId
+    }
+
+    // MARK: - Subscribe to TimelineService
+
+    func subscribe(to timelineService: TimelineService) {
+        self.timelineService = timelineService
+
+        timelineService.rawTimelineItemsSubject
+            .sink { [weak self] items in
+                self?.processItems(items)
+            }
+            .store(in: &cancellables)
+        callLog("Signaling subscribed to TimelineService for room \(roomId)")
+    }
+
+    // MARK: - Send Events
+
+    func sendInvite(_ content: CallInviteContent) async throws {
+        guard let json = CallEventJSON.encode(content) else {
+            callLog("Failed to encode call invite")
+            return
+        }
+        // Send as native m.call.invite — SDK delivers as .callInvite in timeline
+        try await room.sendRaw(eventType: "m.call.invite", content: json)
+        callLog("Sent m.call.invite (callId: \(content.callId))")
+    }
+
+    func sendAnswer(_ content: CallAnswerContent) async throws {
+        try await sendViaTimeline(type: "m.call.answer", content: content)
+        callLog("Sent m.call.answer (callId: \(content.callId))")
+    }
+
+    func sendCandidates(_ content: CallCandidatesContent) async throws {
+        try await sendViaTimeline(type: "m.call.candidates", content: content)
+        callLog("Sent m.call.candidates (callId: \(content.callId), count: \(content.candidates.count))")
+    }
+
+    func sendHangup(_ content: CallHangupContent) async throws {
+        try await sendViaTimeline(type: "m.call.hangup", content: content)
+        callLog("Sent m.call.hangup (callId: \(content.callId))")
+    }
+
+    // MARK: - Stop
+
+    func stop() {
+        cancellables.removeAll()
+        timelineService = nil
+        callLog("Signaling stopped for room \(roomId)")
+    }
+
+    // MARK: - Private — Send
+
+    /// Sends call signaling data as an encrypted text message through the timeline.
+    /// Format: "ZYNA_CALL:m.call.answer:{json_data}"
+    private func sendViaTimeline<T: Encodable>(type: String, content: T) async throws {
+        guard let innerJSON = CallEventJSON.encode(content) else { return }
+        let body = "\(Self.signalingPrefix)\(type):\(innerJSON)"
+        await timelineService?.sendCallSignaling(body)
+    }
+
+    // MARK: - Private — Receive
+
+    private func processItems(_ items: [TimelineItem]) {
+        for item in items {
+            processTimelineItem(item)
+        }
+    }
+
+    private func processTimelineItem(_ item: TimelineItem) {
+        guard let event = item.asEvent() else { return }
+
+        // Skip own events
+        guard !event.isOwn else { return }
+
+        // Deduplicate
+        let itemId = item.uniqueId().id
+        guard !processedEventIds.contains(itemId) else { return }
+        processedEventIds.insert(itemId)
+
+        switch event.content {
+        case .callInvite:
+            handleCallInvite(event)
+
+        case .msgLike(let msgContent):
+            // Check for signaling messages in text content
+            if case .message(let message) = msgContent.kind,
+               case .text(let text) = message.msgType,
+               text.body.hasPrefix(Self.signalingPrefix) {
+                handleTextSignaling(text.body)
+            }
+
+        case .failedToParseMessageLike(let eventType, _) where eventType.hasPrefix("m.call."):
+            handleLegacyCallEvent(event, eventType: eventType)
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Parse Incoming Call Events
+
+    /// Handle native m.call.invite (delivered as .callInvite by SDK)
+    private func handleCallInvite(_ event: EventTimelineItem) {
+        guard let contentDict = extractEventContent(event) else {
+            callLog("Failed to extract content from call invite")
+            return
+        }
+
+        guard let content = CallEventJSON.decode(CallInviteContent.self, from: contentDict) else {
+            callLog("Failed to decode CallInviteContent from raw JSON")
+            return
+        }
+
+        callLog("Received call invite: callId=\(content.callId), sdp=\(content.offer.sdp.count) bytes")
+        incomingEventSubject.send(.invite(content))
+    }
+
+    /// Handle call signaling encoded in text message body.
+    /// Format: "ZYNA_CALL:m.call.answer:{json_data}"
+    private func handleTextSignaling(_ body: String) {
+        let payload = String(body.dropFirst(Self.signalingPrefix.count))
+
+        // Split into type and JSON data at the first ":"
+        guard let colonIndex = payload.firstIndex(of: ":") else { return }
+        let type = String(payload[payload.startIndex..<colonIndex])
+        let jsonString = String(payload[payload.index(after: colonIndex)...])
+
+        callLog("Received signaling via text: \(type)")
+        parseCallData(type: type, jsonString: jsonString)
+    }
+
+    /// Handle legacy/failedToParse call events (from other clients using VoIP v1, etc.)
+    private func handleLegacyCallEvent(_ event: EventTimelineItem, eventType: String) {
+        guard let contentDict = extractEventContent(event) else { return }
+        callLog("Parsed legacy call event type: \(eventType)")
+        parseCallData(type: eventType, dict: contentDict)
+    }
+
+    // MARK: - Shared Parsing
+
+    private func parseCallData(type: String, jsonString: String) {
+        guard let data = jsonString.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        parseCallData(type: type, dict: dict)
+    }
+
+    private func parseCallData(type: String, dict: [String: Any]) {
+        switch type {
+        case "m.call.answer":
+            guard let content = CallEventJSON.decode(CallAnswerContent.self, from: dict) else { return }
+            callLog("Received call answer: callId=\(content.callId)")
+            incomingEventSubject.send(.answer(content))
+
+        case "m.call.candidates":
+            guard let content = CallEventJSON.decode(CallCandidatesContent.self, from: dict) else { return }
+            callLog("Received ICE candidates: callId=\(content.callId), count=\(content.candidates.count)")
+            incomingEventSubject.send(.candidates(content))
+
+        case "m.call.hangup":
+            guard let content = CallEventJSON.decode(CallHangupContent.self, from: dict) else { return }
+            callLog("Received call hangup: callId=\(content.callId)")
+            incomingEventSubject.send(.hangup(content))
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Raw JSON Extraction
+
+    private func extractEventContent(_ event: EventTimelineItem) -> [String: Any]? {
+        let debugInfo = event.lazyProvider.debugInfo()
+        guard let json = debugInfo.originalJson,
+              let data = json.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let contentDict = dict["content"] as? [String: Any] else { return nil }
+        return contentDict
+    }
+}

--- a/Zyna/Services/Call/WebRTC/WebRTCAudioConfig.swift
+++ b/Zyna/Services/Call/WebRTC/WebRTCAudioConfig.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import WebRTC
+
+// MARK: - WebRTC Audio Configuration
+
+enum WebRTCAudioConfig {
+
+    /// Audio constraints: echo cancellation, noise suppression, AGC with gain boost.
+    static let audioConstraints = RTCMediaConstraints(
+        mandatoryConstraints: [
+            "googEchoCancellation": "true",
+            "googNoiseSuppression": "true",
+            "googAutoGainControl": "true",
+            "googHighpassFilter": "false",
+            "googTypingNoiseDetection": "false",
+            "googAudioMirroring": "false",
+            "googAGCStartupMinVolume": "12",
+            "googAGCTargetLevelDbov": "3",
+            "googAGCCompressionGainDb": "20"
+        ],
+        optionalConstraints: [
+            "googDAEchoCancellation": "true",
+            "googNoiseReduction": "false"
+        ]
+    )
+
+    /// Offer/answer constraints for audio-only calls.
+    static let offerConstraints = RTCMediaConstraints(
+        mandatoryConstraints: ["OfferToReceiveAudio": "true"],
+        optionalConstraints: nil
+    )
+
+    /// STUN servers (Google public). Sufficient for most P2P connections.
+    static let iceServers: [RTCIceServer] = [
+        RTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"]),
+        RTCIceServer(urlStrings: ["stun:stun1.l.google.com:19302"]),
+        RTCIceServer(urlStrings: ["stun:stun2.l.google.com:19302"]),
+        RTCIceServer(urlStrings: ["stun:stun3.l.google.com:19302"])
+    ]
+
+    /// RTCConfiguration for peer connections.
+    static func peerConnectionConfig() -> RTCConfiguration {
+        let config = RTCConfiguration()
+        config.iceServers = iceServers
+        config.bundlePolicy = .maxBundle
+        config.rtcpMuxPolicy = .require
+        config.sdpSemantics = .unifiedPlan
+        config.iceTransportPolicy = .all
+        config.continualGatheringPolicy = .gatherContinually
+        config.iceCandidatePoolSize = 10
+        return config
+    }
+}

--- a/Zyna/Services/Call/WebRTC/WebRTCClient.swift
+++ b/Zyna/Services/Call/WebRTC/WebRTCClient.swift
@@ -1,0 +1,414 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import WebRTC
+
+private let callLog = ScopedLog(.call)
+
+// MARK: - WebRTC Client
+
+/// Manages RTCPeerConnection for audio calls.
+/// Implements CallServiceDelegate to receive signaling events from Matrix.
+/// Observes CallService state to know when to create offers.
+final class WebRTCClient: NSObject {
+
+    /// Back-reference to CallService for sending SDP/ICE via Matrix.
+    weak var callService: CallService?
+
+    // MARK: - Private — WebRTC
+
+    private let factory: RTCPeerConnectionFactory
+    private var peerConnection: RTCPeerConnection?
+    private var localAudioTrack: RTCAudioTrack?
+
+    // MARK: - Private — Pending Offer (incoming call, waiting for user to accept)
+
+    private var pendingOfferSDP: String?
+
+    // MARK: - Private — ICE Candidate Queue (incoming remote candidates)
+
+    private var pendingICECandidates: [RTCIceCandidate] = []
+    private var hasRemoteDescription = false
+
+    // MARK: - Private — Local Candidate Queue (outgoing, wait for invite/answer to be sent)
+
+    private var pendingLocalCandidates: [ICECandidate] = []
+    private var localDescriptionSent = false
+
+    // MARK: - Private — State
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    override init() {
+        RTCInitializeSSL()
+        let encoderFactory = RTCDefaultVideoEncoderFactory()
+        let decoderFactory = RTCDefaultVideoDecoderFactory()
+        self.factory = RTCPeerConnectionFactory(
+            encoderFactory: encoderFactory,
+            decoderFactory: decoderFactory
+        )
+        super.init()
+    }
+
+    deinit {
+        cleanup()
+        RTCCleanupSSL()
+    }
+
+    // MARK: - State Observation
+
+    /// Call this after setting callService to start observing state changes.
+    func observeCallState() {
+        callService?.stateSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.handleStateChange(state)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleStateChange(_ state: CallState) {
+        switch state {
+        case .outgoingRinging:
+            Task { await createOfferAndSend() }
+
+        case .connecting:
+            // User accepted incoming call — process buffered offer
+            if let sdp = pendingOfferSDP {
+                pendingOfferSDP = nil
+                callLog("User accepted — processing buffered offer")
+                Task { await handleRemoteOffer(sdp: sdp) }
+            }
+
+        case .ended, .idle:
+            cleanup()
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Outgoing Call — Create Offer
+
+    private func createOfferAndSend() async {
+        guard peerConnection == nil else {
+            callLog("Ignoring duplicate createOffer — peer connection already exists")
+            return
+        }
+
+        createPeerConnection()
+        addLocalAudioTrack()
+
+        do {
+            guard let pc = peerConnection else { return }
+
+            let offer = try await pc.offer(for: WebRTCAudioConfig.offerConstraints)
+            try await pc.setLocalDescription(offer)
+
+            callLog("Created SDP offer (\(offer.sdp.count) bytes)")
+            await callService?.sendOffer(sdp: offer.sdp)
+            flushLocalCandidates()
+        } catch {
+            callLog("Failed to create offer: \(error)")
+            callService?.endCall(reason: .normal)
+        }
+    }
+
+    // MARK: - Incoming Call — Handle Offer & Create Answer
+
+    private func handleRemoteOffer(sdp: String) async {
+        // Guard against duplicate offers — only create if no active peer connection
+        guard peerConnection == nil else {
+            callLog("Ignoring duplicate offer — peer connection already exists")
+            return
+        }
+
+        createPeerConnection()
+        addLocalAudioTrack()
+
+        do {
+            guard let pc = peerConnection else { return }
+
+            let remoteDesc = RTCSessionDescription(type: .offer, sdp: sdp)
+            try await pc.setRemoteDescription(remoteDesc)
+            setHasRemoteDescription(true)
+            processPendingICECandidates()
+
+            let answer = try await pc.answer(for: WebRTCAudioConfig.offerConstraints)
+            try await pc.setLocalDescription(answer)
+
+            callLog("Created SDP answer (\(answer.sdp.count) bytes)")
+            await callService?.sendAnswer(sdp: answer.sdp)
+            flushLocalCandidates()
+        } catch {
+            callLog("Failed to handle offer / create answer: \(error)")
+            callService?.endCall(reason: .normal)
+        }
+    }
+
+    // MARK: - Handle Remote Answer
+
+    private func handleRemoteAnswer(sdp: String) async {
+        do {
+            let remoteDesc = RTCSessionDescription(type: .answer, sdp: sdp)
+            try await peerConnection?.setRemoteDescription(remoteDesc)
+            setHasRemoteDescription(true)
+            processPendingICECandidates()
+            callLog("Set remote answer")
+        } catch {
+            callLog("Failed to set remote answer: \(error)")
+        }
+    }
+
+    // MARK: - Handle Remote ICE Candidates
+
+    private func handleRemoteICECandidates(_ candidates: [ICECandidate]) async {
+        for candidate in candidates {
+            let rtcCandidate = RTCIceCandidate(
+                sdp: candidate.candidate,
+                sdpMLineIndex: Int32(candidate.sdpMLineIndex ?? 0),
+                sdpMid: candidate.sdpMid
+            )
+
+            if hasRemoteDescription {
+                do {
+                    try await peerConnection?.add(rtcCandidate)
+                } catch {
+                    callLog("Failed to add ICE candidate: \(error)")
+                }
+            } else {
+                pendingICECandidates.append(rtcCandidate)
+            }
+        }
+    }
+
+    // MARK: - Peer Connection
+
+    private func createPeerConnection() {
+        if peerConnection != nil {
+            peerConnection?.close()
+            peerConnection = nil
+        }
+
+        resetICEQueue()
+
+        let config = WebRTCAudioConfig.peerConnectionConfig()
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        peerConnection = factory.peerConnection(with: config, constraints: constraints, delegate: self)
+        callLog("Peer connection created")
+    }
+
+    // MARK: - Audio Track
+
+    private func addLocalAudioTrack() {
+        let audioSource = factory.audioSource(with: WebRTCAudioConfig.audioConstraints)
+        let audioTrack = factory.audioTrack(with: audioSource, trackId: "audio_\(UUID().uuidString)")
+        audioTrack.isEnabled = true
+        localAudioTrack = audioTrack
+
+        peerConnection?.add(audioTrack, streamIds: ["local_stream"])
+        callLog("Local audio track added")
+
+        // Configure audio gain after a short delay for sender parameters to settle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.configureAudioGain()
+        }
+    }
+
+    private func configureAudioGain() {
+        guard let pc = peerConnection else { return }
+
+        for transceiver in pc.transceivers where transceiver.mediaType == .audio {
+            let parameters = transceiver.sender.parameters
+            for encoding in parameters.encodings {
+                encoding.maxBitrateBps = NSNumber(value: 128_000)
+                encoding.minBitrateBps = NSNumber(value: 64_000)
+            }
+            transceiver.sender.parameters = parameters
+            callLog("Audio gain configured (64-128 kbps)")
+            break
+        }
+    }
+
+    // MARK: - ICE Queue
+
+    private func setHasRemoteDescription(_ value: Bool) {
+        hasRemoteDescription = value
+    }
+
+    private func processPendingICECandidates() {
+        guard hasRemoteDescription, !pendingICECandidates.isEmpty else { return }
+
+        let candidates = pendingICECandidates
+        pendingICECandidates.removeAll()
+
+        callLog("Processing \(candidates.count) pending ICE candidates")
+
+        Task {
+            for candidate in candidates {
+                try? await peerConnection?.add(candidate)
+            }
+        }
+    }
+
+    private func resetICEQueue() {
+        pendingICECandidates.removeAll()
+        hasRemoteDescription = false
+        pendingLocalCandidates.removeAll()
+        localDescriptionSent = false
+    }
+
+    private func flushLocalCandidates() {
+        localDescriptionSent = true
+        guard !pendingLocalCandidates.isEmpty else { return }
+
+        let candidates = pendingLocalCandidates
+        pendingLocalCandidates.removeAll()
+
+        callLog("Flushing \(candidates.count) queued local ICE candidates")
+        Task {
+            await callService?.sendICECandidates(candidates)
+        }
+    }
+
+    // MARK: - Cleanup
+
+    func cleanup() {
+        localAudioTrack?.isEnabled = false
+        localAudioTrack = nil
+        peerConnection?.close()
+        peerConnection = nil
+        pendingOfferSDP = nil
+        resetICEQueue()
+    }
+}
+
+// MARK: - CallServiceDelegate
+
+extension WebRTCClient: CallServiceDelegate {
+
+    func callService(_ service: CallService, didReceiveOffer sdp: String, callId: String) {
+        callLog("Received remote offer for call \(callId) (state: \(service.state))")
+
+        // For incoming calls: buffer the offer until user accepts (state → .connecting)
+        if case .incomingRinging = service.state {
+            callLog("Buffering offer — waiting for user to accept")
+            pendingOfferSDP = sdp
+            return
+        }
+
+        Task { await handleRemoteOffer(sdp: sdp) }
+    }
+
+    func callService(_ service: CallService, didReceiveAnswer sdp: String, callId: String) {
+        callLog("Received remote answer for call \(callId)")
+        Task { await handleRemoteAnswer(sdp: sdp) }
+    }
+
+    func callService(_ service: CallService, didReceiveICECandidates candidates: [ICECandidate], callId: String) {
+        callLog("Received \(candidates.count) remote ICE candidates")
+        Task { await handleRemoteICECandidates(candidates) }
+    }
+
+    func callService(_ service: CallService, didEndCall callId: String, reason: CallHangupReason) {
+        callLog("Call ended: \(reason.rawValue)")
+        cleanup()
+    }
+}
+
+// MARK: - RTCPeerConnectionDelegate
+
+extension WebRTCClient: RTCPeerConnectionDelegate {
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {
+        callLog("Signaling state: \(stateChanged.rawValue)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
+        for audioTrack in stream.audioTracks {
+            audioTrack.isEnabled = true
+        }
+        callLog("Remote stream added (audio tracks: \(stream.audioTracks.count))")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {
+        callLog("Remote stream removed")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {
+        callLog("ICE connection state: \(newState.rawValue)")
+
+        switch newState {
+        case .connected, .completed:
+            DispatchQueue.main.async { [weak self] in
+                self?.callService?.markConnected()
+            }
+
+        case .failed:
+            callLog("ICE failed — attempting restart")
+            peerConnection.restartIce()
+
+        case .disconnected:
+            // Wait briefly then restart if still in call
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                guard self?.callService?.state.isActive == true else { return }
+                callLog("ICE still disconnected — restarting")
+                peerConnection.restartIce()
+            }
+
+        case .closed:
+            DispatchQueue.main.async { [weak self] in
+                guard self?.callService?.state.isActive == true else { return }
+                self?.callService?.endCall(reason: .iceFailed)
+            }
+
+        default:
+            break
+        }
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
+        let iceCandidate = ICECandidate(
+            candidate: candidate.sdp,
+            sdpMid: candidate.sdpMid,
+            sdpMLineIndex: Int(candidate.sdpMLineIndex)
+        )
+
+        if localDescriptionSent {
+            Task {
+                await callService?.sendICECandidates([iceCandidate])
+            }
+        } else {
+            pendingLocalCandidates.append(iceCandidate)
+        }
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {
+        callLog("ICE candidates removed: \(candidates.count)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {
+        callLog("ICE gathering state: \(newState.rawValue)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd rtpReceiver: RTCRtpReceiver) {
+        if let track = rtpReceiver.track {
+            track.isEnabled = true
+            callLog("RTP receiver added: \(track.kind)")
+        }
+    }
+
+    func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {
+        callLog("Renegotiation needed")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {
+        callLog("Data channel opened: \(dataChannel.label)")
+    }
+}

--- a/Zyna/Services/MediaCache.swift
+++ b/Zyna/Services/MediaCache.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+import MatrixRustSDK
+
+final class MediaCache {
+
+    static let shared = MediaCache()
+
+    private let cache = NSCache<NSString, UIImage>()
+
+    private init() {
+        cache.countLimit = 200
+    }
+
+    // MARK: - Public
+
+    func image(for source: MediaSource) -> UIImage? {
+        cache.object(forKey: cacheKey(source))
+    }
+
+    func loadThumbnail(
+        source: MediaSource,
+        width: UInt64,
+        height: UInt64
+    ) async -> UIImage? {
+        let key = cacheKey(source)
+
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        guard let client = MatrixClientService.shared.client else { return nil }
+
+        do {
+            let data = try await client.getMediaThumbnail(
+                mediaSource: source,
+                width: width,
+                height: height
+            )
+            guard let image = UIImage(data: data) else { return nil }
+            cache.setObject(image, forKey: key)
+            return image
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    private func cacheKey(_ source: MediaSource) -> NSString {
+        source.url() as NSString
+    }
+}

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -166,7 +166,7 @@ final class TimelineService {
         case .text(let content):
             return .text(body: content.body)
         case .image(let content):
-            return .image(width: content.info?.width, height: content.info?.height, caption: nil)
+            return .image(source: content.source, width: content.info?.width, height: content.info?.height, caption: content.caption)
         case .notice(let content):
             return .notice(body: content.body)
         case .emote(let content):

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -15,6 +15,7 @@ final class TimelineService {
 
     let messagesSubject = CurrentValueSubject<[ChatMessage], Never>([])
     let isPaginatingSubject = CurrentValueSubject<Bool, Never>(false)
+    let rawTimelineItemsSubject = PassthroughSubject<[TimelineItem], Never>()
 
     private let room: Room
     private var timeline: Timeline?
@@ -29,6 +30,9 @@ final class TimelineService {
 
     func startListening() async {
         do {
+            // Subscribe room for full sliding sync delivery (live events)
+            try? MatrixClientService.shared.roomListService?.subscribeToRooms(roomIds: [room.id()])
+
             let timeline = try await room.timeline()
             self.timeline = timeline
 
@@ -46,8 +50,44 @@ final class TimelineService {
     // MARK: - Apply Diffs
 
     private func applyDiffs(_ diffs: [TimelineDiff]) {
+        var allItems: [TimelineItem] = []
+        var liveItems: [TimelineItem] = []
+
         for diff in diffs {
+            let change = diff.change()
+
+            switch change {
+            case .append:
+                if let items = diff.append() {
+                    allItems.append(contentsOf: items)
+                    liveItems.append(contentsOf: items)
+                }
+            case .pushBack:
+                if let item = diff.pushBack() {
+                    allItems.append(item)
+                    liveItems.append(item)
+                }
+            case .pushFront:
+                if let item = diff.pushFront() { allItems.append(item) }
+            case .insert:
+                if let update = diff.insert() { allItems.append(update.item) }
+            case .set:
+                if let update = diff.set() { allItems.append(update.item) }
+            case .reset:
+                if let items = diff.reset() { allItems.append(contentsOf: items) }
+            default:
+                break
+            }
+
             applySingleDiff(diff)
+        }
+
+        // Only check LIVE events for call invites (not pagination history)
+        checkForCallInvite(liveItems)
+
+        // Publish raw items for call signaling (deduplication happens in CallSignalingService)
+        if !allItems.isEmpty {
+            rawTimelineItemsSubject.send(allItems)
         }
 
         let messages = timelineItems.compactMap { Self.mapTimelineItem($0) }
@@ -114,6 +154,9 @@ final class TimelineService {
     private static func mapTimelineItem(_ item: TimelineItem) -> ChatMessage? {
         guard let event = item.asEvent() else { return nil }
 
+        // Filter out wrapped call signaling messages
+        if isCallSignalingMessage(event) { return nil }
+
         let timestamp = Date(timeIntervalSince1970: TimeInterval(event.timestamp) / 1000)
 
         let senderName: String?
@@ -176,6 +219,13 @@ final class TimelineService {
         }
     }
 
+    private static func isCallSignalingMessage(_ event: EventTimelineItem) -> Bool {
+        guard case .msgLike(let msgContent) = event.content,
+              case .message(let message) = msgContent.kind,
+              case .text(let text) = message.msgType else { return false }
+        return text.body.hasPrefix(CallSignalingService.signalingPrefix)
+    }
+
     // MARK: - Pagination
 
     func paginateBackwards() async {
@@ -202,6 +252,74 @@ final class TimelineService {
             timelineLog("Message sent")
         } catch {
             timelineLog("Send failed: \(error)")
+        }
+    }
+
+    /// Send call signaling data through the timeline's encrypted send pipeline.
+    func sendCallSignaling(_ text: String) async {
+        guard let timeline else { return }
+        do {
+            _ = try await timeline.send(msg: messageEventContentFromMarkdown(md: text))
+        } catch {
+            timelineLog("Call signaling send failed: \(error)")
+        }
+    }
+
+    // MARK: - Incoming Call Detection
+
+    private func checkForCallInvite(_ items: [TimelineItem]) {
+        for item in items {
+            guard let event = item.asEvent(),
+                  !event.isOwn,
+                  case .callInvite = event.content else { continue }
+
+            // Ignore old invites (e.g. from history pagination)
+            let eventTime = Date(timeIntervalSince1970: TimeInterval(event.timestamp) / 1000)
+            guard abs(eventTime.timeIntervalSinceNow) < 60 else { continue }
+
+            // Don't trigger if already in a call
+            guard !CallService.shared.state.isActive else { continue }
+
+            // Extract callId and SDP from raw event JSON
+            let debugInfo = event.lazyProvider.debugInfo()
+            guard let json = debugInfo.originalJson,
+                  let data = json.data(using: .utf8),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let content = dict["content"] as? [String: Any],
+                  let callId = content["call_id"] as? String else {
+                timelineLog("Call invite detected but failed to extract callId")
+                continue
+            }
+
+            // Extract SDP offer directly — can't rely on signaling receiving it later
+            let offerSDP: String? = {
+                if let offer = content["offer"] as? [String: Any],
+                   let sdp = offer["sdp"] as? String {
+                    return sdp
+                }
+                return nil
+            }()
+
+            let callerName: String? = {
+                if case .ready(let name, _, _) = event.senderProfile { return name }
+                return nil
+            }()
+
+            timelineLog("Incoming call invite detected: callId=\(callId) from \(callerName ?? event.sender), sdp=\(offerSDP?.count ?? 0) bytes")
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                CallService.shared.handleIncomingCall(
+                    room: self.room,
+                    callId: callId,
+                    callerName: callerName,
+                    offerSDP: offerSDP,
+                    timelineService: self
+                )
+            }
+
+            // Only handle the first invite
+            break
         }
     }
 

--- a/Zyna/Utils/ScopedLog.swift
+++ b/Zyna/Utils/ScopedLog.swift
@@ -33,6 +33,7 @@ struct LogScope: OptionSet {
     static let media       = LogScope(rawValue: bit(6))
     static let crypto      = LogScope(rawValue: bit(7))
     static let ui          = LogScope(rawValue: bit(8))
+    static let call        = LogScope(rawValue: bit(9))
 
     // MARK: - Presets
 
@@ -45,7 +46,8 @@ struct LogScope: OptionSet {
         .navigation,
         .media,
         .crypto,
-        .ui
+        .ui,
+        .call
     ]
 
     static let none: LogScope = []
@@ -55,6 +57,7 @@ struct LogScope: OptionSet {
 
 fileprivate enum Dmitry {
     static let base: LogScope = .all
+    static let calls: LogScope = [.call, .timeline]
 }
 
 // MARK: - Global Log Configuration
@@ -69,7 +72,7 @@ enum LogConfig {
     /// - [.messageSend, .calls]
     /// - .all.subtracting(.network)
     /// - .all.subtracting([.network, .calls])
-    static var enabled: LogScope = Dmitry.base
+    static var enabled: LogScope = Dmitry.calls
 
     static func enableAll() { enabled = .all }
     static func disableAll() { enabled = .none }
@@ -132,6 +135,7 @@ private extension LogScope {
         if contains(.media)      { names.append("media") }
         if contains(.crypto)     { names.append("crypto") }
         if contains(.ui)         { names.append("ui") }
+        if contains(.call)       { names.append("call") }
         return names.isEmpty ? "NONE" : names.joined(separator: "|")
     }
 }


### PR DESCRIPTION
## Summary
- WebRTC peer-to-peer audio calls between two Zyna instances
- Call signaling via Matrix: invite as native m.call.invite, answer/candidates/hangup as encrypted text messages through the timeline
- Call UI with accept/decline/hangup, incoming call detection from timeline events
- ICE candidate queuing (both local and remote) for correct ordering

## Architecture
- CallService — state machine + audio session management
- CallSignalingService — sends/receives signaling via Matrix timeline
- WebRTCClient — RTCPeerConnection + audio track, implements CallServiceDelegate
- TimelineService — detects incoming call invites from live diffs, provides encrypted send pipeline for signaling
