### PR TITLE
Context menu with node-level reparenting and drag-to-select

### DIFF
--- a/Zyna/Components/ContextMenu/ContextMenuAction.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuAction.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+struct ContextMenuAction {
+    let title: String
+    let image: UIImage?
+    let isDestructive: Bool
+    let handler: () -> Void
+
+    init(
+        title: String,
+        image: UIImage?,
+        isDestructive: Bool = false,
+        handler: @escaping () -> Void
+    ) {
+        self.title = title
+        self.image = image
+        self.isDestructive = isDestructive
+        self.handler = handler
+    }
+}

--- a/Zyna/Components/ContextMenu/ContextMenuCellNode.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuCellNode.swift
@@ -9,6 +9,7 @@ protocol ContextMenuCellNode: ASCellNode {
     var onContextMenuActivated: (() -> Void)? { get set }
     var onDragChanged: ((CGPoint) -> Void)? { get set }
     var onDragEnded: ((CGPoint) -> Void)? { get set }
+    var onInteractionLockChanged: ((Bool) -> Void)? { get set }
     func extractBubbleForMenu(in coordinateSpace: UICoordinateSpace) -> (node: ASDisplayNode, frame: CGRect)?
     func restoreBubbleFromMenu()
 }

--- a/Zyna/Components/ContextMenu/ContextMenuCellNode.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuCellNode.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+protocol ContextMenuCellNode: ASCellNode {
+    var onContextMenuActivated: (() -> Void)? { get set }
+    var onDragChanged: ((CGPoint) -> Void)? { get set }
+    var onDragEnded: ((CGPoint) -> Void)? { get set }
+    func extractBubbleForMenu(in coordinateSpace: UICoordinateSpace) -> (node: ASDisplayNode, frame: CGRect)?
+    func restoreBubbleFromMenu()
+}

