### PR TITLE
Paint splash message deletion with Matrix redaction

### DIFF
--- a/Zyna/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/TextMessageCellNode.swift
@@ -35,6 +35,8 @@ final class TextMessageCellNode: MessageCellNode {
             bodyText = "🎤 Voice message"
         case .unsupported(let typeName):
             bodyText = "[\(typeName)]"
+        case .redacted:
+            bodyText = "Message deleted"
         }
 
         textNode.attributedText = NSAttributedString(

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -15,6 +15,12 @@ enum ChatMessageContent: Equatable {
     case emote(body: String)
     case voice(source: MediaSource, duration: TimeInterval, waveform: [UInt16])
     case unsupported(typeName: String)
+    case redacted
+
+    var isRedacted: Bool {
+        if case .redacted = self { return true }
+        return false
+    }
 
     static func == (lhs: ChatMessageContent, rhs: ChatMessageContent) -> Bool {
         switch (lhs, rhs) {
@@ -30,6 +36,8 @@ enum ChatMessageContent: Equatable {
             return a == b
         case (.unsupported(let a), .unsupported(let b)):
             return a == b
+        case (.redacted, .redacted):
+            return true
         default:
             return false
         }

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -17,6 +17,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let inputAccessory = ChatInputAccessoryView()
     private let audioPlayer = AudioPlayerService()
     private var activeContextMenu: ContextMenuController?
+    private var pendingRedactedIds: [String] = []
     private var interactionLocks = Set<String>()
     private lazy var fpsBooster = ScrollFPSBooster(hostView: node.tableNode.view)
 
@@ -121,6 +122,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private func bindViewModel() {
         viewModel.onTableUpdate = { [weak self] update in
             self?.applyTableUpdate(update)
+        }
+
+        viewModel.onRedactedDetected = { [weak self] messageIds in
+            self?.handleRedactedMessages(messageIds)
         }
     }
 
@@ -228,21 +233,24 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         guard let window = view.window,
               let info = cellNode.extractBubbleForMenu(in: window.coordinateSpace) else { return }
 
-        let actions = [
+        var actions = [
             ContextMenuAction(
                 title: "Reply",
                 image: UIImage(systemName: "arrowshape.turn.up.left"),
                 handler: { print("[context-menu] Reply tapped: \(message.id)") }
-            ),
-            ContextMenuAction(
+            )
+        ]
+
+        if message.itemIdentifier != nil && !message.content.isRedacted {
+            actions.append(ContextMenuAction(
                 title: "Delete",
                 image: UIImage(systemName: "trash"),
                 isDestructive: true,
                 handler: { [weak self] in
                     self?.triggerPaintSplashDelete(for: message)
                 }
-            )
-        ]
+            ))
+        }
 
         let menuVC = ContextMenuController(
             contentNode: info.node,
@@ -253,6 +261,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             cellNode?.restoreBubbleFromMenu()
             self?.unlockInteraction("contextMenu")
             self?.activeContextMenu = nil
+            self?.flushPendingRedactions()
         }
 
         menuVC.onReactionSelected = { [weak self] emoji in
@@ -324,16 +333,42 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     // MARK: - Paint Splash Delete
 
     private func triggerPaintSplashDelete(for message: ChatMessage) {
-        guard let indexPath = indexPathForMessage(message) else { return }
+        viewModel.redactMessage(message)
+    }
 
-        PaintSplashTrigger.trigger(in: node.tableNode, at: indexPath) { [weak self] in
-            guard let self else { return }
-            // Local-only stub: remove from array + table
-            self.viewModel.deleteMessageLocally(message.id)
-            self.node.tableNode.performBatch(animated: true, updates: {
-                self.node.tableNode.deleteRows(at: [indexPath], with: .automatic)
-            }, completion: nil)
+    private func handleRedactedMessages(_ messageIds: [String]) {
+        // Defer if context menu is active (bubble is reparented to overlay)
+        if activeContextMenu != nil {
+            pendingRedactedIds.append(contentsOf: messageIds)
+            return
         }
+
+        for messageId in messageIds {
+            guard let row = viewModel.messages.firstIndex(where: { $0.id == messageId }) else {
+                viewModel.hideMessage(messageId)
+                continue
+            }
+
+            let indexPath = IndexPath(row: row, section: 0)
+
+            // If cell is off-screen, hide immediately without animation
+            guard let cellNode = node.tableNode.nodeForRow(at: indexPath) as? MessageCellNode,
+                  cellNode.isNodeLoaded else {
+                viewModel.hideMessage(messageId)
+                continue
+            }
+
+            PaintSplashTrigger.trigger(in: node.tableNode, at: indexPath) { [weak self] in
+                self?.viewModel.hideMessage(messageId)
+            }
+        }
+    }
+
+    private func flushPendingRedactions() {
+        guard !pendingRedactedIds.isEmpty else { return }
+        let ids = pendingRedactedIds
+        pendingRedactedIds.removeAll()
+        handleRedactedMessages(ids)
     }
 
     private func indexPathForMessage(_ message: ChatMessage) -> IndexPath? {

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -238,7 +238,9 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 title: "Delete",
                 image: UIImage(systemName: "trash"),
                 isDestructive: true,
-                handler: { print("[context-menu] Delete tapped: \(message.id)") }
+                handler: { [weak self] in
+                    self?.triggerPaintSplashDelete(for: message)
+                }
             )
         ]
 
@@ -317,5 +319,27 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         fpsBooster.stop()
+    }
+
+    // MARK: - Paint Splash Delete
+
+    private func triggerPaintSplashDelete(for message: ChatMessage) {
+        guard let indexPath = indexPathForMessage(message) else { return }
+
+        PaintSplashTrigger.trigger(in: node.tableNode, at: indexPath) { [weak self] in
+            guard let self else { return }
+            // Local-only stub: remove from array + table
+            self.viewModel.deleteMessageLocally(message.id)
+            self.node.tableNode.performBatch(animated: true, updates: {
+                self.node.tableNode.deleteRows(at: [indexPath], with: .automatic)
+            }, completion: nil)
+        }
+    }
+
+    private func indexPathForMessage(_ message: ChatMessage) -> IndexPath? {
+        guard let row = viewModel.messages.firstIndex(where: { $0.id == message.id }) else {
+            return nil
+        }
+        return IndexPath(row: row, section: 0)
     }
 }

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -81,6 +81,13 @@ final class ChatViewModel {
         }
     }
 
+    /// Local-only stub: removes the message from the in-memory array.
+    /// Does NOT redact on the server — message will reappear on next sync.
+    func deleteMessageLocally(_ messageId: String) {
+        guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
+        messages.remove(at: index)
+    }
+
     func loadOlderMessages() {
         guard !isPaginating else { return }
         Task {

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -17,6 +17,12 @@ final class ChatViewModel {
     /// Called on the main queue when the table needs updating.
     var onTableUpdate: ((TableUpdate) -> Void)?
 
+    /// Called when messages become redacted (from any source). Passes message IDs.
+    var onRedactedDetected: (([String]) -> Void)?
+
+    /// Called when a redaction request fails.
+    var onRedactionFailed: ((String, Error) -> Void)?
+
     let roomName: String
 
     // MARK: - Coordinator callback
@@ -45,8 +51,36 @@ final class ChatViewModel {
         coalescer.onBatchReady = { [weak self] newMessages, tableUpdate in
             guard let self else { return }
             Self.prefetchImages(newMessages)
+
+            // Detect newly redacted messages in updates
+            let redactedIds: [String]
+            if case .batch(_, _, let updates, _) = tableUpdate, !updates.isEmpty {
+                redactedIds = updates.compactMap { ip -> String? in
+                    guard ip.row < newMessages.count else { return nil }
+                    let msg = newMessages[ip.row]
+                    return msg.content.isRedacted ? msg.id : nil
+                }
+            } else {
+                redactedIds = []
+            }
+
             self.messages = newMessages
-            self.onTableUpdate?(tableUpdate)
+
+            if !redactedIds.isEmpty {
+                // Filter redacted from normal table update (controller handles them via animation)
+                if case .batch(let del, let ins, let upd, let anim) = tableUpdate {
+                    let filtered = upd.filter { ip in
+                        guard ip.row < newMessages.count else { return true }
+                        return !newMessages[ip.row].content.isRedacted
+                    }
+                    self.onTableUpdate?(.batch(deletions: del, insertions: ins, updates: filtered, animated: anim))
+                } else {
+                    self.onTableUpdate?(tableUpdate)
+                }
+                self.onRedactedDetected?(redactedIds)
+            } else {
+                self.onTableUpdate?(tableUpdate)
+            }
 
             // Auto-paginate when SDK delivers fewer messages than one page
             if newMessages.count < 20 && !self.isPaginating {
@@ -81,11 +115,21 @@ final class ChatViewModel {
         }
     }
 
-    /// Local-only stub: removes the message from the in-memory array.
-    /// Does NOT redact on the server — message will reappear on next sync.
-    func deleteMessageLocally(_ messageId: String) {
-        guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
-        messages.remove(at: index)
+    func redactMessage(_ message: ChatMessage) {
+        guard let itemId = message.itemIdentifier else { return }
+        Task {
+            do {
+                try await timelineService.redactEvent(itemId)
+            } catch {
+                await MainActor.run {
+                    onRedactionFailed?(message.id, error)
+                }
+            }
+        }
+    }
+
+    func hideMessage(_ messageId: String) {
+        coalescer.hide(messageId)
     }
 
     func loadOlderMessages() {

--- a/Zyna/Chat/Timeline/TimelineCoalescer.swift
+++ b/Zyna/Chat/Timeline/TimelineCoalescer.swift
@@ -31,6 +31,9 @@ final class TimelineCoalescer {
     /// Messages in display order (reversed chronological for the inverted table).
     private var displayMessages: [ChatMessage] = []
 
+    /// IDs of messages hidden after paint-splash animation (redacted and dismissed).
+    private var hiddenIds = Set<String>()
+
     private var pendingDiffs: [TimelineDiff] = []
     private var debounceWork: DispatchWorkItem?
 
@@ -44,6 +47,27 @@ final class TimelineCoalescer {
             guard let self else { return }
             self.pendingDiffs.append(contentsOf: diffs)
             self.scheduleFlush()
+        }
+    }
+
+    /// Permanently hides a message from the display array (called after splash animation).
+    func hide(_ messageId: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.hiddenIds.insert(messageId)
+
+            let oldDisplay = self.displayMessages
+            self.displayMessages = self.chronMessages.reversed().filter { msg in
+                !self.hiddenIds.contains(msg.id) && !msg.content.isRedacted
+            }
+
+            guard let oldIdx = oldDisplay.firstIndex(where: { $0.id == messageId }) else { return }
+            self.onBatchReady?(self.displayMessages, .batch(
+                deletions: [IndexPath(row: oldIdx, section: 0)],
+                insertions: [],
+                updates: [],
+                animated: false
+            ))
         }
     }
 
@@ -79,7 +103,11 @@ final class TimelineCoalescer {
             applySingleDiff(diff, updatedIds: &updatedIds)
         }
 
-        displayMessages = Array(chronMessages.reversed())
+        // Filter out: hidden (post-animation) and already-redacted (historical).
+        // Keep live redactions (in updatedIds) so the controller can animate them first.
+        displayMessages = chronMessages.reversed().filter { msg in
+            !hiddenIds.contains(msg.id) && (!msg.content.isRedacted || updatedIds.contains(msg.id))
+        }
 
         if hadResetOrClear {
             onBatchReady?(displayMessages, .reload)

--- a/Zyna/Components/PaintSplash/PaintSplashLayer.swift
+++ b/Zyna/Components/PaintSplash/PaintSplashLayer.swift
@@ -1,0 +1,313 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+import Metal
+import MetalKit
+import QuartzCore
+
+final class PaintSplashLayer: CAMetalLayer {
+
+    private static let referenceArea: CGFloat = 8_000  // ~200×40 text bubble
+    private static let baseDropletCount: UInt32 = 300
+    private static let maxDropletCount: UInt32 = 1200
+
+    var becameEmpty: (() -> Void)?
+
+    // MARK: - Item
+
+    private final class Item {
+        let frame: CGRect
+        let texture: MTLTexture
+        let dropletBuffer: MTLBuffer
+        let dropletCount: UInt32
+
+        var phase: Float = 0
+        var isInitialized = false
+
+        init?(frame: CGRect, image: UIImage, device: MTLDevice) {
+            self.frame = frame
+
+            // Scale droplet count with bubble area
+            let area = frame.width * frame.height
+            let scale = pow(area / PaintSplashLayer.referenceArea, 0.6)
+            self.dropletCount = min(
+                max(UInt32(Float(PaintSplashLayer.baseDropletCount) * Float(scale)), 200),
+                PaintSplashLayer.maxDropletCount
+            )
+
+            guard let cgImage = image.cgImage,
+                  let texture = try? MTKTextureLoader(device: device)
+                      .newTexture(cgImage: cgImage, options: [.SRGB: false as NSNumber])
+            else { return nil }
+            self.texture = texture
+
+            let dropletStride = MemoryLayout<Float>.stride * 16 // matches Droplet struct
+            guard let dbuf = device.makeBuffer(
+                length: Int(dropletCount) * dropletStride,
+                options: .storageModeShared
+            ) else { return nil }
+            self.dropletBuffer = dbuf
+        }
+    }
+
+    // MARK: - Pipeline State Cache
+
+    private struct PipelineStates {
+        let initCompute: MTLComputePipelineState
+        let updateCompute: MTLComputePipelineState
+        let blobRender: MTLRenderPipelineState
+        let compositeRender: MTLRenderPipelineState
+    }
+
+    // MARK: - Properties
+
+    private var items: [Item] = []
+    private var displayLinkToken: DisplayLinkToken?
+    private var pipelineStates: PipelineStates?
+    private var blobTexture: MTLTexture?
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        commonInit()
+    }
+
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        let ctx = MetalContext.shared
+        device = ctx.device
+        pixelFormat = .bgra8Unorm
+        framebufferOnly = false
+        isOpaque = false
+        backgroundColor = nil
+        contentsScale = UIScreen.main.scale
+
+        buildPipelines()
+    }
+
+    private func buildPipelines() {
+        let ctx = MetalContext.shared
+        let lib = ctx.library
+
+        guard let initFn = lib.makeFunction(name: "splashInitializeDroplet"),
+              let updateFn = lib.makeFunction(name: "splashUpdateDroplet"),
+              let vertexFn = lib.makeFunction(name: "splashVertex"),
+              let blobFragFn = lib.makeFunction(name: "splashBlobFragment"),
+              let compVertexFn = lib.makeFunction(name: "splashCompositeVertex"),
+              let compFragFn = lib.makeFunction(name: "splashCompositeFragment")
+        else { return }
+
+        guard let initPSO = try? ctx.device.makeComputePipelineState(function: initFn),
+              let updatePSO = try? ctx.device.makeComputePipelineState(function: updateFn)
+        else { return }
+
+        // Pass 1: blob accumulation — additive blend into float texture
+        let blobRPD = MTLRenderPipelineDescriptor()
+        blobRPD.vertexFunction = vertexFn
+        blobRPD.fragmentFunction = blobFragFn
+        blobRPD.colorAttachments[0].pixelFormat = .rgba16Float
+        blobRPD.colorAttachments[0].isBlendingEnabled = true
+        blobRPD.colorAttachments[0].rgbBlendOperation = .add
+        blobRPD.colorAttachments[0].alphaBlendOperation = .add
+        blobRPD.colorAttachments[0].sourceRGBBlendFactor = .one
+        blobRPD.colorAttachments[0].sourceAlphaBlendFactor = .one
+        blobRPD.colorAttachments[0].destinationRGBBlendFactor = .one
+        blobRPD.colorAttachments[0].destinationAlphaBlendFactor = .one
+
+        // Pass 2: metaball composite — alpha blend to drawable
+        let compRPD = MTLRenderPipelineDescriptor()
+        compRPD.vertexFunction = compVertexFn
+        compRPD.fragmentFunction = compFragFn
+        compRPD.colorAttachments[0].pixelFormat = .bgra8Unorm
+        compRPD.colorAttachments[0].isBlendingEnabled = true
+        compRPD.colorAttachments[0].rgbBlendOperation = .add
+        compRPD.colorAttachments[0].alphaBlendOperation = .add
+        compRPD.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+        compRPD.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+        compRPD.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+        compRPD.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+
+        guard let blobPSO = try? ctx.device.makeRenderPipelineState(descriptor: blobRPD),
+              let compPSO = try? ctx.device.makeRenderPipelineState(descriptor: compRPD)
+        else { return }
+
+        pipelineStates = PipelineStates(
+            initCompute: initPSO,
+            updateCompute: updatePSO,
+            blobRender: blobPSO,
+            compositeRender: compPSO
+        )
+    }
+
+    // MARK: - Public API
+
+    func addItem(frame: CGRect, image: UIImage) {
+        guard let item = Item(
+            frame: frame,
+            image: image,
+            device: MetalContext.shared.device
+        ) else { return }
+
+        items.append(item)
+        updateNeedsAnimation()
+    }
+
+    // MARK: - Animation Loop
+
+    private func updateNeedsAnimation() {
+        if !items.isEmpty {
+            if displayLinkToken == nil {
+                displayLinkToken = DisplayLinkDriver.shared.subscribe(rate: .max) { [weak self] dt in
+                    self?.tick(deltaTime: dt)
+                }
+            }
+        } else {
+            displayLinkToken?.invalidate()
+            displayLinkToken = nil
+        }
+    }
+
+    private func tick(deltaTime: CFTimeInterval) {
+        let dt = Float(min(max(deltaTime, 0.001), 0.05))
+
+        var didRemove = false
+        for i in (0..<items.count).reversed() {
+            items[i].phase += dt
+            if items[i].phase >= 1.2 {
+                items.remove(at: i)
+                didRemove = true
+            }
+        }
+
+        render(timeStep: dt)
+
+        if didRemove && items.isEmpty {
+            displayLinkToken?.invalidate()
+            displayLinkToken = nil
+            becameEmpty?()
+        }
+    }
+
+    // MARK: - Metal Rendering
+
+    private func render(timeStep: Float) {
+        guard let pipelineStates else { return }
+        guard let drawable = nextDrawable() else { return }
+
+        let ctx = MetalContext.shared
+        guard let commandBuffer = ctx.commandQueue.makeCommandBuffer() else { return }
+
+        let containerSize = bounds.size
+        guard containerSize.width > 0, containerSize.height > 0 else { return }
+
+        // Ensure offscreen blob texture matches drawable
+        let dw = Int(drawableSize.width)
+        let dh = Int(drawableSize.height)
+        if blobTexture?.width != dw || blobTexture?.height != dh {
+            let desc = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .rgba16Float, width: dw, height: dh, mipmapped: false
+            )
+            desc.usage = [.renderTarget, .shaderRead]
+            desc.storageMode = .private
+            blobTexture = ctx.device.makeTexture(descriptor: desc)
+        }
+        guard let blobTex = blobTexture else { return }
+
+        // --- Compute pass ---
+        if let computeEncoder = commandBuffer.makeComputeCommandEncoder() {
+            let threadgroupSize = MTLSize(width: 64, height: 1, depth: 1)
+
+            for item in items {
+                let threadgroupCount = MTLSize(
+                    width: (Int(item.dropletCount) + 63) / 64,
+                    height: 1,
+                    depth: 1
+                )
+
+                computeEncoder.setBuffer(item.dropletBuffer, offset: 0, index: 0)
+
+                if !item.isInitialized {
+                    item.isInitialized = true
+                    computeEncoder.setComputePipelineState(pipelineStates.initCompute)
+                    computeEncoder.setTexture(item.texture, index: 0)
+                    var itemSize = SIMD2<Float>(Float(item.frame.width), Float(item.frame.height))
+                    computeEncoder.setBytes(&itemSize, length: MemoryLayout<SIMD2<Float>>.size, index: 1)
+                    var count = item.dropletCount
+                    computeEncoder.setBytes(&count, length: MemoryLayout<UInt32>.size, index: 2)
+                    computeEncoder.dispatchThreadgroups(threadgroupCount, threadsPerThreadgroup: threadgroupSize)
+                }
+
+                computeEncoder.setComputePipelineState(pipelineStates.updateCompute)
+                var ts = timeStep
+                computeEncoder.setBytes(&ts, length: MemoryLayout<Float>.size, index: 1)
+                var count = item.dropletCount
+                computeEncoder.setBytes(&count, length: MemoryLayout<UInt32>.size, index: 2)
+                computeEncoder.dispatchThreadgroups(threadgroupCount, threadsPerThreadgroup: threadgroupSize)
+            }
+
+            computeEncoder.endEncoding()
+        }
+
+        // --- Pass 1: Blobs → offscreen float texture (additive) ---
+        let blobRPD = MTLRenderPassDescriptor()
+        blobRPD.colorAttachments[0].texture = blobTex
+        blobRPD.colorAttachments[0].loadAction = .clear
+        blobRPD.colorAttachments[0].storeAction = .store
+        blobRPD.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        if let blobEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: blobRPD) {
+            blobEncoder.setRenderPipelineState(pipelineStates.blobRender)
+
+            var container = SIMD2<Float>(Float(containerSize.width), Float(containerSize.height))
+            blobEncoder.setVertexBytes(&container, length: MemoryLayout<SIMD2<Float>>.size, index: 0)
+
+            for item in items {
+                var origin = SIMD2<Float>(Float(item.frame.origin.x), Float(item.frame.origin.y))
+                blobEncoder.setVertexBytes(&origin, length: MemoryLayout<SIMD2<Float>>.size, index: 1)
+
+                var size = SIMD2<Float>(Float(item.frame.width), Float(item.frame.height))
+                blobEncoder.setVertexBytes(&size, length: MemoryLayout<SIMD2<Float>>.size, index: 2)
+
+                blobEncoder.setVertexBuffer(item.dropletBuffer, offset: 0, index: 3)
+
+                blobEncoder.drawPrimitives(
+                    type: .triangle,
+                    vertexStart: 0,
+                    vertexCount: 6,
+                    instanceCount: Int(item.dropletCount)
+                )
+            }
+
+            blobEncoder.endEncoding()
+        }
+
+        // --- Pass 2: Metaball composite → drawable ---
+        let compRPD = MTLRenderPassDescriptor()
+        compRPD.colorAttachments[0].texture = drawable.texture
+        compRPD.colorAttachments[0].loadAction = .clear
+        compRPD.colorAttachments[0].storeAction = .store
+        compRPD.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        if let compEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: compRPD) {
+            compEncoder.setRenderPipelineState(pipelineStates.compositeRender)
+            compEncoder.setFragmentTexture(blobTex, index: 0)
+            compEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
+            compEncoder.endEncoding()
+        }
+
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+}

--- a/Zyna/Components/PaintSplash/PaintSplashShaders.metal
+++ b/Zyna/Components/PaintSplash/PaintSplashShaders.metal
@@ -1,0 +1,371 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#include <metal_stdlib>
+#include "loki_header.metal"
+
+using namespace metal;
+
+// MARK: - Data Structures
+
+struct Droplet {
+    packed_float2 position;     // relative to item frame origin, in points (Y-down)
+    packed_float2 velocity;     // px/s (Y-down = gravity positive)
+    packed_float4 color;        // RGB from bubble texture, A = per-droplet opacity
+    float         baseSize;     // radius in points
+    float         aspectRatio;  // Y/X scale (reserved for velocity stretching)
+    float         rotation;     // radians
+    float         lifetime;     // remaining seconds
+    uint          phase;        // 0=flying, 2=fading
+    float         dragFactor;   // deceleration rate
+    packed_float2 srcUV;        // source UV in bubble texture (for textured fragments)
+};
+
+// MARK: - Quad Geometry
+
+constant static float2 quadVertices[6] = {
+    float2(0.0, 0.0),
+    float2(1.0, 0.0),
+    float2(0.0, 1.0),
+    float2(1.0, 0.0),
+    float2(0.0, 1.0),
+    float2(1.0, 1.0)
+};
+
+struct VertexOut {
+    float4 position [[position]];
+    float2 uv;
+    float4 color;
+    float  alpha;
+    float2 srcUV;
+    float2 patchExtent;  // UV extent of this droplet's texture patch
+};
+
+// MARK: - Compute: Initialize Droplets
+
+kernel void splashInitializeDroplet(
+    device Droplet *droplets             [[buffer(0)]],
+    texture2d<float, access::sample> tex [[texture(0)]],
+    const device float2 &itemSize        [[buffer(1)]],
+    const device uint   &dropletCount    [[buffer(2)]],
+    uint gid                             [[thread_position_in_grid]]
+) {
+    if (gid >= dropletCount) return;
+
+    Loki rng = Loki(gid, 42, 137);
+
+    Droplet d;
+
+    // Gentle scaling: large bubbles get more droplets (Swift side) rather than bigger ones
+    float areaScale = pow(sqrt(itemSize.x * itemSize.y) / 90.0, 0.35);
+    areaScale = clamp(areaScale, 1.0, 1.6);
+
+    // Grid layout: distribute droplets to cover the entire bubble
+    uint cols = uint(ceil(sqrt(float(dropletCount) * itemSize.x / itemSize.y)));
+    uint rows = (dropletCount + cols - 1) / cols;
+
+    float cellW = itemSize.x / float(cols);
+    float cellH = itemSize.y / float(rows);
+
+    float posX, posY;
+
+    if (gid < rows * cols) {
+        uint col = gid % cols;
+        uint row = gid / cols;
+        float jitterX = (rng.rand() - 0.5) * cellW * 0.3;
+        float jitterY = (rng.rand() - 0.5) * cellH * 0.3;
+        posX = (float(col) + 0.5) * cellW + jitterX;
+        posY = (float(row) + 0.5) * cellH + jitterY;
+    } else {
+        posX = rng.rand() * itemSize.x;
+        posY = rng.rand() * itemSize.y;
+    }
+
+    posX = clamp(posX, 0.0, itemSize.x);
+    posY = clamp(posY, 0.0, itemSize.y);
+    d.position = packed_float2(posX, posY);
+
+    // Source UV for textured fragment rendering
+    float2 uv = float2(posX / itemSize.x, posY / itemSize.y);
+    d.srcUV = packed_float2(uv);
+
+    // Color: sample from bubble texture; alpha encodes per-droplet opacity variation
+    constexpr sampler s(coord::normalized, address::clamp_to_edge, filter::linear);
+    float4 sampledColor = tex.sample(s, uv);
+    float opacity = 0.4 + rng.rand() * 0.6;
+    d.color = packed_float4(float4(sampledColor.rgb, opacity));
+
+    // Size: more small droplets, fewer large ones
+    float baseGridSize = max(cellW, cellH);
+    float sizeRoll = rng.rand();
+    float sizeMul;
+    if (sizeRoll < 0.70) {
+        sizeMul = 0.4 + rng.rand() * 0.4;       // 70% small: 0.4–0.8×
+    } else if (sizeRoll < 0.92) {
+        sizeMul = 0.8 + rng.rand() * 0.7;       // 22% medium: 0.8–1.5×
+    } else {
+        sizeMul = 1.5 + rng.rand() * 1.5;       // 8% large: 1.5–3.0×
+    }
+    d.baseSize = max(baseGridSize * sizeMul * areaScale, 2.0);
+
+    // Velocity: outward from center
+    float2 center = itemSize * 0.5;
+    float2 toEdge = float2(posX, posY) - center;
+    float distFromCenter = length(toEdge);
+    float2 dir;
+    if (distFromCenter > 0.001) {
+        dir = toEdge / distFromCenter;
+    } else {
+        float a = rng.rand() * 6.28318530718;
+        dir = float2(cos(a), sin(a));
+    }
+
+    // Angular spread for natural scatter
+    float spread = (rng.rand() - 0.5) * 0.6;
+    float cs = cos(spread);
+    float sn = sin(spread);
+    dir = float2(dir.x * cs - dir.y * sn, dir.x * sn + dir.y * cs);
+
+    float bubbleDiag = sqrt(itemSize.x * itemSize.x + itemSize.y * itemSize.y);
+    float normalizedDist = distFromCenter / (bubbleDiag * 0.5);
+    float speed = bubbleDiag * (1.2 + rng.rand() * 1.5);
+    speed *= (0.7 + normalizedDist * 0.6);     // edge droplets slightly faster
+    speed /= max(d.baseSize / (baseGridSize * areaScale), 0.5);
+
+    d.velocity = packed_float2(dir.x * speed, dir.y * speed);
+
+    d.aspectRatio = 1.0;
+    d.rotation = rng.rand() * 6.28318530718;
+    d.lifetime = 0.5 + rng.rand() * 0.4;
+    d.phase = 0;
+    d.dragFactor = 5.0 / max(d.baseSize / (baseGridSize * areaScale), 1.0);
+
+    droplets[gid] = d;
+}
+
+// MARK: - Compute: Update Droplets
+
+kernel void splashUpdateDroplet(
+    device Droplet *droplets          [[buffer(0)]],
+    const device float  &timeStep     [[buffer(1)]],
+    const device uint   &dropletCount [[buffer(2)]],
+    uint gid                          [[thread_position_in_grid]]
+) {
+    if (gid >= dropletCount) return;
+
+    Droplet d = droplets[gid];
+
+    if (d.phase == 0) {
+        // Flying: apply physics
+        float2 vel = float2(d.velocity);
+        float2 pos = float2(d.position);
+
+        // Gravity (Y-down in UIKit; appears upward due to inverted table scroll)
+        vel.y += 800.0 * timeStep;
+
+        // Air drag (smaller particles decelerate faster)
+        float drag = 1.0 - d.dragFactor * timeStep;
+        drag = max(drag, 0.0);
+        vel *= drag;
+
+        pos += vel * timeStep;
+
+        d.velocity = packed_float2(vel);
+        d.position = packed_float2(pos);
+
+        d.lifetime -= timeStep;
+        if (d.lifetime <= 0.0) {
+            d.phase = 2;
+            d.lifetime = 0.15;
+        }
+    } else {
+        // Fading out
+        d.lifetime -= timeStep;
+        if (d.lifetime <= 0.0) {
+            d.position = packed_float2(-1000.0, -1000.0);
+            d.lifetime = -1.0;
+        }
+    }
+
+    droplets[gid] = d;
+}
+
+// MARK: - Noise Utilities
+
+float splashHash(float2 p) {
+    float3 p3 = fract(float3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+float splashNoise(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = splashHash(i);
+    float b = splashHash(i + float2(1.0, 0.0));
+    float c = splashHash(i + float2(0.0, 1.0));
+    float d = splashHash(i + float2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+// Inflate quads so gaussian blobs overlap and merge into metaballs
+constant float blobScale = 2.5;
+
+// MARK: - Vertex Shader
+
+vertex VertexOut splashVertex(
+    const device float2   &containerSize [[buffer(0)]],  // container bounds in points
+    const device float2   &itemOrigin    [[buffer(1)]],  // item frame origin (UIKit points)
+    const device float2   &itemSize      [[buffer(2)]],  // item frame size (UIKit points)
+    const device Droplet  *droplets      [[buffer(3)]],
+    unsigned int vid                      [[vertex_id]],
+    unsigned int iid                      [[instance_id]]
+) {
+    VertexOut out;
+
+    Droplet d = droplets[iid];
+
+    if (d.lifetime < -0.5) {
+        out.position = float4(-10.0, -10.0, 0.0, 1.0);
+        out.uv = float2(0.0);
+        out.color = float4(0.0);
+        out.alpha = 0.0;
+        out.srcUV = float2(0.0);
+        out.patchExtent = float2(0.0);
+        return out;
+    }
+
+    float2 quadVertex = quadVertices[vid];
+    out.uv = quadVertex;
+
+    // Droplet quad: inflated by blobScale for metaball overlap
+    float w = d.baseSize * blobScale;
+    float h = d.baseSize * d.aspectRatio * blobScale;
+
+    // Rotate quad around center
+    float cosR = cos(d.rotation);
+    float sinR = sin(d.rotation);
+
+    float2 local = (quadVertex - 0.5) * float2(w, h);
+    float2 rotated = float2(
+        local.x * cosR - local.y * sinR,
+        local.x * sinR + local.y * cosR
+    );
+
+    // Item-local position → screen position (UIKit coords, Y-down)
+    float2 screenPos = itemOrigin + float2(d.position) + rotated;
+
+    // UIKit → Metal NDC: X [0,w]→[-1,+1], Y [0,h]→[+1,-1] (flip Y)
+    float ndcX = screenPos.x / containerSize.x * 2.0 - 1.0;
+    float ndcY = 1.0 - screenPos.y / containerSize.y * 2.0;
+    out.position = float4(ndcX, ndcY, 0.0, 1.0);
+
+    out.color = float4(d.color);
+
+    // Texture mapping: source UV and patch extent for fragment sampling
+    out.srcUV = float2(d.srcUV);
+    out.patchExtent = float2(w, h) / itemSize;
+
+    // Alpha based on phase
+    if (d.phase == 2) {
+        out.alpha = max(0.0, d.lifetime / 0.15);
+    } else {
+        out.alpha = 1.0;
+    }
+
+    return out;
+}
+
+// MARK: - Pass 1: Blob Accumulation
+
+fragment half4 splashBlobFragment(VertexOut in [[stage_in]]) {
+    float2 centered = in.uv - 0.5;
+    float dist2 = dot(centered, centered) * 4.0;
+
+    // Gaussian falloff — soft enough for smooth merging
+    float energy = exp(-dist2 * 5.0);
+    if (energy < 0.001) discard_fragment();
+
+    // Output: energy-weighted color (RGB * e) and raw energy (A)
+    // color.a carries per-droplet opacity variation from init
+    half e = half(energy * in.alpha * in.color.a);
+    return half4(half3(in.color.rgb) * e, e);
+}
+
+// MARK: - Pass 2: Metaball Composite
+
+struct CompositeVertexOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+vertex CompositeVertexOut splashCompositeVertex(uint vid [[vertex_id]]) {
+    float2 positions[6] = {
+        float2(-1.0, -1.0), float2(1.0, -1.0), float2(-1.0, 1.0),
+        float2(1.0, -1.0), float2(-1.0, 1.0), float2(1.0, 1.0)
+    };
+    float2 uvs[6] = {
+        float2(0.0, 1.0), float2(1.0, 1.0), float2(0.0, 0.0),
+        float2(1.0, 1.0), float2(0.0, 0.0), float2(1.0, 0.0)
+    };
+
+    CompositeVertexOut out;
+    out.position = float4(positions[vid], 0.0, 1.0);
+    out.uv = uvs[vid];
+    return out;
+}
+
+fragment half4 splashCompositeFragment(
+    CompositeVertexOut in [[stage_in]],
+    texture2d<float> blobTex [[texture(0)]]
+) {
+    constexpr sampler s(coord::normalized, filter::linear);
+    float4 blob = blobTex.sample(s, in.uv);
+
+    float energy = blob.a;
+    if (energy < 0.05) discard_fragment();
+
+    // Multi-scale noise for organic edge deformation
+    float2 pixelCoord = in.uv * float2(blobTex.get_width(), blobTex.get_height());
+    float n = splashNoise(pixelCoord * 0.04) * 0.06
+            + splashNoise(pixelCoord * 0.12) * 0.04;
+
+    // Metaball threshold with noisy boundary
+    float threshold = 0.4;
+    float edge = smoothstep(threshold - 0.06 + n, threshold + 0.02 + n, energy);
+    if (edge < 0.01) discard_fragment();
+
+    // Reconstruct color from energy-weighted accumulation
+    float3 baseColor = blob.rgb / max(energy, 0.001);
+
+    // Gradient-based pseudo-normal from energy field
+    float2 texelSize = 1.0 / float2(blobTex.get_width(), blobTex.get_height());
+    float eL = blobTex.sample(s, in.uv + float2(-texelSize.x, 0.0)).a;
+    float eR = blobTex.sample(s, in.uv + float2( texelSize.x, 0.0)).a;
+    float eU = blobTex.sample(s, in.uv + float2(0.0, -texelSize.y)).a;
+    float eD = blobTex.sample(s, in.uv + float2(0.0,  texelSize.y)).a;
+
+    float3 normal = normalize(float3((eL - eR) * 2.0, (eU - eD) * 2.0, 0.15));
+
+    // Blinn-Phong lighting — top-right light source
+    float3 lightDir = normalize(float3(0.3, -0.5, 1.0));
+    float diffuse = max(dot(normal, lightDir), 0.0) * 0.2 + 0.8;
+    float3 halfVec = normalize(lightDir + float3(0.0, 0.0, 1.0));
+    float spec = pow(max(dot(normal, halfVec), 0.0), 32.0);
+
+    float3 finalColor = baseColor * diffuse + spec * 0.3;
+
+    // Edge darkening for volume
+    float depth = smoothstep(threshold, threshold + 0.3, energy);
+    finalColor *= 0.88 + 0.12 * depth;
+
+    // Thin areas (low energy) are more transparent — liquid feel
+    float alphaFromEnergy = smoothstep(threshold, threshold + 0.4, energy);
+    float alphaNoise = splashNoise(pixelCoord * 0.06) * 0.15;
+    float finalAlpha = edge * (0.65 + 0.35 * alphaFromEnergy + alphaNoise);
+
+    return half4(half3(finalColor), half(finalAlpha));
+}

--- a/Zyna/Components/PaintSplash/PaintSplashTrigger.swift
+++ b/Zyna/Components/PaintSplash/PaintSplashTrigger.swift
@@ -1,0 +1,92 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+import AsyncDisplayKit
+
+enum PaintSplashTrigger {
+
+    private static weak var activeSplashLayer: PaintSplashLayer?
+
+    static func trigger(
+        in tableNode: ASTableNode,
+        at indexPath: IndexPath,
+        completion: @escaping () -> Void
+    ) {
+        guard let cellNode = tableNode.nodeForRow(at: indexPath) as? MessageCellNode,
+              cellNode.isNodeLoaded
+        else {
+            completion()
+            return
+        }
+
+        let bubbleView = cellNode.bubbleNode.view
+
+        guard bubbleView.bounds.width > 0, bubbleView.bounds.height > 0 else {
+            completion()
+            return
+        }
+
+        // Snapshot the bubble via layer rendering (immune to compositing race)
+        let image = UIGraphicsImageRenderer(bounds: bubbleView.bounds).image { ctx in
+            bubbleView.layer.render(in: ctx.cgContext)
+        }
+
+        guard image.cgImage != nil else {
+            completion()
+            return
+        }
+
+        // Bubble frame in visible table coordinates (subtract contentOffset)
+        let contentFrame = bubbleView.convert(bubbleView.bounds, to: tableNode.view)
+        let contentOffset = tableNode.view.contentOffset
+        let bubbleFrame = contentFrame.offsetBy(dx: -contentOffset.x, dy: -contentOffset.y)
+
+        // Phase 1: Anticipation — squash the bubble
+        UIView.animate(
+            withDuration: 0.08,
+            delay: 0,
+            options: .curveEaseIn,
+            animations: {
+                bubbleView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            },
+            completion: { _ in
+                // Phase 2: Burst — hide cell and start Metal animation
+                cellNode.alpha = 0
+
+                let splashLayer: PaintSplashLayer
+                if let existing = activeSplashLayer {
+                    splashLayer = existing
+                } else {
+                    splashLayer = PaintSplashLayer()
+                    splashLayer.frame = tableNode.view.bounds
+                    splashLayer.zPosition = 10
+                    tableNode.view.layer.addSublayer(splashLayer)
+                    activeSplashLayer = splashLayer
+                }
+
+                splashLayer.frame = tableNode.view.bounds
+                splashLayer.drawableSize = CGSize(
+                    width: tableNode.view.bounds.width * UIScreen.main.scale,
+                    height: tableNode.view.bounds.height * UIScreen.main.scale
+                )
+
+                splashLayer.addItem(
+                    frame: bubbleFrame,
+                    image: image
+                )
+
+                // Layer self-cleans when all droplets are done
+                splashLayer.becameEmpty = { [weak splashLayer] in
+                    splashLayer?.removeFromSuperlayer()
+                    activeSplashLayer = nil
+                }
+
+                // Collapse the gap immediately
+                completion()
+            }
+        )
+    }
+}

--- a/Zyna/Components/PaintSplash/loki.metal
+++ b/Zyna/Components/PaintSplash/loki.metal
@@ -1,0 +1,53 @@
+#include <metal_stdlib>
+#include "loki_header.metal"
+
+unsigned Loki::TausStep(const unsigned z, const int s1, const int s2, const int s3, const unsigned M)
+{
+    unsigned b=(((z << s1) ^ z) >> s2);
+    return (((z & M) << s3) ^ b);
+}
+
+thread Loki::Loki(const unsigned seed1, const unsigned seed2, const unsigned seed3) {
+    unsigned seed = seed1 * 1099087573UL;
+    unsigned seedb = seed2 * 1099087573UL;
+    unsigned seedc = seed3 * 1099087573UL;
+
+    // Round 1: Randomise seed
+    unsigned z1 = TausStep(seed,13,19,12,429496729UL);
+    unsigned z2 = TausStep(seed,2,25,4,4294967288UL);
+    unsigned z3 = TausStep(seed,3,11,17,429496280UL);
+    unsigned z4 = (1664525*seed + 1013904223UL);
+
+    // Round 2: Randomise seed again using second seed
+    unsigned r1 = (z1^z2^z3^z4^seedb);
+
+    z1 = TausStep(r1,13,19,12,429496729UL);
+    z2 = TausStep(r1,2,25,4,4294967288UL);
+    z3 = TausStep(r1,3,11,17,429496280UL);
+    z4 = (1664525*r1 + 1013904223UL);
+
+    // Round 3: Randomise seed again using third seed
+    r1 = (z1^z2^z3^z4^seedc);
+
+    z1 = TausStep(r1,13,19,12,429496729UL);
+    z2 = TausStep(r1,2,25,4,4294967288UL);
+    z3 = TausStep(r1,3,11,17,429496280UL);
+    z4 = (1664525*r1 + 1013904223UL);
+
+    this->seed = (z1^z2^z3^z4) * 2.3283064365387e-10;
+}
+
+thread float Loki::rand() {
+    unsigned hashed_seed = this->seed * 1099087573UL;
+
+    unsigned z1 = TausStep(hashed_seed,13,19,12,429496729UL);
+    unsigned z2 = TausStep(hashed_seed,2,25,4,4294967288UL);
+    unsigned z3 = TausStep(hashed_seed,3,11,17,429496280UL);
+    unsigned z4 = (1664525*hashed_seed + 1013904223UL);
+
+    thread float old_seed = this->seed;
+
+    this->seed = (z1^z2^z3^z4) * 2.3283064365387e-10;
+
+    return old_seed;
+}

--- a/Zyna/Components/PaintSplash/loki_header.metal
+++ b/Zyna/Components/PaintSplash/loki_header.metal
@@ -1,0 +1,44 @@
+/*
+ * Loki Random Number Generator
+ * Copyright (c) 2017 Youssef Victor All rights reserved.
+ *
+ *      Function                        Result
+ *      ------------------------------------------------------------------
+ *
+ *      TausStep                        Combined Tausworthe Generator or
+ *                                      Linear Feedback Shift Register (LFSR)
+ *                                      random number generator. This is a
+ *                                      helper method for rng, which uses
+ *                                      a hybrid approach combining LFSR with
+ *                                      a Linear Congruential Generator (LCG)
+ *                                      in order to produce random numbers with
+ *                                      periods of well over 2^121
+ *
+ *      rand                            A pseudo-random number based on the
+ *                                      method outlined in "Efficient
+ *                                      pseudo-random number generation
+ *                                      for monte-carlo simulations using
+ *                                      graphic processors" by Siddhant
+ *                                      Mohanty et al 2012.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+#ifndef LOKI
+#define LOKI
+
+
+class Loki {
+private:
+    thread float seed;
+    unsigned TausStep(const unsigned z, const int s1, const int s2, const int s3, const unsigned M);
+
+public:
+    thread Loki(const unsigned seed1, const unsigned seed2 = 1, const unsigned seed3 = 1);
+
+    thread float rand();
+};
+
+#endif

--- a/Zyna/Core/Metal/MetalContext.swift
+++ b/Zyna/Core/Metal/MetalContext.swift
@@ -38,4 +38,3 @@ final class MetalContext {
         self.library = library
     }
 }
-

--- a/Zyna/Core/Metal/MetalContext.swift
+++ b/Zyna/Core/Metal/MetalContext.swift
@@ -1,0 +1,41 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Metal
+import CoreImage
+
+final class MetalContext {
+    static let shared = MetalContext()
+
+    let device: MTLDevice
+    let commandQueue: MTLCommandQueue
+    let library: MTLLibrary
+
+    /// Shared CIContext for GPU-accelerated Core Image operations
+    lazy var ciContext: CIContext = {
+        CIContext(mtlDevice: device, options: [
+            .workingColorSpace: CGColorSpaceCreateDeviceRGB(),
+            .cacheIntermediates: false
+        ])
+    }()
+
+    private init() {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            fatalError("Metal is not supported on this device")
+        }
+        self.device = device
+
+        guard let queue = device.makeCommandQueue() else {
+            fatalError("Failed to create Metal command queue")
+        }
+        self.commandQueue = queue
+
+        guard let library = device.makeDefaultLibrary() else {
+            fatalError("Failed to create Metal default library")
+        }
+        self.library = library
+    }
+}
+

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -197,7 +197,7 @@ final class ZynaRoomListService: NSObject {
         case .poll(let question, _, _, _, _, _, _):
             text = "Poll: \(question)"
         case .redacted:
-            text = "Message deleted"
+            text = "..последнее сообщение удалено.."
         case .unableToDecrypt:
             text = "Encrypted message"
         }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -167,7 +167,7 @@ final class TimelineService {
         case .poll:
             return .unsupported(typeName: "poll")
         case .redacted:
-            return .text(body: "Message deleted")
+            return .redacted
         case .unableToDecrypt:
             return .text(body: "Encrypted message")
         }
@@ -251,6 +251,12 @@ final class TimelineService {
         } catch {
             timelineLog("Voice send failed: \(error)")
         }
+    }
+
+    func redactEvent(_ itemId: ChatItemIdentifier, reason: String? = nil) async throws {
+        guard let timeline else { return }
+        try await timeline.redactEvent(eventOrTransactionId: itemId.toSDK(), reason: reason)
+        timelineLog("Redacted event \(itemId)")
     }
 
     func toggleReaction(_ key: String, to itemId: ChatItemIdentifier) async {


### PR DESCRIPTION
## Summary
- Metal-based metaball paint splash animation for message deletion
- MetalContext singleton for shared GPU resources (device, command queue, shader library)
- Server-side Matrix redaction via reactive flow: redact request → SDK diff → splash animation → message removed
- Redacted messages filtered from timeline (historical)
- Context menu race condition handled: redaction deferred while bubble is reparented to menu overlay

## Technical details
- Two-pass Metal rendering: blob accumulation + metaball composite
- Loki noise for organic droplet variation
- TimelineCoalescer hiddenIds for post-animation removal
- Paint splash plays identically for own, remote, and moderator deletions

https://github.com/user-attachments/assets/88aae05b-7ee6-4652-a0ae-e518c3ec098c