--- a/Zyna/Components/ContextMenu/ContextMenuController.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuController.swift
@@ -1,0 +1,322 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class ContextMenuController: NSObject {
+
+    // MARK: - Init Data
+
+    private let contentNode: ASDisplayNode
+    private let sourceFrame: CGRect
+    private let actions: [ContextMenuAction]
+
+    var onDismissComplete: (() -> Void)?
+
+    // MARK: - Views
+
+    private var overlayWindow: OverlayWindow?
+    private let hostNode = ASDisplayNode()
+    private let contentScroll = UIScrollView()
+    private let dimmingView = UIView()
+    private let actionsContainer = UIView()
+    private let actionsStack = UIStackView()
+
+    // MARK: - Drag-to-Select
+
+    private var actionRows: [(control: HighlightControl, action: ContextMenuAction)] = []
+    private weak var highlightedRow: HighlightControl?
+    private let selectionFeedback = UISelectionFeedbackGenerator()
+
+    // MARK: - Layout State
+
+    private var targetContentFrame: CGRect = .zero
+    private var targetActionsY: CGFloat = 0
+
+    // MARK: - Constants
+
+    private static let actionsWidth: CGFloat = 250
+    private static let actionsCornerRadius: CGFloat = 14
+    private static let actionRowHeight: CGFloat = 44
+    private static let gap: CGFloat = 8
+    private static let screenPadding: CGFloat = 16
+
+    // MARK: - Init
+
+    init(contentNode: ASDisplayNode, sourceFrame: CGRect, actions: [ContextMenuAction]) {
+        self.contentNode = contentNode
+        self.sourceFrame = sourceFrame
+        self.actions = actions
+    }
+
+    // MARK: - Presentation
+
+    func show(in sourceWindow: UIWindow) {
+        guard let scene = sourceWindow.windowScene else { return }
+
+        let window = OverlayWindow(windowScene: scene)
+        window.windowLevel = sourceWindow.windowLevel + 1
+        window.frame = sourceWindow.bounds
+        window.isHidden = false
+        self.overlayWindow = window
+
+        let container = window.rootViewController!.view!
+        let bounds = sourceWindow.bounds
+        let safeTop = sourceWindow.safeAreaInsets.top + Self.screenPadding
+        let maxBottom = bounds.height - sourceWindow.safeAreaInsets.bottom - Self.screenPadding
+
+        // 1. Dimming
+        setupDimming(in: container)
+
+        // 2. Actions (calculate size before layout)
+        buildActions(in: container)
+        let actionsHeight = actionsContainer.frame.height
+
+        // 3. Calculate layout
+        let availableHeight = maxBottom - safeTop
+        let maxContentVisible = availableHeight - Self.gap - actionsHeight
+        let contentHeight = sourceFrame.height
+        let visibleContentHeight = min(contentHeight, maxContentVisible)
+
+        var bubbleY = sourceFrame.origin.y
+        var actionsY = bubbleY + visibleContentHeight + Self.gap
+
+        if actionsY + actionsHeight > maxBottom {
+            let excess = actionsY + actionsHeight - maxBottom
+            bubbleY -= excess
+            actionsY -= excess
+        }
+
+        if bubbleY < safeTop {
+            bubbleY = safeTop
+            actionsY = bubbleY + visibleContentHeight + Self.gap
+        }
+
+        targetContentFrame = CGRect(
+            x: sourceFrame.origin.x,
+            y: bubbleY,
+            width: sourceFrame.width,
+            height: visibleContentHeight
+        )
+        targetActionsY = actionsY
+
+        // 4. Content scroll view
+        contentScroll.clipsToBounds = true
+        contentScroll.showsVerticalScrollIndicator = false
+        contentScroll.isScrollEnabled = contentHeight > maxContentVisible
+        contentScroll.bounces = true
+        contentScroll.frame = sourceFrame
+        contentScroll.contentSize = sourceFrame.size
+        container.addSubview(contentScroll)
+
+        hostNode.frame = CGRect(origin: .zero, size: sourceFrame.size)
+        contentScroll.addSubview(hostNode.view)
+        hostNode.addSubnode(contentNode)
+        contentNode.frame = CGRect(origin: .zero, size: sourceFrame.size)
+
+        // 5. Actions position
+        actionsContainer.frame.origin.y = sourceFrame.maxY + Self.gap
+        let centerX = sourceFrame.midX - actionsContainer.frame.width / 2
+        actionsContainer.frame.origin.x = min(
+            max(Self.screenPadding, centerX),
+            bounds.width - Self.screenPadding - actionsContainer.frame.width
+        )
+
+        // 6. Initial state
+        dimmingView.alpha = 0
+        actionsContainer.alpha = 0
+        actionsContainer.transform = CGAffineTransform(translationX: 0, y: 8)
+        selectionFeedback.prepare()
+
+        // 7. Animate in
+        UIView.animate(
+            withDuration: 0.4,
+            delay: 0,
+            usingSpringWithDamping: 0.75,
+            initialSpringVelocity: 0,
+            options: []
+        ) {
+            self.dimmingView.alpha = 1
+            self.contentNode.view.transform = .identity
+            self.contentScroll.frame = self.targetContentFrame
+            self.actionsContainer.frame.origin.y = self.targetActionsY
+            self.actionsContainer.alpha = 1
+            self.actionsContainer.transform = .identity
+        }
+    }
+
+    // MARK: - Drag-to-Select
+
+    func trackFinger(at screenPoint: CGPoint) {
+        let row = hitTestRow(at: screenPoint)
+
+        guard row !== highlightedRow else { return }
+
+        highlightedRow?.backgroundColor = .clear
+        row?.backgroundColor = .systemGray4
+        highlightedRow = row
+
+        if row != nil {
+            selectionFeedback.selectionChanged()
+            selectionFeedback.prepare()
+        }
+    }
+
+    func releaseFinger(at screenPoint: CGPoint) {
+        guard let row = highlightedRow else { return }
+        row.backgroundColor = .clear
+        highlightedRow = nil
+
+        guard let match = actionRows.first(where: { $0.control === row }) else { return }
+        dismissMenu { match.action.handler() }
+    }
+
+    private func hitTestRow(at screenPoint: CGPoint) -> HighlightControl? {
+        let pointInStack = actionsStack.convert(screenPoint, from: nil)
+        return actionRows.first { $0.control.frame.contains(pointInStack) }?.control
+    }
+
+    // MARK: - Setup
+
+    private func setupDimming(in container: UIView) {
+        dimmingView.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        dimmingView.frame = container.bounds
+        dimmingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        container.addSubview(dimmingView)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
+        dimmingView.addGestureRecognizer(tap)
+    }
+
+    private func buildActions(in container: UIView) {
+        actionsContainer.backgroundColor = .secondarySystemBackground
+        actionsContainer.layer.cornerRadius = Self.actionsCornerRadius
+        actionsContainer.clipsToBounds = true
+        actionsContainer.layer.shadowColor = UIColor.black.cgColor
+        actionsContainer.layer.shadowOpacity = 0.15
+        actionsContainer.layer.shadowRadius = 12
+        actionsContainer.layer.shadowOffset = CGSize(width: 0, height: 4)
+
+        actionsStack.axis = .vertical
+        actionsStack.alignment = .fill
+        actionsStack.distribution = .fill
+        actionsContainer.addSubview(actionsStack)
+
+        for (index, action) in actions.enumerated() {
+            if index > 0 {
+                let separator = UIView()
+                separator.backgroundColor = .separator
+                separator.translatesAutoresizingMaskIntoConstraints = false
+                separator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale).isActive = true
+                actionsStack.addArrangedSubview(separator)
+            }
+            let row = makeActionRow(action)
+            actionsStack.addArrangedSubview(row)
+            actionRows.append((control: row, action: action))
+        }
+
+        container.addSubview(actionsContainer)
+
+        let fittingHeight = actionsStack.systemLayoutSizeFitting(
+            CGSize(width: Self.actionsWidth, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        actionsStack.frame = CGRect(x: 0, y: 0, width: Self.actionsWidth, height: fittingHeight)
+        actionsContainer.frame.size = actionsStack.frame.size
+    }
+
+    // MARK: - Action Row
+
+    private func makeActionRow(_ action: ContextMenuAction) -> HighlightControl {
+        let row = HighlightControl()
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.heightAnchor.constraint(equalToConstant: Self.actionRowHeight).isActive = true
+
+        let color: UIColor = action.isDestructive ? .systemRed : .label
+
+        let icon = UIImageView(image: action.image)
+        icon.tintColor = color
+        icon.contentMode = .scaleAspectFit
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: 20).isActive = true
+
+        let label = UILabel()
+        label.text = action.title
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = color
+
+        let stack = UIStackView(arrangedSubviews: [icon, label])
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        stack.isUserInteractionEnabled = false
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        row.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -16),
+            stack.centerYAnchor.constraint(equalTo: row.centerYAnchor)
+        ])
+
+        row.addAction(UIAction { [weak self] _ in
+            self?.dismissMenu { action.handler() }
+        }, for: .touchUpInside)
+
+        return row
+    }
+
+    // MARK: - Dismiss
+
+    private func dismissMenu(completion: (() -> Void)? = nil) {
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn) {
+            self.dimmingView.alpha = 0
+            self.contentScroll.contentOffset = .zero
+            self.contentScroll.frame = self.sourceFrame
+            self.actionsContainer.alpha = 0
+            self.actionsContainer.frame.origin.y = self.sourceFrame.maxY + Self.gap
+        } completion: { _ in
+            self.onDismissComplete?()
+            self.overlayWindow?.isHidden = true
+            self.overlayWindow = nil
+            completion?()
+        }
+    }
+
+    @objc private func backgroundTapped() {
+        dismissMenu()
+    }
+}
+
+// MARK: - Overlay Window (does not steal key status → input bar stays)
+
+private final class OverlayWindow: UIWindow {
+
+    override var canBecomeKey: Bool { false }
+
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+        backgroundColor = .clear
+        let rootVC = UIViewController()
+        rootVC.view.backgroundColor = .clear
+        rootViewController = rootVC
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Highlight Control
+
+private final class HighlightControl: UIControl {
+    override var isHighlighted: Bool {
+        didSet {
+            backgroundColor = isHighlighted ? .systemGray4 : .clear
+        }
+    }
+}

--- a/Zyna/Components/ContextMenu/ContextMenuController.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuController.swift
@@ -118,9 +118,15 @@ final class ContextMenuController: NSObject {
 
         // 5. Actions position
         actionsContainer.frame.origin.y = sourceFrame.maxY + Self.gap
-        let centerX = sourceFrame.midX - actionsContainer.frame.width / 2
+        let isRightAligned = sourceFrame.midX > bounds.width / 2
+        let actionsX: CGFloat
+        if isRightAligned {
+            actionsX = sourceFrame.maxX - actionsContainer.frame.width
+        } else {
+            actionsX = sourceFrame.minX
+        }
         actionsContainer.frame.origin.x = min(
-            max(Self.screenPadding, centerX),
+            max(Self.screenPadding, actionsX),
             bounds.width - Self.screenPadding - actionsContainer.frame.width
         )
 
@@ -132,7 +138,7 @@ final class ContextMenuController: NSObject {
 
         // 7. Animate in
         UIView.animate(
-            withDuration: 0.4,
+            withDuration: 0.35,
             delay: 0,
             usingSpringWithDamping: 0.75,
             initialSpringVelocity: 0,

--- a/Zyna/Components/ContextMenu/ContextMenuController.swift
+++ b/Zyna/Components/ContextMenu/ContextMenuController.swift
@@ -287,9 +287,11 @@ final class ContextMenuController: NSObject {
             self.actionsContainer.frame.origin.y = self.sourceFrame.maxY + Self.gap
         } completion: { _ in
             self.onDismissComplete?()
-            self.overlayWindow?.isHidden = true
-            self.overlayWindow = nil
             completion?()
+            DispatchQueue.main.async {
+                self.overlayWindow?.isHidden = true
+                self.overlayWindow = nil
+            }
         }
     }
 

--- a/Zyna/Components/ContextMenu/ContextSourceNode.swift
+++ b/Zyna/Components/ContextMenu/ContextSourceNode.swift
@@ -1,0 +1,176 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class ContextSourceNode: ASDisplayNode {
+
+    var activated: ((CGPoint) -> Void)?
+    var shouldBegin: ((CGPoint) -> Bool)?
+
+    /// Called with screen-space point while finger drags after activation.
+    var onDragChanged: ((CGPoint) -> Void)?
+    /// Called with screen-space point when finger lifts after activation.
+    var onDragEnded: ((CGPoint) -> Void)?
+
+    private var shrinkAnimator: UIViewPropertyAnimator?
+    private var activationTimer: Timer?
+    let contentNode: ASDisplayNode
+    private var didActivate = false
+
+    init(contentNode: ASDisplayNode) {
+        self.contentNode = contentNode
+        super.init()
+        addSubnode(contentNode)
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        let gesture = UILongPressGestureRecognizer(
+            target: self, action: #selector(handleGesture)
+        )
+        gesture.minimumPressDuration = 0
+        gesture.delegate = self
+        view.addGestureRecognizer(gesture)
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        ASWrapperLayoutSpec(layoutElement: contentNode)
+    }
+
+    override func layout() {
+        super.layout()
+        contentNode.frame = bounds
+    }
+
+    // MARK: - Reparenting
+
+    func extractContentForMenu(in coordinateSpace: UICoordinateSpace) -> (node: ASDisplayNode, frame: CGRect) {
+        let contentView = contentNode.view
+        let savedTransform = contentView.transform
+        contentView.transform = .identity
+        let frame = contentView.convert(contentView.bounds, to: coordinateSpace)
+        contentView.transform = savedTransform
+        return (contentNode, frame)
+    }
+
+    func restoreContentFromMenu() {
+        addSubnode(contentNode)
+        contentNode.view.transform = .identity
+        contentNode.view.alpha = 1
+        contentNode.frame = bounds
+    }
+
+    // MARK: - Gesture
+
+    @objc private func handleGesture(_ gesture: UILongPressGestureRecognizer) {
+        let location = gesture.location(in: view)
+
+        switch gesture.state {
+        case .began:
+            if shouldBegin?(location) == false {
+                gesture.isEnabled = false
+                gesture.isEnabled = true
+                return
+            }
+            startShrink()
+
+        case .changed:
+            if didActivate {
+                let screenPoint = gesture.location(in: nil)
+                onDragChanged?(screenPoint)
+            } else {
+                let expandedBounds = view.bounds.insetBy(dx: -40, dy: -40)
+                if !expandedBounds.contains(location) {
+                    cancelShrink()
+                    gesture.isEnabled = false
+                    gesture.isEnabled = true
+                }
+            }
+
+        case .ended, .cancelled, .failed:
+            if didActivate {
+                let screenPoint = gesture.location(in: nil)
+                onDragEnded?(screenPoint)
+            } else {
+                cancelShrink()
+            }
+            didActivate = false
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Animation
+
+    private func startShrink() {
+        shrinkAnimator?.stopAnimation(true)
+
+        activationTimer = Timer.scheduledTimer(
+            withTimeInterval: 0.12, repeats: false
+        ) { [weak self] _ in
+            self?.beginShrinkAnimation()
+        }
+    }
+
+    private func beginShrinkAnimation() {
+        let targetScale: CGFloat = 0.92
+
+        shrinkAnimator = UIViewPropertyAnimator(
+            duration: 0.25,
+            curve: .easeOut
+        ) {
+            self.contentNode.view.transform = CGAffineTransform(
+                scaleX: targetScale, y: targetScale
+            )
+        }
+
+        shrinkAnimator?.addCompletion { [weak self] position in
+            guard position == .end else { return }
+            self?.triggerActivation()
+        }
+
+        shrinkAnimator?.startAnimation()
+    }
+
+    private func triggerActivation() {
+        didActivate = true
+        shrinkAnimator = nil
+
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        let location = CGPoint(
+            x: bounds.midX,
+            y: bounds.midY
+        )
+        activated?(location)
+    }
+
+    private func cancelShrink() {
+        activationTimer?.invalidate()
+        activationTimer = nil
+
+        guard let animator = shrinkAnimator else { return }
+        animator.stopAnimation(true)
+        shrinkAnimator = nil
+
+        UIView.animate(withDuration: 0.2) {
+            self.contentNode.view.transform = .identity
+        }
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension ContextSourceNode: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        return other is UIPanGestureRecognizer
+    }
+}

--- a/Zyna/Components/ContextMenu/ContextSourceNode.swift
+++ b/Zyna/Components/ContextMenu/ContextSourceNode.swift
@@ -14,6 +14,8 @@ final class ContextSourceNode: ASDisplayNode {
     var onDragChanged: ((CGPoint) -> Void)?
     /// Called with screen-space point when finger lifts after activation.
     var onDragEnded: ((CGPoint) -> Void)?
+    /// Called when interaction should be locked (true) or unlocked (false).
+    var onInteractionLockChanged: ((Bool) -> Void)?
 
     private var shrinkAnimator: UIViewPropertyAnimator?
     private var activationTimer: Timer?
@@ -117,6 +119,7 @@ final class ContextSourceNode: ASDisplayNode {
     }
 
     private func beginShrinkAnimation() {
+        onInteractionLockChanged?(true)
         let targetScale: CGFloat = 0.92
 
         shrinkAnimator = UIViewPropertyAnimator(
@@ -157,6 +160,7 @@ final class ContextSourceNode: ASDisplayNode {
         guard let animator = shrinkAnimator else { return }
         animator.stopAnimation(true)
         shrinkAnimator = nil
+        onInteractionLockChanged?(false)
 
         UIView.animate(withDuration: 0.2) {
             self.contentNode.view.transform = .identity
@@ -171,6 +175,7 @@ extension ContextSourceNode: UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
     ) -> Bool {
+        if shrinkAnimator != nil || didActivate { return false }
         return other is UIPanGestureRecognizer
     }
 }

--- a/Zyna/Components/ContextMenu/ContextSourceNode.swift
+++ b/Zyna/Components/ContextMenu/ContextSourceNode.swift
@@ -59,10 +59,13 @@ final class ContextSourceNode: ASDisplayNode {
     }
 
     func restoreContentFromMenu() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         addSubnode(contentNode)
         contentNode.view.transform = .identity
         contentNode.view.alpha = 1
         contentNode.frame = bounds
+        CATransaction.commit()
     }
 
     // MARK: - Gesture

--- a/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
+++ b/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
@@ -22,6 +22,11 @@ final class ImageMessageCellNode: ASCellNode, ContextMenuCellNode {
         set { contextSourceNode.onDragEnded = newValue }
     }
 
+    var onInteractionLockChanged: ((Bool) -> Void)? {
+        get { contextSourceNode.onInteractionLockChanged }
+        set { contextSourceNode.onInteractionLockChanged = newValue }
+    }
+
     // MARK: - Subnodes
 
     private let bubbleNode = ASDisplayNode()

--- a/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
+++ b/Zyna/Screens/Chat/CellNodes/ImageMessageCellNode.swift
@@ -6,11 +6,26 @@
 import AsyncDisplayKit
 import MatrixRustSDK
 
-final class ImageMessageCellNode: ASCellNode {
+final class ImageMessageCellNode: ASCellNode, ContextMenuCellNode {
+
+    // MARK: - Context Menu
+
+    var onContextMenuActivated: (() -> Void)?
+
+    var onDragChanged: ((CGPoint) -> Void)? {
+        get { contextSourceNode.onDragChanged }
+        set { contextSourceNode.onDragChanged = newValue }
+    }
+
+    var onDragEnded: ((CGPoint) -> Void)? {
+        get { contextSourceNode.onDragEnded }
+        set { contextSourceNode.onDragEnded = newValue }
+    }
 
     // MARK: - Subnodes
 
     private let bubbleNode = ASDisplayNode()
+    private let contextSourceNode: ContextSourceNode
     private let imageNode = ASImageNode()
     private let timeNode = ASTextNode()
     private let timeBadgeNode = ASDisplayNode()
@@ -63,7 +78,12 @@ final class ImageMessageCellNode: ASCellNode {
             self.aspectRatio = 4.0 / 3.0
         }
 
+        self.contextSourceNode = ContextSourceNode(contentNode: bubbleNode)
         super.init()
+
+        contextSourceNode.activated = { [weak self] _ in
+            self?.onContextMenuActivated?()
+        }
 
         automaticallyManagesSubnodes = true
         selectionStyle = .none
@@ -74,10 +94,36 @@ final class ImageMessageCellNode: ASCellNode {
         imageNode.clipsToBounds = true
         imageNode.displaysAsynchronously = true
 
-        // Bubble
+        // Bubble — self-contained with all content
         bubbleNode.backgroundColor = isOutgoing ? .systemBlue : .systemGray5
         bubbleNode.cornerRadius = 18
         bubbleNode.clipsToBounds = true
+        bubbleNode.automaticallyManagesSubnodes = true
+        bubbleNode.layoutSpecBlock = { [weak self] _, _ in
+            guard let self else { return ASLayoutSpec() }
+            let maxWidth = ScreenConstants.width * Self.maxBubbleWidthRatio
+            let imgHeight = maxWidth / self.aspectRatio
+
+            self.imageNode.style.preferredSize = CGSize(width: maxWidth, height: min(imgHeight, 400))
+
+            let timePadded = ASInsetLayoutSpec(
+                insets: UIEdgeInsets(top: 2, left: 6, bottom: 2, right: 6),
+                child: self.timeNode
+            )
+            let timeBadge = ASBackgroundLayoutSpec(child: timePadded, background: self.timeBadgeNode)
+
+            let timeOverlay = ASRelativeLayoutSpec(
+                horizontalPosition: .end,
+                verticalPosition: .end,
+                sizingOption: .minimumSize,
+                child: ASInsetLayoutSpec(
+                    insets: UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 8),
+                    child: timeBadge
+                )
+            )
+
+            return ASOverlayLayoutSpec(child: self.imageNode, overlay: timeOverlay)
+        }
 
         // Time badge
         timeBadgeNode.backgroundColor = UIColor.black.withAlphaComponent(0.4)
@@ -136,35 +182,6 @@ final class ImageMessageCellNode: ASCellNode {
     // MARK: - Layout
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        let maxWidth = ScreenConstants.width * Self.maxBubbleWidthRatio
-        let imageHeight = maxWidth / aspectRatio
-
-        imageNode.style.preferredSize = CGSize(width: maxWidth, height: min(imageHeight, 400))
-
-        // Time badge with padding
-        let timePadded = ASInsetLayoutSpec(
-            insets: UIEdgeInsets(top: 2, left: 6, bottom: 2, right: 6),
-            child: timeNode
-        )
-        let timeBadge = ASBackgroundLayoutSpec(child: timePadded, background: timeBadgeNode)
-
-        // Time overlay at bottom-right
-        let timeOverlay = ASRelativeLayoutSpec(
-            horizontalPosition: .end,
-            verticalPosition: .end,
-            sizingOption: .minimumSize,
-            child: ASInsetLayoutSpec(
-                insets: UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 8),
-                child: timeBadge
-            )
-        )
-
-        let imageWithTime = ASOverlayLayoutSpec(child: imageNode, overlay: timeOverlay)
-
-        // Bubble behind image
-        let bubble = ASBackgroundLayoutSpec(child: imageWithTime, background: bubbleNode)
-
-        // Sender name above bubble
         let bubbleWithName: ASLayoutElement
         if showSenderName {
             let nameInset = ASInsetLayoutSpec(
@@ -176,13 +193,12 @@ final class ImageMessageCellNode: ASCellNode {
                 spacing: 0,
                 justifyContent: .start,
                 alignItems: .start,
-                children: [nameInset, bubble]
+                children: [nameInset, contextSourceNode]
             )
         } else {
-            bubbleWithName = bubble
+            bubbleWithName = contextSourceNode
         }
 
-        // Spacer for alignment
         let spacer = ASLayoutSpec()
         spacer.style.flexGrow = 1
 
@@ -194,6 +210,17 @@ final class ImageMessageCellNode: ASCellNode {
             : [bubbleWithName, spacer]
 
         return ASInsetLayoutSpec(insets: Self.cellInsets, child: hStack)
+    }
+
+    // MARK: - Context Menu Reparenting
+
+    func extractBubbleForMenu(in coordinateSpace: UICoordinateSpace) -> (node: ASDisplayNode, frame: CGRect)? {
+        guard isNodeLoaded else { return nil }
+        return contextSourceNode.extractContentForMenu(in: coordinateSpace)
+    }
+
+    func restoreBubbleFromMenu() {
+        contextSourceNode.restoreContentFromMenu()
     }
 
     // MARK: - Helpers

--- a/Zyna/Screens/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Screens/Chat/CellNodes/TextMessageCellNode.swift
@@ -21,6 +21,11 @@ final class TextMessageCellNode: ASCellNode, ContextMenuCellNode {
         set { contextSourceNode.onDragEnded = newValue }
     }
 
+    var onInteractionLockChanged: ((Bool) -> Void)? {
+        get { contextSourceNode.onInteractionLockChanged }
+        set { contextSourceNode.onInteractionLockChanged = newValue }
+    }
+
     // MARK: - Subnodes
 
     private let bubbleNode = ASDisplayNode()

--- a/Zyna/Screens/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Screens/Chat/CellNodes/TextMessageCellNode.swift
@@ -5,11 +5,26 @@
 
 import AsyncDisplayKit
 
-final class TextMessageCellNode: ASCellNode {
+final class TextMessageCellNode: ASCellNode, ContextMenuCellNode {
+
+    // MARK: - Context Menu
+
+    var onContextMenuActivated: (() -> Void)?
+
+    var onDragChanged: ((CGPoint) -> Void)? {
+        get { contextSourceNode.onDragChanged }
+        set { contextSourceNode.onDragChanged = newValue }
+    }
+
+    var onDragEnded: ((CGPoint) -> Void)? {
+        get { contextSourceNode.onDragEnded }
+        set { contextSourceNode.onDragEnded = newValue }
+    }
 
     // MARK: - Subnodes
 
     private let bubbleNode = ASDisplayNode()
+    private let contextSourceNode: ContextSourceNode
     private let textNode = ASTextNode()
     private let timeNode = ASTextNode()
     private let senderNameNode = ASTextNode()
@@ -41,7 +56,12 @@ final class TextMessageCellNode: ASCellNode {
     init(message: ChatMessage, isGroupChat: Bool = false) {
         self.isOutgoing = message.isOutgoing
         self.showSenderName = !message.isOutgoing && isGroupChat
+        self.contextSourceNode = ContextSourceNode(contentNode: bubbleNode)
         super.init()
+
+        contextSourceNode.activated = { [weak self] _ in
+            self?.onContextMenuActivated?()
+        }
 
         automaticallyManagesSubnodes = true
         selectionStyle = .none
@@ -84,10 +104,29 @@ final class TextMessageCellNode: ASCellNode {
             ]
         )
 
-        // Bubble
+        // Bubble — self-contained with all content
         bubbleNode.backgroundColor = isOutgoing ? .systemBlue : .systemGray5
         bubbleNode.cornerRadius = 18
         bubbleNode.clipsToBounds = true
+        bubbleNode.automaticallyManagesSubnodes = true
+        bubbleNode.layoutSpecBlock = { [weak self] _, _ in
+            guard let self else { return ASLayoutSpec() }
+            let timeSpec = ASStackLayoutSpec(
+                direction: .vertical,
+                spacing: 0,
+                justifyContent: .end,
+                alignItems: .end,
+                children: [self.timeNode]
+            )
+            let textTimeRow = ASStackLayoutSpec(
+                direction: .horizontal,
+                spacing: 6,
+                justifyContent: .start,
+                alignItems: .end,
+                children: [self.textNode, timeSpec]
+            )
+            return ASInsetLayoutSpec(insets: Self.bubbleInsets, child: textTimeRow)
+        }
 
         // Sender name
         if showSenderName, let name = message.senderDisplayName {
@@ -105,32 +144,6 @@ final class TextMessageCellNode: ASCellNode {
     // MARK: - Layout
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        // Time aligned to bottom
-        let timeSpec = ASStackLayoutSpec(
-            direction: .vertical,
-            spacing: 0,
-            justifyContent: .end,
-            alignItems: .end,
-            children: [timeNode]
-        )
-
-        // Text + time row
-        let textTimeRow = ASStackLayoutSpec(
-            direction: .horizontal,
-            spacing: 6,
-            justifyContent: .start,
-            alignItems: .end,
-            children: [textNode, timeSpec]
-        )
-
-        let paddedContent = ASInsetLayoutSpec(
-            insets: Self.bubbleInsets,
-            child: textTimeRow
-        )
-
-        let bubble = ASBackgroundLayoutSpec(child: paddedContent, background: bubbleNode)
-
-        // Sender name above bubble (for incoming in group chats)
         let bubbleWithName: ASLayoutElement
         if showSenderName {
             let nameInset = ASInsetLayoutSpec(
@@ -142,13 +155,12 @@ final class TextMessageCellNode: ASCellNode {
                 spacing: 0,
                 justifyContent: .start,
                 alignItems: .start,
-                children: [nameInset, bubble]
+                children: [nameInset, contextSourceNode]
             )
         } else {
-            bubbleWithName = bubble
+            bubbleWithName = contextSourceNode
         }
 
-        // Spacer for left/right alignment
         let spacer = ASLayoutSpec()
         spacer.style.flexGrow = 1
 
@@ -160,6 +172,17 @@ final class TextMessageCellNode: ASCellNode {
             : [bubbleWithName, spacer]
 
         return ASInsetLayoutSpec(insets: Self.cellInsets, child: hStack)
+    }
+
+    // MARK: - Context Menu Reparenting
+
+    func extractBubbleForMenu(in coordinateSpace: UICoordinateSpace) -> (node: ASDisplayNode, frame: CGRect)? {
+        guard isNodeLoaded else { return nil }
+        return contextSourceNode.extractContentForMenu(in: coordinateSpace)
+    }
+
+    func restoreBubbleFromMenu() {
+        contextSourceNode.restoreContentFromMenu()
     }
 
     // MARK: - Helpers

--- a/Zyna/Screens/Chat/ChatView.swift
+++ b/Zyna/Screens/Chat/ChatView.swift
@@ -14,6 +14,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let viewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
     private let inputAccessory = ChatInputAccessoryView()
+    private var activeContextMenu: ContextMenuController?
 
     // MARK: - InputAccessoryView
 
@@ -162,14 +163,65 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
         let message = viewModel.messages[indexPath.row]
-        return {
+        return { [weak self] in
+            let cellNode: ASCellNode & ContextMenuCellNode
             switch message.content {
             case .image:
-                return ImageMessageCellNode(message: message)
+                cellNode = ImageMessageCellNode(message: message)
             default:
-                return TextMessageCellNode(message: message)
+                cellNode = TextMessageCellNode(message: message)
             }
+
+            cellNode.onContextMenuActivated = { [weak self, weak cellNode] in
+                guard let self, let cellNode else { return }
+                self.presentContextMenu(for: message, from: cellNode)
+            }
+
+            return cellNode
         }
+    }
+
+    // MARK: - Context Menu
+
+    private func presentContextMenu(for message: ChatMessage, from cellNode: ContextMenuCellNode) {
+        guard let window = view.window,
+              let info = cellNode.extractBubbleForMenu(in: window.coordinateSpace) else { return }
+
+        let actions = [
+            ContextMenuAction(
+                title: "Reply",
+                image: UIImage(systemName: "arrowshape.turn.up.left"),
+                handler: { print("[context-menu] Reply tapped: \(message.id)") }
+            ),
+            ContextMenuAction(
+                title: "Delete",
+                image: UIImage(systemName: "trash"),
+                isDestructive: true,
+                handler: { print("[context-menu] Delete tapped: \(message.id)") }
+            )
+        ]
+
+        let menuVC = ContextMenuController(
+            contentNode: info.node,
+            sourceFrame: info.frame,
+            actions: actions
+        )
+        menuVC.onDismissComplete = { [weak self, weak cellNode] in
+            cellNode?.restoreBubbleFromMenu()
+            self?.node.tableNode.view.isScrollEnabled = true
+            self?.activeContextMenu = nil
+        }
+
+        cellNode.onDragChanged = { [weak menuVC] point in
+            menuVC?.trackFinger(at: point)
+        }
+        cellNode.onDragEnded = { [weak menuVC] point in
+            menuVC?.releaseFinger(at: point)
+        }
+
+        node.tableNode.view.isScrollEnabled = false
+        activeContextMenu = menuVC
+        menuVC.show(in: window)
     }
 
     // MARK: - ASTableDelegate — Batch Fetching (Pagination)

--- a/Zyna/Screens/Chat/ChatView.swift
+++ b/Zyna/Screens/Chat/ChatView.swift
@@ -15,6 +15,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private var cancellables = Set<AnyCancellable>()
     private let inputAccessory = ChatInputAccessoryView()
     private var activeContextMenu: ContextMenuController?
+    private var interactionLocks = Set<String>()
 
     // MARK: - InputAccessoryView
 
@@ -172,6 +173,14 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 cellNode = TextMessageCellNode(message: message)
             }
 
+            cellNode.onInteractionLockChanged = { [weak self] locked in
+                if locked {
+                    self?.lockInteraction("contextMenu")
+                } else {
+                    self?.unlockInteraction("contextMenu")
+                }
+            }
+
             cellNode.onContextMenuActivated = { [weak self, weak cellNode] in
                 guard let self, let cellNode else { return }
                 self.presentContextMenu(for: message, from: cellNode)
@@ -208,7 +217,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         )
         menuVC.onDismissComplete = { [weak self, weak cellNode] in
             cellNode?.restoreBubbleFromMenu()
-            self?.node.tableNode.view.isScrollEnabled = true
+            self?.unlockInteraction("contextMenu")
             self?.activeContextMenu = nil
         }
 
@@ -219,9 +228,27 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             menuVC?.releaseFinger(at: point)
         }
 
-        node.tableNode.view.isScrollEnabled = false
         activeContextMenu = menuVC
         menuVC.show(in: window)
+    }
+
+    // MARK: - Interaction Lock
+
+    func lockInteraction(_ token: String) {
+        let wasEmpty = interactionLocks.isEmpty
+        interactionLocks.insert(token)
+        if wasEmpty {
+            node.tableNode.view.isScrollEnabled = false
+            navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        }
+    }
+
+    func unlockInteraction(_ token: String) {
+        interactionLocks.remove(token)
+        if interactionLocks.isEmpty {
+            node.tableNode.view.isScrollEnabled = true
+            navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        }
     }
 
     // MARK: - ASTableDelegate — Batch Fetching (Pagination)


### PR DESCRIPTION
## Summary
- Context menu with long-press activation, shrink animation, and haptic feedback

- Node-level reparenting: the actual bubble node is extracted into an overlay window
- Drag-to-select: finger movement highlights action rows with selection feedback
- Edge-aligned action positioning based on bubble side
- Token-based interaction lock to prevent scroll conflicts during context menu
- Flicker-free reverse reparenting via CATransaction and deferred overlay teardown