### PR TITLE
 Stage 7: Image sending, chat creation, voice UX, OIDC registration

### DIFF
--- a/Zyna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Zyna.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/matrix-org/matrix-rust-components-swift",
       "state" : {
-        "revision" : "25f075020019e3086605007658a87d183ab0e837",
-        "version" : "25.7.2"
+        "revision" : "081c8b433e7df1c4690fb5d2a3fa505a2f21fd97",
+        "version" : "25.11.11"
       }
     },
     {

--- a/Zyna/App/Info.plist
+++ b/Zyna/App/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zyna</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.markovsdima.Zyna.oidc</string>
+		</dict>
+	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -5,6 +5,8 @@
 
 import AsyncDisplayKit
 import Combine
+import PhotosUI
+import UniformTypeIdentifiers
 
 final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource, ASTableDelegate {
 
@@ -18,6 +20,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let audioPlayer = AudioPlayerService()
     private var activeContextMenu: ContextMenuController?
     private var pendingRedactedIds: [String] = []
+    private var isPickerPresented = false
     private var interactionLocks = Set<String>()
     private lazy var fpsBooster = ScrollFPSBooster(hostView: node.tableNode.view)
 
@@ -150,9 +153,11 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
 
         inputAccessory.inputNode.onVoiceRecordingFinished = { [weak self] fileURL, duration, waveform in
-            // Convert Float waveform (0...1) to UInt16 (0...1024) for Matrix SDK
-            let sdkWaveform = waveform.map { UInt16(min(max($0, 0), 1) * 1024) }
-            self?.viewModel.sendVoiceMessage(fileURL: fileURL, duration: duration, waveform: sdkWaveform)
+            self?.viewModel.sendVoiceMessage(fileURL: fileURL, duration: duration, waveform: waveform)
+        }
+
+        inputAccessory.inputNode.onAttachTapped = { [weak self] in
+            self?.presentPhotoPicker()
         }
     }
 
@@ -173,6 +178,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     @objc private func keyboardWillChangeFrame(_ note: Notification) {
         guard !isMovingFromParent,
+              !isPickerPresented,
               navigationController?.transitionCoordinator == nil,
               let endFrame = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
         // How much of the screen the keyboard (+ accessory) covers
@@ -376,5 +382,61 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             return nil
         }
         return IndexPath(row: row, section: 0)
+    }
+
+    // MARK: - Photo Picker
+
+    private func presentPhotoPicker() {
+        isPickerPresented = true
+        var config = PHPickerConfiguration()
+        config.selectionLimit = 10
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+}
+
+// MARK: - PHPickerViewControllerDelegate
+
+extension ChatViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true) { [weak self] in
+            guard let self else { return }
+            self.isPickerPresented = false
+            self.becomeFirstResponder()
+        }
+        guard !results.isEmpty else { return }
+
+        let captionText = inputAccessory.inputNode.textInputNode.textView.text?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let caption = (captionText?.isEmpty == false) ? captionText : nil
+        if caption != nil {
+            inputAccessory.inputNode.textInputNode.textView.text = ""
+        }
+
+        Task {
+            var processed: [ProcessedImage] = []
+            for result in results {
+                guard let data = await loadImageData(from: result) else { continue }
+                if let image = try? await MediaPreprocessor.processImage(from: data) {
+                    processed.append(image)
+                }
+            }
+            guard !processed.isEmpty else { return }
+            await MainActor.run {
+                viewModel.sendImages(processed, caption: caption)
+            }
+        }
+    }
+
+    private func loadImageData(from result: PHPickerResult) async -> Data? {
+        await withCheckedContinuation { continuation in
+            result.itemProvider.loadDataRepresentation(
+                forTypeIdentifier: UTType.image.identifier
+            ) { data, _ in
+                continuation.resume(returning: data)
+            }
+        }
     }
 }

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -101,10 +101,22 @@ final class ChatViewModel {
         }
     }
 
-    func sendVoiceMessage(fileURL: URL, duration: TimeInterval, waveform: [UInt16]) {
+    func sendVoiceMessage(fileURL: URL, duration: TimeInterval, waveform: [Float]) {
         Task {
             await timelineService.sendVoiceMessage(url: fileURL, duration: duration, waveform: waveform)
             try? FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
+    func sendImages(_ images: [ProcessedImage], caption: String?) {
+        for (i, image) in images.enumerated() {
+            let cap = (i == 0) ? caption : nil
+            Task {
+                await timelineService.sendImage(
+                    imageData: image.imageData,
+                    width: image.width, height: image.height, caption: cap
+                )
+            }
         }
     }
 

--- a/Zyna/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Chat/Nodes/ChatInputNode.swift
@@ -30,6 +30,7 @@ final class ChatInputNode: ASDisplayNode {
 
     var onSend: ((String) -> Void)?
     var onVoiceRecordingFinished: ((URL, TimeInterval, [Float]) -> Void)?
+    var onAttachTapped: (() -> Void)?
     var onSizeChanged: (() -> Void)?
 
     override init() {
@@ -96,6 +97,7 @@ final class ChatInputNode: ASDisplayNode {
         textInputNode.view.layer.cornerRadius = 18
         textInputNode.view.clipsToBounds = true
         sendButtonNode.addTarget(self, action: #selector(sendTapped), forControlEvents: .touchUpInside)
+        attachButtonNode.addTarget(self, action: #selector(attachTapped), forControlEvents: .touchUpInside)
 
         // Long press on parent view — ASButtonNode swallows touches,
         // so we track mic hit in the gesture handler instead.
@@ -311,6 +313,10 @@ final class ChatInputNode: ASDisplayNode {
     }
 
     // MARK: - Actions
+
+    @objc private func attachTapped() {
+        onAttachTapped?()
+    }
 
     @objc private func sendTapped() {
         let text = textInputNode.textView.text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Zyna/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Chat/Nodes/ChatInputNode.swift
@@ -56,24 +56,15 @@ final class ChatInputNode: ASDisplayNode {
 
         textInputNode.backgroundColor = .secondarySystemBackground
 
-        attachButtonNode.setImage(
-            Self.renderSymbol("paperclip", pointSize: 22, color: .gray),
-            for: .normal
-        )
+        attachButtonNode.setImage(AppIcon.attach.rendered(size: 22, color: .gray), for: .normal)
         attachButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
         // Send button
-        sendButtonNode.setImage(
-            Self.renderSymbol("arrow.up.circle.fill", pointSize: 22, weight: .semibold, color: .systemBlue),
-            for: .normal
-        )
+        sendButtonNode.setImage(AppIcon.send.rendered(size: 22, weight: .semibold, color: .systemBlue), for: .normal)
         sendButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
         // Mic button
-        micButtonNode.setImage(
-            Self.renderSymbol("mic.fill", pointSize: 22, color: .gray),
-            for: .normal
-        )
+        micButtonNode.setImage(AppIcon.mic.rendered(size: 22, color: .gray), for: .normal)
         micButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
         // Overlay is hidden by default
@@ -284,23 +275,6 @@ final class ChatInputNode: ASDisplayNode {
     private var currentWaveform: [Float] {
         if case .recording(_, let w) = recorder.state { return w }
         return []
-    }
-
-    // MARK: - Helpers
-
-    private static func renderSymbol(
-        _ name: String,
-        pointSize: CGFloat,
-        weight: UIImage.SymbolWeight = .regular,
-        color: UIColor
-    ) -> UIImage? {
-        let config = UIImage.SymbolConfiguration(pointSize: pointSize, weight: weight)
-        guard let symbol = UIImage(systemName: name, withConfiguration: config) else { return nil }
-        let renderer = UIGraphicsImageRenderer(size: symbol.size)
-        return renderer.image { _ in
-            color.setFill()
-            symbol.withRenderingMode(.alwaysTemplate).draw(at: .zero)
-        }
     }
 
     // MARK: - Actions

--- a/Zyna/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Chat/Nodes/ChatInputNode.swift
@@ -15,13 +15,21 @@ final class ChatInputNode: ASDisplayNode {
     private let separatorNode = ASDisplayNode()
 
     private let overlayNode = VoiceRecordingOverlayNode()
+    private let previewNode = VoicePreviewNode()
     private let recorder = AudioRecorderService()
+    private let previewPlayer = AudioPlayerService()
     private var cancellables = Set<AnyCancellable>()
 
     private var isTextEmpty: Bool = true
     private var isRecording: Bool = false
+    private var voicePreview: VoicePreviewData?
     private var gestureState: VoiceRecordingGestureState = .idle
     private var gestureStartPoint: CGPoint = .zero
+
+    /// Saved mic button center in self coordinates (before layout switch hides it)
+    private var micCenter: CGPoint = .zero
+    private var pulseView: UIView?
+    private var lockView: LockIndicatorView?
 
     /// Thresholds for gesture recognition
     private let cancelSlideDistance: CGFloat = 120
@@ -53,30 +61,22 @@ final class ChatInputNode: ASDisplayNode {
         textInputNode.style.minHeight = ASDimension(unit: .points, value: 36)
         textInputNode.style.maxHeight = ASDimension(unit: .points, value: 120)
         textInputNode.scrollEnabled = true
-
         textInputNode.backgroundColor = .secondarySystemBackground
 
         attachButtonNode.setImage(AppIcon.attach.rendered(size: 22, color: .gray), for: .normal)
         attachButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
-        // Send button
         sendButtonNode.setImage(AppIcon.send.rendered(size: 22, weight: .semibold, color: .systemBlue), for: .normal)
         sendButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
-        // Mic button
         micButtonNode.setImage(AppIcon.mic.rendered(size: 22, color: .gray), for: .normal)
         micButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
-        // Overlay is hidden by default
         overlayNode.alpha = 0
         overlayNode.isUserInteractionEnabled = false
 
-        overlayNode.onStop = { [weak self] in
-            self?.finishRecording()
-        }
-        overlayNode.onCancel = { [weak self] in
-            self?.cancelRecording()
-        }
+        overlayNode.onStop = { [weak self] in self?.finishRecording() }
+        overlayNode.onCancel = { [weak self] in self?.cancelRecording() }
     }
 
     // MARK: - didLoad
@@ -90,7 +90,6 @@ final class ChatInputNode: ASDisplayNode {
         sendButtonNode.addTarget(self, action: #selector(sendTapped), forControlEvents: .touchUpInside)
         attachButtonNode.addTarget(self, action: #selector(attachTapped), forControlEvents: .touchUpInside)
 
-        // Long press for mic — only recognized near the mic button
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleMicGesture(_:)))
         longPress.minimumPressDuration = 0.05
         longPress.allowableMovement = 20
@@ -101,6 +100,9 @@ final class ChatInputNode: ASDisplayNode {
     // MARK: - Layout
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        if voicePreview != nil {
+            return previewLayout(constrainedSize)
+        }
         if isRecording {
             return recordingLayout(constrainedSize)
         }
@@ -108,30 +110,19 @@ final class ChatInputNode: ASDisplayNode {
     }
 
     private func normalLayout(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        // Buttons pinned to bottom (when text field expands to multiple lines)
         let attachSpec = ASStackLayoutSpec(
-            direction: .vertical,
-            spacing: 0,
-            justifyContent: .end,
-            alignItems: .center,
+            direction: .vertical, spacing: 0, justifyContent: .end, alignItems: .center,
             children: [attachButtonNode]
         )
 
         let rightButton = isTextEmpty ? micButtonNode : sendButtonNode
         let rightSpec = ASStackLayoutSpec(
-            direction: .vertical,
-            spacing: 0,
-            justifyContent: .end,
-            alignItems: .center,
+            direction: .vertical, spacing: 0, justifyContent: .end, alignItems: .center,
             children: [rightButton]
         )
 
-        // Horizontal stack: [attach] [input] [send/mic]
         let inputRow = ASStackLayoutSpec(
-            direction: .horizontal,
-            spacing: 8,
-            justifyContent: .start,
-            alignItems: .end,
+            direction: .horizontal, spacing: 8, justifyContent: .start, alignItems: .end,
             children: [attachSpec, textInputNode, rightSpec]
         )
 
@@ -140,10 +131,8 @@ final class ChatInputNode: ASDisplayNode {
             child: inputRow
         )
 
-        // Separator + input row
         let fullStack = ASStackLayoutSpec.vertical()
         fullStack.children = [separatorNode, paddedRow]
-
         return fullStack
     }
 
@@ -157,7 +146,19 @@ final class ChatInputNode: ASDisplayNode {
 
         let fullStack = ASStackLayoutSpec.vertical()
         fullStack.children = [separatorNode, paddedOverlay]
+        return fullStack
+    }
 
+    private func previewLayout(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        previewNode.style.height = ASDimension(unit: .points, value: 48)
+
+        let paddedPreview = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 6, left: 0, bottom: 6, right: 0),
+            child: previewNode
+        )
+
+        let fullStack = ASStackLayoutSpec.vertical()
+        fullStack.children = [separatorNode, paddedPreview]
         return fullStack
     }
 
@@ -166,8 +167,14 @@ final class ChatInputNode: ASDisplayNode {
     private func bindRecorder() {
         recorder.$state
             .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in self?.handleRecorderState(state) }
+            .store(in: &cancellables)
+
+        previewPlayer.$state
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
-                self?.handleRecorderState(state)
+                guard self?.voicePreview != nil else { return }
+                self?.previewNode.updatePlayState(state.isPlaying)
             }
             .store(in: &cancellables)
     }
@@ -179,12 +186,16 @@ final class ChatInputNode: ASDisplayNode {
         case .recording(let duration, let waveform):
             overlayNode.update(state: gestureState, duration: duration, waveform: waveform)
         case .finished(let fileURL, let duration, let waveform):
-            onVoiceRecordingFinished?(fileURL, duration, waveform)
-            hideOverlay()
+            if gestureState == .locked {
+                showVoicePreview(VoicePreviewData(fileURL: fileURL, duration: duration, waveform: waveform))
+            } else {
+                onVoiceRecordingFinished?(fileURL, duration, waveform)
+                hideRecording()
+            }
         case .cancelled:
-            hideOverlay()
+            hideRecording()
         case .error:
-            hideOverlay()
+            hideRecording()
         }
     }
 
@@ -196,13 +207,21 @@ final class ChatInputNode: ASDisplayNode {
             let point = gesture.location(in: view)
             gestureStartPoint = point
             gestureState = .holding
-            showOverlay()
+            // Save mic center before layout switch
+            micCenter = CGPoint(
+                x: micButtonNode.view.frame.midX,
+                y: micButtonNode.view.frame.midY
+            )
+            showRecording()
             recorder.startRecording()
 
         case .changed:
             let point = gesture.location(in: view)
-            let dx = gestureStartPoint.x - point.x  // positive = left
-            let dy = gestureStartPoint.y - point.y   // positive = up
+            let dx = gestureStartPoint.x - point.x
+            let dy = gestureStartPoint.y - point.y
+
+            // Pulse follows finger upward
+            if dy > 0 { updatePulsePosition(dy: dy) }
 
             if gestureState == .locked { return }
 
@@ -210,11 +229,20 @@ final class ChatInputNode: ASDisplayNode {
                 gestureState = .locked
                 overlayNode.isUserInteractionEnabled = true
                 overlayNode.update(state: .locked, duration: currentDuration, waveform: currentWaveform)
+                lockView?.snapAndDismiss { }
+                lockView = nil
+                dismissPulse()
                 setNeedsLayout()
+            } else if dy > slideDeadZone {
+                let progress = dy / lockSlideDistance
+                lockView?.updateProgress(progress)
+                positionLockView(dy: dy)
             } else if dx > slideDeadZone {
                 let effectiveDx = dx - slideDeadZone
                 let progress = min(1, effectiveDx / cancelSlideDistance)
                 gestureState = .slidingToCancel(progress)
+                lockView?.dismiss()
+                lockView = nil
 
                 if progress >= 1 {
                     gestureState = .cancelled
@@ -239,21 +267,141 @@ final class ChatInputNode: ASDisplayNode {
         }
     }
 
-    // MARK: - Recording Control
+    // MARK: - Recording State
 
-    private func showOverlay() {
+    private func showRecording() {
         isRecording = true
         overlayNode.alpha = 1
         overlayNode.isUserInteractionEnabled = false
         setNeedsLayout()
         onSizeChanged?()
+        showPulse()
+        showLock()
     }
 
-    private func hideOverlay() {
+    private func hideRecording() {
         isRecording = false
         gestureState = .idle
         overlayNode.alpha = 0
         overlayNode.isUserInteractionEnabled = false
+        dismissPulse()
+        lockView?.dismiss()
+        lockView = nil
+        setNeedsLayout()
+        onSizeChanged?()
+    }
+
+    // MARK: - Pulse (UIView — per-frame position tracking)
+
+    private func showPulse() {
+        let size: CGFloat = 64
+        let pulse = UIView(frame: CGRect(
+            x: micCenter.x - size / 2,
+            y: micCenter.y - size / 2,
+            width: size, height: size
+        ))
+        pulse.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.25)
+        pulse.layer.cornerRadius = size / 2
+        pulse.alpha = 0
+        view.addSubview(pulse)
+        pulseView = pulse
+
+        UIView.animate(withDuration: 0.15) { pulse.alpha = 1 }
+
+        let anim = CABasicAnimation(keyPath: "transform.scale")
+        anim.fromValue = 1.0
+        anim.toValue = 1.4
+        anim.duration = 0.8
+        anim.autoreverses = true
+        anim.repeatCount = .infinity
+        pulse.layer.add(anim, forKey: "pulse")
+    }
+
+    private func updatePulsePosition(dy: CGFloat) {
+        pulseView?.center = CGPoint(x: micCenter.x, y: micCenter.y - dy)
+    }
+
+    private func dismissPulse() {
+        guard let pulse = pulseView else { return }
+        pulse.layer.removeAllAnimations()
+        UIView.animate(withDuration: 0.15, animations: { pulse.alpha = 0 }) { _ in
+            pulse.removeFromSuperview()
+        }
+        pulseView = nil
+    }
+
+    // MARK: - Lock Indicator (UIView — per-frame position tracking)
+
+    private func showLock() {
+        let lock = LockIndicatorView()
+        let lockSize = CGSize(width: 40, height: 80)
+        lock.frame = CGRect(
+            x: micCenter.x - lockSize.width / 2,
+            y: micCenter.y - lockSize.height - 24,
+            width: lockSize.width,
+            height: lockSize.height
+        )
+        view.addSubview(lock)
+        lock.show()
+        lockView = lock
+    }
+
+    private func positionLockView(dy: CGFloat) {
+        guard let lock = lockView else { return }
+        let lockSize = CGSize(width: 40, height: 80)
+        lock.frame.origin = CGPoint(
+            x: micCenter.x - lockSize.width / 2,
+            y: micCenter.y - lockSize.height - 24 - dy
+        )
+    }
+
+    // MARK: - Voice Preview
+
+    private func showVoicePreview(_ data: VoicePreviewData) {
+        voicePreview = data
+        isRecording = false
+        overlayNode.alpha = 0
+        overlayNode.isUserInteractionEnabled = false
+        gestureState = .idle
+        dismissPulse()
+        lockView?.dismiss()
+        lockView = nil
+
+        previewNode.configure(with: data)
+        previewNode.onPlay = { [weak self] in
+            guard let url = self?.voicePreview?.fileURL else { return }
+            self?.previewPlayer.playLocal(url: url)
+        }
+        previewNode.onPause = { [weak self] in
+            self?.previewPlayer.pause()
+        }
+        previewNode.onDelete = { [weak self] in
+            self?.discardVoicePreview()
+        }
+        previewNode.onSend = { [weak self] in
+            self?.sendVoicePreview()
+        }
+
+        setNeedsLayout()
+        onSizeChanged?()
+    }
+
+    private func discardVoicePreview() {
+        previewPlayer.stop()
+        if let url = voicePreview?.fileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        voicePreview = nil
+        setNeedsLayout()
+        onSizeChanged?()
+    }
+
+    private func sendVoicePreview() {
+        previewPlayer.stop()
+        if let data = voicePreview {
+            onVoiceRecordingFinished?(data.fileURL, data.duration, data.waveform)
+        }
+        voicePreview = nil
         setNeedsLayout()
         onSizeChanged?()
     }
@@ -266,7 +414,6 @@ final class ChatInputNode: ASDisplayNode {
         recorder.cancelRecording()
     }
 
-    /// Convenience accessors for current recorder state
     private var currentDuration: TimeInterval {
         if case .recording(let d, _) = recorder.state { return d }
         return 0
@@ -308,7 +455,7 @@ final class ChatInputNode: ASDisplayNode {
 
 extension ChatInputNode: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard isTextEmpty else { return false }
+        guard isTextEmpty, !isRecording, voicePreview == nil else { return false }
         let point = touch.location(in: view)
         let micFrame = micButtonNode.view.frame.insetBy(dx: -20, dy: -20)
         let micFrameInSelf = view.convert(micFrame, from: micButtonNode.supernode?.view ?? view)

--- a/Zyna/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Chat/Nodes/ChatInputNode.swift
@@ -99,11 +99,11 @@ final class ChatInputNode: ASDisplayNode {
         sendButtonNode.addTarget(self, action: #selector(sendTapped), forControlEvents: .touchUpInside)
         attachButtonNode.addTarget(self, action: #selector(attachTapped), forControlEvents: .touchUpInside)
 
-        // Long press on parent view — ASButtonNode swallows touches,
-        // so we track mic hit in the gesture handler instead.
+        // Long press for mic — only recognized near the mic button
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleMicGesture(_:)))
         longPress.minimumPressDuration = 0.05
         longPress.allowableMovement = 20
+        longPress.delegate = self
         view.addGestureRecognizer(longPress)
     }
 
@@ -203,15 +203,6 @@ final class ChatInputNode: ASDisplayNode {
         switch gesture.state {
         case .began:
             let point = gesture.location(in: view)
-            // Only start if the gesture began on the mic button
-            guard isTextEmpty,
-                  micButtonNode.view.frame.insetBy(dx: -20, dy: -20).contains(
-                      view.convert(point, to: micButtonNode.supernode?.view ?? view)
-                  ) else {
-                gesture.isEnabled = false
-                gesture.isEnabled = true
-                return
-            }
             gestureStartPoint = point
             gestureState = .holding
             showOverlay()
@@ -336,6 +327,18 @@ final class ChatInputNode: ASDisplayNode {
             isTextEmpty = empty
             setNeedsLayout()
         }
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension ChatInputNode: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard isTextEmpty else { return false }
+        let point = touch.location(in: view)
+        let micFrame = micButtonNode.view.frame.insetBy(dx: -20, dy: -20)
+        let micFrameInSelf = view.convert(micFrame, from: micButtonNode.supernode?.view ?? view)
+        return micFrameInSelf.contains(point)
     }
 }
 

--- a/Zyna/Chat/Timeline/TimelineCoalescer.swift
+++ b/Zyna/Chat/Timeline/TimelineCoalescer.swift
@@ -94,7 +94,7 @@ final class TimelineCoalescer {
         var hadResetOrClear = false
 
         for diff in diffs {
-            switch diff.change() {
+            switch diff {
             case .reset, .clear:
                 hadResetOrClear = true
             default:
@@ -162,10 +162,9 @@ final class TimelineCoalescer {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func applySingleDiff(_ diff: TimelineDiff, updatedIds: inout Set<String>) {
-        switch diff.change() {
+        switch diff {
 
-        case .append:
-            guard let items = diff.append() else { return }
+        case .append(let items):
             for item in items {
                 currentItems.append(item)
                 if let msg = TimelineService.mapTimelineItem(item) {
@@ -176,8 +175,7 @@ final class TimelineCoalescer {
                 }
             }
 
-        case .pushBack:
-            guard let item = diff.pushBack() else { return }
+        case .pushBack(let item):
             currentItems.append(item)
             if let msg = TimelineService.mapTimelineItem(item) {
                 chronMessages.append(msg)
@@ -186,8 +184,7 @@ final class TimelineCoalescer {
                 isMappable.append(false)
             }
 
-        case .pushFront:
-            guard let item = diff.pushFront() else { return }
+        case .pushFront(let item):
             currentItems.insert(item, at: 0)
             if let msg = TimelineService.mapTimelineItem(item) {
                 chronMessages.insert(msg, at: 0)
@@ -196,12 +193,11 @@ final class TimelineCoalescer {
                 isMappable.insert(false, at: 0)
             }
 
-        case .insert:
-            guard let update = diff.insert() else { return }
-            let idx = Int(update.index)
+        case .insert(let index, let item):
+            let idx = Int(index)
             guard idx <= currentItems.count else { return }
-            currentItems.insert(update.item, at: idx)
-            if let msg = TimelineService.mapTimelineItem(update.item) {
+            currentItems.insert(item, at: idx)
+            if let msg = TimelineService.mapTimelineItem(item) {
                 let msgIdx = chatMessageIndex(forTimelineIndex: idx)
                 chronMessages.insert(msg, at: msgIdx)
                 isMappable.insert(true, at: idx)
@@ -209,15 +205,14 @@ final class TimelineCoalescer {
                 isMappable.insert(false, at: idx)
             }
 
-        case .set:
-            guard let update = diff.set() else { return }
-            let idx = Int(update.index)
+        case .set(let index, let item):
+            let idx = Int(index)
             guard idx < currentItems.count else { return }
 
             let oldMsgIdx = isMappable[idx] ? chatMessageIndex(forTimelineIndex: idx) : nil
 
-            currentItems[idx] = update.item
-            let newMsg = TimelineService.mapTimelineItem(update.item)
+            currentItems[idx] = item
+            let newMsg = TimelineService.mapTimelineItem(item)
             isMappable[idx] = newMsg != nil
 
             switch (oldMsgIdx, newMsg) {
@@ -235,8 +230,7 @@ final class TimelineCoalescer {
                 break
             }
 
-        case .remove:
-            guard let index = diff.remove() else { return }
+        case .remove(let index):
             let idx = Int(index)
             guard idx < currentItems.count else { return }
             if isMappable[idx] {
@@ -262,14 +256,12 @@ final class TimelineCoalescer {
             currentItems.removeFirst()
             isMappable.removeFirst()
 
-        case .reset:
-            currentItems = diff.reset() ?? []
+        case .reset(let items):
+            currentItems = items
             rebuildChronMessages()
 
-        case .truncate:
-            if let length = diff.truncate() {
-                currentItems = Array(currentItems.prefix(Int(length)))
-            }
+        case .truncate(let length):
+            currentItems = Array(currentItems.prefix(Int(length)))
             rebuildChronMessages()
 
         case .clear:

--- a/Zyna/Chat/VoiceRecording/LockIndicatorView.swift
+++ b/Zyna/Chat/VoiceRecording/LockIndicatorView.swift
@@ -1,0 +1,96 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+final class LockIndicatorView: UIView {
+
+    private let lockImageView = UIImageView()
+    private let chevronImageView = UIImageView()
+    private let capsuleBackground = UIView()
+
+    private static let capsuleSize = CGSize(width: 40, height: 80)
+    private static let lockThreshold: CGFloat = 0.7
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        let size = Self.capsuleSize
+
+        capsuleBackground.backgroundColor = .systemGray5
+        capsuleBackground.layer.cornerRadius = size.width / 2
+        capsuleBackground.frame = CGRect(origin: .zero, size: size)
+        addSubview(capsuleBackground)
+
+        lockImageView.image = AppIcon.lockOpen.rendered(size: 20, color: .secondaryLabel)
+        lockImageView.contentMode = .center
+        lockImageView.frame = CGRect(x: 0, y: 12, width: size.width, height: 28)
+        addSubview(lockImageView)
+
+        chevronImageView.image = AppIcon.chevronUp.rendered(size: 12, color: .tertiaryLabel)
+        chevronImageView.contentMode = .center
+        chevronImageView.frame = CGRect(x: 0, y: 46, width: size.width, height: 20)
+        addSubview(chevronImageView)
+
+        self.frame.size = size
+        alpha = 0
+    }
+
+    // MARK: - Public
+
+    /// Show with fade-in animation. Call after adding to superview and setting initial position.
+    func show() {
+        UIView.animate(withDuration: 0.2) {
+            self.alpha = 1
+        }
+    }
+
+    /// Update lock progress (0 = at mic button, 1 = threshold reached).
+    func updateProgress(_ progress: CGFloat) {
+        let clamped = min(max(progress, 0), 1)
+
+        // Switch icon at threshold
+        let isLocked = clamped >= Self.lockThreshold
+        let icon: AppIcon = isLocked ? .lockClosed : .lockOpen
+        let color: UIColor = isLocked ? .label : .secondaryLabel
+        lockImageView.image = icon.rendered(size: 20, color: color)
+
+        // Fade out chevron as we approach lock
+        chevronImageView.alpha = max(0, 1 - clamped * 2)
+    }
+
+    /// Animate the "snap to locked" effect and disappear.
+    func snapAndDismiss(completion: @escaping () -> Void) {
+        lockImageView.image = AppIcon.lockClosed.rendered(size: 20, color: .systemBlue)
+
+        UIView.animate(withDuration: 0.15, animations: {
+            self.transform = CGAffineTransform(scaleX: 1.3, y: 1.3)
+        }) { _ in
+            UIView.animate(withDuration: 0.2, animations: {
+                self.transform = .identity
+                self.alpha = 0
+            }) { _ in
+                self.removeFromSuperview()
+                completion()
+            }
+        }
+    }
+
+    /// Remove without snap animation.
+    func dismiss() {
+        UIView.animate(withDuration: 0.15, animations: {
+            self.alpha = 0
+        }) { _ in
+            self.removeFromSuperview()
+        }
+    }
+}

--- a/Zyna/Chat/VoiceRecording/VoicePreviewNode.swift
+++ b/Zyna/Chat/VoiceRecording/VoicePreviewNode.swift
@@ -1,0 +1,148 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+struct VoicePreviewData {
+    let fileURL: URL
+    let duration: TimeInterval
+    let waveform: [Float]
+}
+
+final class VoicePreviewNode: ASDisplayNode {
+
+    var onPlay: (() -> Void)?
+    var onPause: (() -> Void)?
+    var onDelete: (() -> Void)?
+    var onSend: (() -> Void)?
+
+    private let deleteButton = ASButtonNode()
+    private let playPauseButton = ASButtonNode()
+    private let durationNode = ASTextNode()
+    private let sendButton = ASButtonNode()
+    private var waveformBars: [ASDisplayNode] = []
+
+    private let maxBars = 32
+    private var isPlaying = false
+
+    override init() {
+        super.init()
+        automaticallyManagesSubnodes = true
+        backgroundColor = .systemBackground
+        setupNodes()
+    }
+
+    private func setupNodes() {
+        deleteButton.setImage(AppIcon.trash.rendered(size: 22, color: .systemRed), for: .normal)
+        deleteButton.style.preferredSize = CGSize(width: 36, height: 36)
+
+        playPauseButton.setImage(AppIcon.play.rendered(size: 22, color: .systemBlue), for: .normal)
+        playPauseButton.style.preferredSize = CGSize(width: 36, height: 36)
+
+        sendButton.setImage(AppIcon.send.rendered(size: 22, weight: .semibold, color: .systemBlue), for: .normal)
+        sendButton.style.preferredSize = CGSize(width: 36, height: 36)
+
+        for _ in 0..<maxBars {
+            let bar = ASDisplayNode()
+            bar.backgroundColor = .systemBlue
+            bar.cornerRadius = 1.5
+            bar.style.width = ASDimension(unit: .points, value: 3)
+            waveformBars.append(bar)
+        }
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        deleteButton.addTarget(self, action: #selector(deleteTapped), forControlEvents: .touchUpInside)
+        playPauseButton.addTarget(self, action: #selector(playPauseTapped), forControlEvents: .touchUpInside)
+        sendButton.addTarget(self, action: #selector(sendTapped), forControlEvents: .touchUpInside)
+    }
+
+    // MARK: - Public
+
+    func configure(with data: VoicePreviewData) {
+        updateDuration(data.duration)
+        updateWaveform(data.waveform)
+        updatePlayState(false)
+    }
+
+    func updatePlayState(_ playing: Bool) {
+        isPlaying = playing
+        let icon: AppIcon = playing ? .pause : .play
+        playPauseButton.setImage(icon.rendered(size: 22, color: .systemBlue), for: .normal)
+    }
+
+    // MARK: - Layout
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let visibleBars = waveformBars.filter { $0.style.height.value > 0 }
+        let waveformStack = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 2,
+            justifyContent: .start,
+            alignItems: .center,
+            children: visibleBars
+        )
+        waveformStack.style.flexShrink = 1
+        waveformStack.style.flexGrow = 1
+
+        let row = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 8,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [deleteButton, playPauseButton, waveformStack, durationNode, sendButton]
+        )
+
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8),
+            child: row
+        )
+    }
+
+    // MARK: - Private
+
+    private func updateDuration(_ duration: TimeInterval) {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        durationNode.attributedText = NSAttributedString(
+            string: String(format: "%d:%02d", minutes, seconds),
+            attributes: [
+                .font: UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .medium),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        )
+    }
+
+    private func updateWaveform(_ waveform: [Float]) {
+        // Resample to maxBars
+        let count = waveform.count
+        for (i, bar) in waveformBars.enumerated() {
+            if waveform.isEmpty {
+                bar.style.height = ASDimension(unit: .points, value: 0)
+                bar.alpha = 0
+                continue
+            }
+            let sampleIdx = i * count / maxBars
+            if sampleIdx < count {
+                let sample = waveform[sampleIdx]
+                let height = max(3, CGFloat(sample) * 20)
+                bar.style.height = ASDimension(unit: .points, value: height)
+                bar.alpha = 1
+            } else {
+                bar.style.height = ASDimension(unit: .points, value: 0)
+                bar.alpha = 0
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func deleteTapped() { onDelete?() }
+    @objc private func playPauseTapped() {
+        if isPlaying { onPause?() } else { onPlay?() }
+    }
+    @objc private func sendTapped() { onSend?() }
+}

--- a/Zyna/Chat/VoiceRecording/VoiceRecordingOverlayNode.swift
+++ b/Zyna/Chat/VoiceRecording/VoiceRecordingOverlayNode.swift
@@ -64,25 +64,11 @@ final class VoiceRecordingOverlayNode: ASDisplayNode {
         chevronNode.style.preferredSize = CGSize(width: 12, height: 14)
 
         // Stop button (locked mode)
-        stopButtonNode.setImage(
-            UIImage(
-                systemName: "stop.circle.fill",
-                withConfiguration: UIImage.SymbolConfiguration(pointSize: 28, weight: .medium)
-            ),
-            for: .normal
-        )
-        stopButtonNode.tintColor = .systemBlue
+        stopButtonNode.setImage(AppIcon.stop.rendered(size: 28, color: .systemBlue), for: .normal)
         stopButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
         // Cancel button (locked mode)
-        cancelButtonNode.setImage(
-            UIImage(
-                systemName: "trash.circle.fill",
-                withConfiguration: UIImage.SymbolConfiguration(pointSize: 28, weight: .medium)
-            ),
-            for: .normal
-        )
-        cancelButtonNode.tintColor = .systemRed
+        cancelButtonNode.setImage(AppIcon.trash.rendered(size: 28, color: .systemRed), for: .normal)
         cancelButtonNode.style.preferredSize = CGSize(width: 36, height: 36)
 
         // Waveform bars

--- a/Zyna/Core/Theme/AppIcon.swift
+++ b/Zyna/Core/Theme/AppIcon.swift
@@ -8,11 +8,21 @@ import UIKit
 enum AppIcon {
     case play
     case pause
+    case stop
+    case trash
+    case attach
+    case send
+    case mic
 
     var systemName: String {
         switch self {
-        case .play:  return "play.fill"
-        case .pause: return "pause.fill"
+        case .play:   return "play.fill"
+        case .pause:  return "pause.fill"
+        case .stop:   return "stop.circle.fill"
+        case .trash:  return "trash.circle.fill"
+        case .attach: return "paperclip"
+        case .send:   return "arrow.up.circle.fill"
+        case .mic:    return "mic.fill"
         }
     }
 

--- a/Zyna/Core/Theme/AppIcon.swift
+++ b/Zyna/Core/Theme/AppIcon.swift
@@ -13,16 +13,22 @@ enum AppIcon {
     case attach
     case send
     case mic
+    case lockOpen
+    case lockClosed
+    case chevronUp
 
     var systemName: String {
         switch self {
-        case .play:   return "play.fill"
-        case .pause:  return "pause.fill"
-        case .stop:   return "stop.circle.fill"
-        case .trash:  return "trash.circle.fill"
-        case .attach: return "paperclip"
-        case .send:   return "arrow.up.circle.fill"
-        case .mic:    return "mic.fill"
+        case .play:       return "play.fill"
+        case .pause:      return "pause.fill"
+        case .stop:       return "stop.circle.fill"
+        case .trash:      return "trash.circle.fill"
+        case .attach:     return "paperclip"
+        case .send:       return "arrow.up.circle.fill"
+        case .mic:        return "mic.fill"
+        case .lockOpen:   return "lock.open.fill"
+        case .lockClosed: return "lock.fill"
+        case .chevronUp:  return "chevron.up"
         }
     }
 

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -10,6 +10,7 @@ import MatrixRustSDK
 final class ChatsCoordinator {
 
     let navigationController = ASDKNavigationController()
+    private let roomListService = ZynaRoomListService()
     private var cancellables = Set<AnyCancellable>()
 
     func start() {
@@ -17,8 +18,57 @@ final class ChatsCoordinator {
         vc.onChatSelected = { [weak self] room in
             self?.showChat(room)
         }
+        vc.onComposeTapped = { [weak self] in
+            self?.showStartChat()
+        }
         navigationController.setViewControllers([vc], animated: false)
         observeIncomingCalls()
+    }
+
+    // MARK: - Start Chat Flow
+
+    private func showStartChat() {
+        let vm = StartChatViewModel(roomListService: roomListService)
+        let vc = StartChatViewController(viewModel: vm)
+
+        let nav = ASDKNavigationController(rootViewController: vc)
+
+        vm.onDMReady = { [weak self] room in
+            self?.dismissAndShowChat(room: room)
+        }
+        vm.onNewGroup = { [weak self] in
+            self?.showSelectMembers(in: nav)
+        }
+
+        navigationController.present(nav, animated: true)
+    }
+
+    private func showSelectMembers(in nav: ASDKNavigationController) {
+        let vm = SelectMembersViewModel()
+        let vc = SelectMembersViewController(viewModel: vm)
+
+        vm.onNext = { [weak self] users in
+            self?.showCreateGroup(members: users, in: nav)
+        }
+
+        nav.pushViewController(vc, animated: true)
+    }
+
+    private func showCreateGroup(members: [UserProfile], in nav: ASDKNavigationController) {
+        let vm = CreateGroupViewModel(members: members, roomListService: roomListService)
+        let vc = CreateGroupViewController(viewModel: vm)
+
+        vm.onRoomCreated = { [weak self] room in
+            self?.dismissAndShowChat(room: room)
+        }
+
+        nav.pushViewController(vc, animated: true)
+    }
+
+    private func dismissAndShowChat(room: Room) {
+        navigationController.dismiss(animated: true) { [weak self] in
+            self?.showChat(room)
+        }
     }
 
     private func observeIncomingCalls() {

--- a/Zyna/Screens/CreateGroup/CreateGroupNode.swift
+++ b/Zyna/Screens/CreateGroup/CreateGroupNode.swift
@@ -1,0 +1,99 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class CreateGroupNode: BaseNode {
+
+    let nameInputNode = ASEditableTextNode()
+    let topicInputNode = ASEditableTextNode()
+    let membersLabel = ASTextNode()
+    let membersCountNode = ASTextNode()
+    let createButtonNode = ASButtonNode()
+
+    private let nameLabel = ASTextNode()
+    private let topicLabel = ASTextNode()
+    private let nameSeparator = ASDisplayNode()
+    private let topicSeparator = ASDisplayNode()
+
+    override init() {
+        super.init()
+
+        nameLabel.attributedText = NSAttributedString(
+            string: "Group Name",
+            attributes: [.font: UIFont.systemFont(ofSize: 13), .foregroundColor: UIColor.secondaryLabel]
+        )
+
+        nameInputNode.typingAttributes = [
+            NSAttributedString.Key.font.rawValue: UIFont.systemFont(ofSize: 16)
+        ]
+        nameInputNode.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        nameInputNode.style.minHeight = ASDimension(unit: .points, value: 36)
+
+        nameSeparator.backgroundColor = .separator
+        nameSeparator.style.height = ASDimension(unit: .points, value: 0.5)
+
+        topicLabel.attributedText = NSAttributedString(
+            string: "Topic (optional)",
+            attributes: [.font: UIFont.systemFont(ofSize: 13), .foregroundColor: UIColor.secondaryLabel]
+        )
+
+        topicInputNode.typingAttributes = [
+            NSAttributedString.Key.font.rawValue: UIFont.systemFont(ofSize: 16)
+        ]
+        topicInputNode.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+        topicInputNode.style.minHeight = ASDimension(unit: .points, value: 36)
+
+        topicSeparator.backgroundColor = .separator
+        topicSeparator.style.height = ASDimension(unit: .points, value: 0.5)
+
+        membersLabel.attributedText = NSAttributedString(
+            string: "Members",
+            attributes: [.font: UIFont.systemFont(ofSize: 13), .foregroundColor: UIColor.secondaryLabel]
+        )
+
+        createButtonNode.setTitle("Create Group", with: UIFont.systemFont(ofSize: 17, weight: .semibold), with: .white, for: .normal)
+        createButtonNode.backgroundColor = .systemBlue
+        createButtonNode.cornerRadius = 12
+        createButtonNode.style.height = ASDimension(unit: .points, value: 50)
+    }
+
+    func updateMembersCount(_ count: Int) {
+        membersCountNode.attributedText = NSAttributedString(
+            string: "\(count) member\(count == 1 ? "" : "s")",
+            attributes: [.font: UIFont.systemFont(ofSize: 15), .foregroundColor: UIColor.label]
+        )
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let nameSection = ASStackLayoutSpec(
+            direction: .vertical, spacing: 4, justifyContent: .start, alignItems: .stretch,
+            children: [nameLabel, nameInputNode, nameSeparator]
+        )
+
+        let topicSection = ASStackLayoutSpec(
+            direction: .vertical, spacing: 4, justifyContent: .start, alignItems: .stretch,
+            children: [topicLabel, topicInputNode, topicSeparator]
+        )
+
+        let membersSection = ASStackLayoutSpec(
+            direction: .vertical, spacing: 4, justifyContent: .start, alignItems: .stretch,
+            children: [membersLabel, membersCountNode]
+        )
+
+        let spacer = ASLayoutSpec()
+        spacer.style.flexGrow = 1
+
+        let mainStack = ASStackLayoutSpec(
+            direction: .vertical, spacing: 24, justifyContent: .start, alignItems: .stretch,
+            children: [nameSection, topicSection, membersSection, spacer, createButtonNode]
+        )
+
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 16, left: 16, bottom: 24, right: 16),
+            child: mainStack
+        )
+    }
+}

--- a/Zyna/Screens/CreateGroup/CreateGroupViewController.swift
+++ b/Zyna/Screens/CreateGroup/CreateGroupViewController.swift
@@ -1,0 +1,65 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class CreateGroupViewController: ASDKViewController<CreateGroupNode> {
+
+    private let viewModel: CreateGroupViewModel
+
+    init(viewModel: CreateGroupViewModel) {
+        self.viewModel = viewModel
+        super.init(node: CreateGroupNode())
+        title = "New Group"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        edgesForExtendedLayout = []
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .appBG
+        appearance.shadowColor = .clear
+        navigationItem.standardAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+
+        node.updateMembersCount(viewModel.members.count)
+        node.nameInputNode.delegate = self
+        node.topicInputNode.delegate = self
+        node.createButtonNode.addTarget(self, action: #selector(createTapped), forControlEvents: .touchUpInside)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        tap.cancelsTouchesInView = false
+        node.view.addGestureRecognizer(tap)
+    }
+
+    @objc private func createTapped() {
+        viewModel.roomName = node.nameInputNode.textView.text ?? ""
+        viewModel.roomTopic = node.topicInputNode.textView.text ?? ""
+        viewModel.createRoom()
+    }
+
+    @objc private func dismissKeyboard() {
+        node.view.endEditing(true)
+    }
+}
+
+// MARK: - ASEditableTextNodeDelegate
+
+extension CreateGroupViewController: ASEditableTextNodeDelegate {
+    func editableTextNodeDidUpdateText(_ editableTextNode: ASEditableTextNode) {
+        // Sync text to viewModel on every change
+        if editableTextNode === node.nameInputNode {
+            viewModel.roomName = editableTextNode.textView.text ?? ""
+        } else if editableTextNode === node.topicInputNode {
+            viewModel.roomTopic = editableTextNode.textView.text ?? ""
+        }
+    }
+}

--- a/Zyna/Screens/CreateGroup/CreateGroupViewModel.swift
+++ b/Zyna/Screens/CreateGroup/CreateGroupViewModel.swift
@@ -1,0 +1,59 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import MatrixRustSDK
+
+final class CreateGroupViewModel {
+
+    let members: [UserProfile]
+    var roomName = ""
+    var roomTopic = ""
+
+    var onRoomCreated: ((Room) -> Void)?
+    var onError: ((String) -> Void)?
+
+    private let roomListService: ZynaRoomListService
+
+    init(members: [UserProfile], roomListService: ZynaRoomListService) {
+        self.members = members
+        self.roomListService = roomListService
+    }
+
+    func createRoom() {
+        let name = roomName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            onError?("Room name is required")
+            return
+        }
+
+        Task {
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                let params = CreateRoomParameters(
+                    name: name,
+                    topic: roomTopic.isEmpty ? nil : roomTopic,
+                    isEncrypted: true,
+                    isDirect: false,
+                    visibility: .private,
+                    preset: .privateChat,
+                    invite: members.map(\.userId),
+                    avatar: nil,
+                    powerLevelContentOverride: nil,
+                    joinRuleOverride: nil,
+                    historyVisibilityOverride: nil,
+                    canonicalAlias: nil
+                )
+                let roomId = try await client.createRoom(request: params)
+
+                if let room = roomListService.room(for: roomId) {
+                    await MainActor.run { onRoomCreated?(room) }
+                }
+            } catch {
+                await MainActor.run { onError?("Failed to create room: \(error.localizedDescription)") }
+            }
+        }
+    }
+}

--- a/Zyna/Screens/CreateGroup/SelectMembersNode.swift
+++ b/Zyna/Screens/CreateGroup/SelectMembersNode.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class SelectMembersNode: BaseNode {
+
+    let tableNode = ASTableNode()
+
+    override init() {
+        super.init()
+        tableNode.backgroundColor = .appBG
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        ASWrapperLayoutSpec(layoutElement: tableNode)
+    }
+}

--- a/Zyna/Screens/CreateGroup/SelectMembersViewController.swift
+++ b/Zyna/Screens/CreateGroup/SelectMembersViewController.swift
@@ -1,0 +1,167 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import Combine
+import MatrixRustSDK
+
+final class SelectMembersViewController: ASDKViewController<SelectMembersNode>, ASTableDataSource, ASTableDelegate {
+
+    private let viewModel: SelectMembersViewModel
+    private var cancellables = Set<AnyCancellable>()
+    private let searchController = UISearchController(searchResultsController: nil)
+    private var nextButton: UIBarButtonItem!
+
+    // Chips scroll view for selected users
+    private let chipsScrollView = UIScrollView()
+    private let chipsStack = UIStackView()
+
+    init(viewModel: SelectMembersViewModel) {
+        self.viewModel = viewModel
+        super.init(node: SelectMembersNode())
+        title = "Add Members"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        node.tableNode.dataSource = self
+        node.tableNode.delegate = self
+        node.tableNode.view.separatorStyle = .none
+        node.tableNode.view.keyboardDismissMode = .onDrag
+
+        setupNavigation()
+        setupSearch()
+        setupChipsView()
+        bindViewModel()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigation() {
+        nextButton = UIBarButtonItem(title: "Next", style: .done, target: self, action: #selector(nextTapped))
+        navigationItem.rightBarButtonItem = nextButton
+    }
+
+    private func setupSearch() {
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search users"
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        definesPresentationContext = true
+    }
+
+    private func setupChipsView() {
+        chipsScrollView.showsHorizontalScrollIndicator = false
+        chipsScrollView.alwaysBounceHorizontal = true
+
+        chipsStack.axis = .horizontal
+        chipsStack.spacing = 8
+        chipsStack.alignment = .center
+
+        chipsScrollView.addSubview(chipsStack)
+        chipsStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            chipsStack.leadingAnchor.constraint(equalTo: chipsScrollView.contentLayoutGuide.leadingAnchor, constant: 16),
+            chipsStack.trailingAnchor.constraint(equalTo: chipsScrollView.contentLayoutGuide.trailingAnchor, constant: -16),
+            chipsStack.topAnchor.constraint(equalTo: chipsScrollView.contentLayoutGuide.topAnchor),
+            chipsStack.bottomAnchor.constraint(equalTo: chipsScrollView.contentLayoutGuide.bottomAnchor),
+            chipsStack.heightAnchor.constraint(equalTo: chipsScrollView.frameLayoutGuide.heightAnchor)
+        ])
+    }
+
+    private func bindViewModel() {
+        viewModel.$searchResults
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.node.tableNode.reloadData()
+            }
+            .store(in: &cancellables)
+
+        viewModel.$selectedUsers
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] users in
+                self?.updateChips(users)
+                self?.node.tableNode.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Chips
+
+    private func updateChips(_ users: [UserProfile]) {
+        chipsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        for user in users {
+            let chipNode = SelectedUserChipNode(user: user)
+            chipNode.onRemove = { [weak self] in
+                self?.viewModel.removeUser(user)
+            }
+            let chipView = chipNode.view
+            chipView.translatesAutoresizingMaskIntoConstraints = false
+            chipsStack.addArrangedSubview(chipView)
+        }
+
+        let hasChips = !users.isEmpty
+        let targetHeight: CGFloat = hasChips ? 44 : 0
+        if chipsScrollView.superview == nil && hasChips {
+            node.view.addSubview(chipsScrollView)
+            chipsScrollView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                chipsScrollView.topAnchor.constraint(equalTo: node.view.safeAreaLayoutGuide.topAnchor),
+                chipsScrollView.leadingAnchor.constraint(equalTo: node.view.leadingAnchor),
+                chipsScrollView.trailingAnchor.constraint(equalTo: node.view.trailingAnchor),
+                chipsScrollView.heightAnchor.constraint(equalToConstant: targetHeight)
+            ])
+            node.tableNode.contentInset.top = targetHeight
+        } else if !hasChips {
+            chipsScrollView.removeFromSuperview()
+            node.tableNode.contentInset.top = 0
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func nextTapped() {
+        viewModel.proceed()
+    }
+
+    // MARK: - ASTableDataSource
+
+    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
+        viewModel.searchResults.count
+    }
+
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        let results = viewModel.searchResults
+        guard indexPath.row < results.count else { return { ASCellNode() } }
+        let user = results[indexPath.row]
+        let isSelected = viewModel.isSelected(user)
+        return {
+            UserCellNode(user: user, isSelected: isSelected, showCheckmark: true)
+        }
+    }
+
+    // MARK: - ASTableDelegate
+
+    func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
+        tableNode.deselectRow(at: indexPath, animated: true)
+        guard indexPath.row < viewModel.searchResults.count else { return }
+        viewModel.toggleUser(viewModel.searchResults[indexPath.row])
+    }
+}
+
+// MARK: - UISearchResultsUpdating
+
+extension SelectMembersViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        viewModel.searchUsers(searchController.searchBar.text ?? "")
+    }
+}

--- a/Zyna/Screens/CreateGroup/SelectMembersViewModel.swift
+++ b/Zyna/Screens/CreateGroup/SelectMembersViewModel.swift
@@ -1,0 +1,64 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import MatrixRustSDK
+
+final class SelectMembersViewModel {
+
+    @Published private(set) var searchResults: [UserProfile] = []
+    @Published private(set) var selectedUsers: [UserProfile] = []
+
+    var onNext: (([UserProfile]) -> Void)?
+
+    private var searchTask: Task<Void, Never>?
+
+    func searchUsers(_ query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 3 else {
+            searchResults = []
+            return
+        }
+
+        searchTask?.cancel()
+        searchTask = Task {
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                let results = try await client.searchUsers(searchTerm: trimmed, limit: 20)
+                if !Task.isCancelled {
+                    let currentUserId = try? client.userId()
+                    await MainActor.run {
+                        self.searchResults = results.results.filter { $0.userId != currentUserId }
+                    }
+                }
+            } catch {
+                if !Task.isCancelled {
+                    await MainActor.run { self.searchResults = [] }
+                }
+            }
+        }
+    }
+
+    func toggleUser(_ user: UserProfile) {
+        if let idx = selectedUsers.firstIndex(where: { $0.userId == user.userId }) {
+            selectedUsers.remove(at: idx)
+        } else {
+            selectedUsers.append(user)
+        }
+    }
+
+    func isSelected(_ user: UserProfile) -> Bool {
+        selectedUsers.contains { $0.userId == user.userId }
+    }
+
+    func removeUser(_ user: UserProfile) {
+        selectedUsers.removeAll { $0.userId == user.userId }
+    }
+
+    func proceed() {
+        onNext?(selectedUsers)
+    }
+}

--- a/Zyna/Screens/CreateGroup/SelectedUserChipNode.swift
+++ b/Zyna/Screens/CreateGroup/SelectedUserChipNode.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class SelectedUserChipNode: ASDisplayNode {
+
+    var onRemove: (() -> Void)?
+
+    private let nameNode = ASTextNode()
+    private let removeNode = ASImageNode()
+    private let backgroundNode = ASDisplayNode()
+
+    init(user: UserProfile) {
+        super.init()
+        automaticallyManagesSubnodes = true
+
+        let name = user.displayName ?? String(user.userId.prefix(10))
+
+        backgroundNode.backgroundColor = .systemGray5
+        backgroundNode.cornerRadius = 16
+
+        nameNode.attributedText = NSAttributedString(
+            string: name,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 14, weight: .medium),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        nameNode.maximumNumberOfLines = 1
+
+        removeNode.image = UIImage(systemName: "xmark.circle.fill")?
+            .withTintColor(.systemGray2, renderingMode: .alwaysOriginal)
+        removeNode.style.preferredSize = CGSize(width: 18, height: 18)
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        let tap = UITapGestureRecognizer(target: self, action: #selector(tapped))
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func tapped() {
+        onRemove?()
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let row = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 4,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [nameNode, removeNode]
+        )
+
+        let padded = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 6, left: 12, bottom: 6, right: 8),
+            child: row
+        )
+
+        return ASBackgroundLayoutSpec(child: padded, background: backgroundNode)
+    }
+}

--- a/Zyna/Screens/Rooms/RoomsController.swift
+++ b/Zyna/Screens/Rooms/RoomsController.swift
@@ -19,6 +19,8 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
         set { viewModel.onChatSelected = newValue }
     }
 
+    var onComposeTapped: (() -> Void)?
+
     override init() {
         super.init(node: BaseNode())
 
@@ -75,7 +77,7 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
     }
 
     @objc private func composeButtonTapped() {
-        print("Compose button tapped")
+        onComposeTapped?()
     }
 }
 

--- a/Zyna/Screens/StartChat/StartChatNode.swift
+++ b/Zyna/Screens/StartChat/StartChatNode.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class StartChatNode: BaseNode {
+
+    let tableNode = ASTableNode()
+
+    override init() {
+        super.init()
+        tableNode.backgroundColor = .appBG
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        ASWrapperLayoutSpec(layoutElement: tableNode)
+    }
+}

--- a/Zyna/Screens/StartChat/StartChatViewController.swift
+++ b/Zyna/Screens/StartChat/StartChatViewController.swift
@@ -1,0 +1,151 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import Combine
+import MatrixRustSDK
+
+final class StartChatViewController: ASDKViewController<StartChatNode>, ASTableDataSource, ASTableDelegate {
+
+    private let viewModel: StartChatViewModel
+    private var cancellables = Set<AnyCancellable>()
+    private let searchController = UISearchController(searchResultsController: nil)
+
+    init(viewModel: StartChatViewModel) {
+        self.viewModel = viewModel
+        super.init(node: StartChatNode())
+        title = "New Chat"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        node.tableNode.dataSource = self
+        node.tableNode.delegate = self
+        node.tableNode.view.separatorStyle = .none
+        node.tableNode.view.keyboardDismissMode = .onDrag
+
+        setupNavigation()
+        setupSearch()
+        bindViewModel()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigation() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(cancelTapped)
+        )
+    }
+
+    private func setupSearch() {
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search users (@user:server)"
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        definesPresentationContext = true
+    }
+
+    private func bindViewModel() {
+        viewModel.$users
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.node.tableNode.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Actions
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    // MARK: - ASTableDataSource
+
+    func numberOfSections(in tableNode: ASTableNode) -> Int { 2 }
+
+    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
+        section == 0 ? 1 : viewModel.users.count
+    }
+
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        if indexPath.section == 0 {
+            return {
+                let cell = ASCellNode()
+                cell.automaticallyManagesSubnodes = true
+
+                let icon = ASImageNode()
+                icon.image = UIImage(systemName: "person.2.fill")?.withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
+                icon.style.preferredSize = CGSize(width: 24, height: 24)
+
+                let text = ASTextNode()
+                text.attributedText = NSAttributedString(
+                    string: "New Group",
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: 16, weight: .medium),
+                        .foregroundColor: UIColor.systemBlue
+                    ]
+                )
+
+                let separator = ASDisplayNode()
+                separator.backgroundColor = .separator
+                separator.style.height = ASDimension(unit: .points, value: 0.5)
+
+                cell.layoutSpecBlock = { _, _ in
+                    let row = ASStackLayoutSpec(
+                        direction: .horizontal,
+                        spacing: 12,
+                        justifyContent: .start,
+                        alignItems: .center,
+                        children: [icon, text]
+                    )
+                    let padded = ASInsetLayoutSpec(
+                        insets: UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16),
+                        child: row
+                    )
+                    let stack = ASStackLayoutSpec.vertical()
+                    stack.children = [padded, separator]
+                    return stack
+                }
+                return cell
+            }
+        }
+
+        let users = viewModel.users
+        guard indexPath.row < users.count else { return { ASCellNode() } }
+        let user = users[indexPath.row]
+        return {
+            UserCellNode(user: user)
+        }
+    }
+
+    // MARK: - ASTableDelegate
+
+    func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
+        tableNode.deselectRow(at: indexPath, animated: true)
+        if indexPath.section == 0 {
+            viewModel.newGroupTapped()
+        } else {
+            guard indexPath.row < viewModel.users.count else { return }
+            viewModel.selectUser(viewModel.users[indexPath.row])
+        }
+    }
+}
+
+// MARK: - UISearchResultsUpdating
+
+extension StartChatViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        viewModel.searchUsers(searchController.searchBar.text ?? "")
+    }
+}

--- a/Zyna/Screens/StartChat/StartChatViewModel.swift
+++ b/Zyna/Screens/StartChat/StartChatViewModel.swift
@@ -1,0 +1,96 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import MatrixRustSDK
+
+final class StartChatViewModel {
+
+    @Published private(set) var users: [UserProfile] = []
+    @Published private(set) var isSearching = false
+
+    var onDMReady: ((Room) -> Void)?
+    var onNewGroup: (() -> Void)?
+    var onError: ((String) -> Void)?
+
+    private var searchTask: Task<Void, Never>?
+    private let roomListService: ZynaRoomListService
+
+    init(roomListService: ZynaRoomListService) {
+        self.roomListService = roomListService
+    }
+
+    func searchUsers(_ query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 3 else {
+            users = []
+            return
+        }
+
+        searchTask?.cancel()
+        searchTask = Task {
+            isSearching = true
+            defer { isSearching = false }
+
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                let results = try await client.searchUsers(searchTerm: trimmed, limit: 20)
+                if !Task.isCancelled {
+                    // Filter out self
+                    let currentUserId = try? client.userId()
+                    await MainActor.run {
+                        self.users = results.results.filter { $0.userId != currentUserId }
+                    }
+                }
+            } catch {
+                if !Task.isCancelled {
+                    await MainActor.run { self.users = [] }
+                }
+            }
+        }
+    }
+
+    func selectUser(_ user: UserProfile) {
+        Task {
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                // Check existing DM
+                if let existingRoom = try client.getDmRoom(userId: user.userId) {
+                    await MainActor.run { onDMReady?(existingRoom) }
+                    return
+                }
+
+                // Create new DM
+                let params = CreateRoomParameters(
+                    name: nil,
+                    topic: nil,
+                    isEncrypted: true,
+                    isDirect: true,
+                    visibility: .private,
+                    preset: .trustedPrivateChat,
+                    invite: [user.userId],
+                    avatar: nil,
+                    powerLevelContentOverride: nil,
+                    joinRuleOverride: nil,
+                    historyVisibilityOverride: nil,
+                    canonicalAlias: nil
+                )
+                let roomId = try await client.createRoom(request: params)
+
+                // Find Room object from list service
+                if let room = roomListService.room(for: roomId) {
+                    await MainActor.run { onDMReady?(room) }
+                }
+            } catch {
+                await MainActor.run { onError?("Failed to create chat: \(error.localizedDescription)") }
+            }
+        }
+    }
+
+    func newGroupTapped() {
+        onNewGroup?()
+    }
+}

--- a/Zyna/Screens/StartChat/UserCellNode.swift
+++ b/Zyna/Screens/StartChat/UserCellNode.swift
@@ -1,0 +1,112 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class UserCellNode: ASCellNode {
+
+    private let avatarNode = ASDisplayNode()
+    private let initialsNode = ASTextNode()
+    private let nameNode = ASTextNode()
+    private let userIdNode = ASTextNode()
+    private let checkmarkNode = ASImageNode()
+    private let separatorNode = ASDisplayNode()
+
+    private let showCheckmark: Bool
+
+    init(user: UserProfile, isSelected: Bool = false, showCheckmark: Bool = false) {
+        self.showCheckmark = showCheckmark
+        super.init()
+        automaticallyManagesSubnodes = true
+
+        let displayName = user.displayName ?? user.userId
+        let initials = String(displayName.prefix(1)).uppercased()
+
+        avatarNode.backgroundColor = .systemGray4
+        avatarNode.cornerRadius = 22
+        avatarNode.style.preferredSize = CGSize(width: 44, height: 44)
+
+        initialsNode.attributedText = NSAttributedString(
+            string: initials,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 17, weight: .medium),
+                .foregroundColor: UIColor.white
+            ]
+        )
+
+        nameNode.attributedText = NSAttributedString(
+            string: displayName,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16, weight: .medium),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        nameNode.maximumNumberOfLines = 1
+        nameNode.truncationMode = .byTruncatingTail
+
+        userIdNode.attributedText = NSAttributedString(
+            string: user.userId,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 13),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        )
+        userIdNode.maximumNumberOfLines = 1
+        userIdNode.truncationMode = .byTruncatingTail
+
+        if showCheckmark {
+            let imageName = isSelected ? "checkmark.circle.fill" : "circle"
+            let color: UIColor = isSelected ? .systemBlue : .systemGray3
+            checkmarkNode.image = UIImage(systemName: imageName)?.withTintColor(color, renderingMode: .alwaysOriginal)
+            checkmarkNode.style.preferredSize = CGSize(width: 24, height: 24)
+        }
+
+        separatorNode.backgroundColor = .separator
+        separatorNode.style.height = ASDimension(unit: .points, value: 0.5)
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let avatarWithInitials = ASCenterLayoutSpec(
+            centeringOptions: .XY,
+            sizingOptions: .minimumXY,
+            child: initialsNode
+        )
+        let avatar = ASBackgroundLayoutSpec(child: avatarWithInitials, background: avatarNode)
+        avatar.style.preferredSize = CGSize(width: 44, height: 44)
+
+        let textStack = ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 2,
+            justifyContent: .center,
+            alignItems: .start,
+            children: [nameNode, userIdNode]
+        )
+        textStack.style.flexShrink = 1
+        textStack.style.flexGrow = 1
+
+        var rowChildren: [ASLayoutElement] = [avatar, textStack]
+        if showCheckmark {
+            rowChildren.append(checkmarkNode)
+        }
+
+        let row = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 12,
+            justifyContent: .start,
+            alignItems: .center,
+            children: rowChildren
+        )
+
+        let padded = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16),
+            child: row
+        )
+
+        let withSeparator = ASStackLayoutSpec.vertical()
+        withSeparator.children = [padded, separatorNode]
+        return withSeparator
+    }
+}

--- a/Zyna/Services/Authentication/AuthenticationService.swift
+++ b/Zyna/Services/Authentication/AuthenticationService.swift
@@ -15,6 +15,8 @@ enum AuthenticationError: LocalizedError {
     case invalidCredentials
     case networkError
     case sessionNotFound
+    case invalidOIDCURL
+    case registrationNotSupported
 
     var errorDescription: String? {
         switch self {
@@ -28,6 +30,10 @@ enum AuthenticationError: LocalizedError {
             return "Network connection error"
         case .sessionNotFound:
             return "No saved session found"
+        case .invalidOIDCURL:
+            return "Server returned an invalid authentication URL"
+        case .registrationNotSupported:
+            return "This server does not support registration"
         }
     }
 }

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -93,17 +93,16 @@ final class MatrixClientService {
         clearSessionDirectories()
 
         do {
+            let storeConfig = SqliteStoreBuilder(dataPath: sessionDataPath(), cachePath: sessionCachePath())
+                .passphrase(passphrase: passphrase)
+
             let client = try await ClientBuilder()
                 .serverNameOrHomeserverUrl(serverNameOrUrl: homeserver)
-                .sessionPaths(
-                    dataPath: sessionDataPath(),
-                    cachePath: sessionCachePath()
-                )
-                .sessionPassphrase(passphrase: passphrase)
+                .sqliteStore(config: storeConfig)
                 .slidingSyncVersionBuilder(versionBuilder: .discoverNative)
                 .setSessionDelegate(sessionDelegate: sessionDelegate)
                 .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-                .requestConfig(config: .init(retryLimit: 3, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
+                .requestConfig(config: RequestConfig(retryLimit: 3, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
                 .build()
 
             try await client.login(
@@ -144,17 +143,16 @@ final class MatrixClientService {
         do {
             let session = try sessionDelegate.retrieveSessionFromKeychain(userId: userId)
 
+            let storeConfig = SqliteStoreBuilder(dataPath: sessionDataPath(), cachePath: sessionCachePath())
+                .passphrase(passphrase: passphrase)
+
             let client = try await ClientBuilder()
                 .homeserverUrl(url: session.homeserverUrl)
-                .sessionPaths(
-                    dataPath: sessionDataPath(),
-                    cachePath: sessionCachePath()
-                )
-                .sessionPassphrase(passphrase: passphrase)
+                .sqliteStore(config: storeConfig)
                 .slidingSyncVersionBuilder(versionBuilder: .discoverNative)
                 .setSessionDelegate(sessionDelegate: sessionDelegate)
                 .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
-                .requestConfig(config: .init(retryLimit: 3, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
+                .requestConfig(config: RequestConfig(retryLimit: 3, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
                 .build()
 
             try await client.restoreSession(session: session)

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -209,6 +209,71 @@ final class MatrixClientService {
         stateSubject.send(.loggedOut)
     }
 
+    // MARK: - OIDC
+
+    // TODO: Replace with https://markovsdima.github.io/oidc/callback + Associated Domains once Apple Developer Account is active
+    private static let oidcRedirectURI = "zyna://oidc/callback"
+
+    private static let oidcConfig = OidcConfiguration(
+        clientName: "Zyna",
+        redirectUri: oidcRedirectURI,
+        clientUri: "https://github.com/markovsdima/Zyna",
+        logoUri: nil,
+        tosUri: nil,
+        policyUri: nil,
+        staticRegistrations: [:]
+    )
+
+    /// Build a client for a given homeserver (without logging in).
+    func buildUnauthenticatedClient(homeserver: String) async throws -> Client {
+        clearSessionDirectories()
+
+        let storeConfig = SqliteStoreBuilder(dataPath: sessionDataPath(), cachePath: sessionCachePath())
+            .passphrase(passphrase: passphrase)
+
+        return try await ClientBuilder()
+            .serverNameOrHomeserverUrl(serverNameOrUrl: homeserver)
+            .sqliteStore(config: storeConfig)
+            .slidingSyncVersionBuilder(versionBuilder: .discoverNative)
+            .setSessionDelegate(sessionDelegate: sessionDelegate)
+            .userAgent(userAgent: UserAgentBuilder.makeASCIIUserAgent())
+            .requestConfig(config: RequestConfig(retryLimit: 3, timeout: 30000, maxConcurrentRequests: nil, maxRetryTime: nil))
+            .build()
+    }
+
+    /// Start an OIDC authentication flow. Returns the login URL and authorization data.
+    func startOIDCFlow(client: Client) async throws -> (loginURL: URL, authData: OAuthAuthorizationData) {
+        let authData = try await client.urlForOidc(
+            oidcConfiguration: Self.oidcConfig,
+            prompt: .consent,
+            loginHint: nil,
+            deviceId: nil,
+            additionalScopes: nil
+        )
+        guard let url = URL(string: authData.loginUrl()) else {
+            throw AuthenticationError.invalidOIDCURL
+        }
+        return (url, authData)
+    }
+
+    /// Complete an OIDC flow after receiving the callback URL from the browser.
+    func completeOIDCFlow(client: Client, callbackURL: String) async throws {
+        try await client.loginWithOidcCallback(callbackUrl: callbackURL)
+
+        let userId = try client.userId()
+        UserDefaults.standard.set(userId, forKey: userIdKey)
+
+        let session = try client.session()
+        sessionDelegate.saveSessionInKeychain(session: session)
+
+        authLog("OIDC login successful as \(userId)")
+
+        self.client = client
+        stateSubject.send(.loggedIn)
+
+        try await startSync()
+    }
+
     // MARK: - Helpers
 
     var hasStoredSession: Bool {

--- a/Zyna/Services/MediaPreprocessor.swift
+++ b/Zyna/Services/MediaPreprocessor.swift
@@ -1,0 +1,110 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+import ImageIO
+
+// MARK: - Processed Image
+
+struct ProcessedImage {
+    let imageData: Data
+    let width: UInt64
+    let height: UInt64
+    // TODO: Thumbnail ready for when sendImage SDK bug is fixed
+    // let thumbnailData: Data
+    // let thumbnailWidth: UInt64
+    // let thumbnailHeight: UInt64
+}
+
+// MARK: - Media Preprocessor
+
+enum MediaPreprocessor {
+
+    static let maxDimension: CGFloat = 2048
+    static let jpegQuality: CGFloat = 0.78
+    // static let thumbMaxDimension: CGFloat = 800  // TODO: for sendImage thumbnail
+
+    // MARK: - Public
+
+    static func processImage(from data: Data) async throws -> ProcessedImage {
+        try await Task.detached {
+            let strippedData = stripGPSMetadata(from: data)
+
+            // UIImage handles all formats (JPEG, PNG, HEIC, WebP) and normalizes pixel format
+            guard let original = UIImage(data: strippedData) else {
+                throw PreprocessorError.invalidImageData
+            }
+
+            // Resize main image
+            let resized = resizeUIImage(original, maxDimension: maxDimension)
+
+            guard let imageData = resized.jpegData(compressionQuality: jpegQuality) else {
+                throw PreprocessorError.encodingFailed
+            }
+
+            return ProcessedImage(
+                imageData: imageData,
+                width: UInt64(resized.size.width * resized.scale),
+                height: UInt64(resized.size.height * resized.scale)
+            )
+        }.value
+    }
+
+    // MARK: - GPS Stripping
+
+    private static func stripGPSMetadata(from data: Data) -> Data {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let type = CGImageSourceGetType(source) else {
+            return data
+        }
+
+        let mutableData = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(mutableData, type, 1, nil) else {
+            return data
+        }
+
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] else {
+            return data
+        }
+
+        var cleaned = properties
+        cleaned.removeValue(forKey: kCGImagePropertyGPSDictionary)
+
+        CGImageDestinationAddImageFromSource(dest, source, 0, cleaned as CFDictionary)
+
+        guard CGImageDestinationFinalize(dest) else {
+            return data
+        }
+
+        return mutableData as Data
+    }
+
+    // MARK: - Resize
+
+    /// Resizes and normalizes an image: forces scale 1.0 and standard dynamic range (strips HDR).
+    /// Always redraws through the renderer even if dimensions fit, to normalize pixel format.
+    private static func resizeUIImage(_ image: UIImage, maxDimension: CGFloat) -> UIImage {
+        let w = image.size.width * image.scale   // pixel dimensions
+        let h = image.size.height * image.scale
+        let scale = min(maxDimension / w, maxDimension / h, 1.0)
+
+        let newSize = CGSize(width: w * scale, height: h * scale)
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        format.preferredRange = .standard   // Force SDR, strip HDR gain map
+        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+
+    // MARK: - Errors
+
+    enum PreprocessorError: Error {
+        case invalidImageData
+        case encodingFailed
+    }
+}

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -200,6 +200,8 @@ final class ZynaRoomListService: NSObject {
             text = "..последнее сообщение удалено.."
         case .unableToDecrypt:
             text = "Encrypted message"
+        case .other:
+            return (nil, timestamp)
         }
 
         return (text, timestamp)

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -32,7 +32,7 @@ final class TimelineService {
     func startListening() async {
         do {
             // Subscribe room for full sliding sync delivery (live events)
-            try? MatrixClientService.shared.roomListService?.subscribeToRooms(roomIds: [room.id()])
+            try? await MatrixClientService.shared.roomListService?.subscribeToRooms(roomIds: [room.id()])
 
             let timeline = try await room.timeline()
             self.timeline = timeline
@@ -55,25 +55,21 @@ final class TimelineService {
         var liveItems: [TimelineItem] = []
 
         for diff in diffs {
-            switch diff.change() {
-            case .append:
-                if let items = diff.append() {
-                    allItems.append(contentsOf: items)
-                    liveItems.append(contentsOf: items)
-                }
-            case .pushBack:
-                if let item = diff.pushBack() {
-                    allItems.append(item)
-                    liveItems.append(item)
-                }
-            case .pushFront:
-                if let item = diff.pushFront() { allItems.append(item) }
-            case .insert:
-                if let update = diff.insert() { allItems.append(update.item) }
-            case .set:
-                if let update = diff.set() { allItems.append(update.item) }
-            case .reset:
-                if let items = diff.reset() { allItems.append(contentsOf: items) }
+            switch diff {
+            case .append(let items):
+                allItems.append(contentsOf: items)
+                liveItems.append(contentsOf: items)
+            case .pushBack(let item):
+                allItems.append(item)
+                liveItems.append(item)
+            case .pushFront(let item):
+                allItems.append(item)
+            case .insert(_, let item):
+                allItems.append(item)
+            case .set(_, let item):
+                allItems.append(item)
+            case .reset(let items):
+                allItems.append(contentsOf: items)
             default:
                 break
             }
@@ -170,6 +166,8 @@ final class TimelineService {
             return .redacted
         case .unableToDecrypt:
             return .text(body: "Encrypted message")
+        case .other:
+            return nil
         }
     }
 
@@ -228,28 +226,47 @@ final class TimelineService {
         }
     }
 
-    func sendVoiceMessage(url: URL, duration: TimeInterval, waveform: [UInt16]) async {
+    func sendVoiceMessage(url: URL, duration: TimeInterval, waveform: [Float]) async {
         guard let timeline else { return }
         let fileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? UInt64) ?? 0
         let params = UploadParameters(
             source: .file(filename: url.path),
-            caption: nil,
-            formattedCaption: nil,
-            mentions: nil,
-            replyParams: nil,
-            useSendQueue: true
+            caption: nil, formattedCaption: nil, mentions: nil, inReplyTo: nil
         )
         let audioInfo = AudioInfo(duration: duration, size: fileSize, mimetype: "audio/mp4")
         do {
             _ = try timeline.sendVoiceMessage(
-                params: params,
-                audioInfo: audioInfo,
-                waveform: waveform,
-                progressWatcher: nil
+                params: params, audioInfo: audioInfo, waveform: waveform
             )
             timelineLog("Voice message sent, duration=\(String(format: "%.1f", duration))s")
         } catch {
             timelineLog("Voice send failed: \(error)")
+        }
+    }
+
+    func sendImage(imageData: Data, width: UInt64, height: UInt64, caption: String?) async {
+        guard let timeline else { return }
+
+        let imageURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".jpg")
+        do { try imageData.write(to: imageURL) } catch {
+            timelineLog("Image write to temp failed: \(error)")
+            return
+        }
+
+        // sendImage throws InvalidAttachmentData — using sendFile as workaround
+        let fileInfo = FileInfo(
+            mimetype: "image/jpeg", size: UInt64(imageData.count),
+            thumbnailInfo: nil, thumbnailSource: nil
+        )
+        let params = UploadParameters(
+            source: .file(filename: imageURL.path(percentEncoded: false)),
+            caption: caption, formattedCaption: nil, mentions: nil, inReplyTo: nil
+        )
+        do {
+            _ = try timeline.sendFile(params: params, fileInfo: fileInfo)
+            timelineLog("Image sent via sendFile, \(width)×\(height)")
+        } catch {
+            timelineLog("Image send failed: \(error)")
         }
     }
 

--- a/Zyna/SwiftUIScreens/Auth/AuthView.swift
+++ b/Zyna/SwiftUIScreens/Auth/AuthView.swift
@@ -7,19 +7,19 @@ import SwiftUI
 
 struct AuthView: View {
     @ObservedObject var viewModel: AuthViewModel
-    
+
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var homeserver: String = "matrix.org"
     @State private var showPassword = false
-    
+
     var body: some View {
         ZStack {
-            
+
             // MARK: - Background Layers
-            
+
             Color.black.ignoresSafeArea(.all)
-            
+
             Group {
                 ParticlePatternView()
                 InterstellarLinesView()
@@ -30,17 +30,20 @@ struct AuthView: View {
             .onTapGesture {
                 UIApplication.shared.endEditing()
             }
-            
+
             // MARK: - Content
-            
+
             VStack(spacing: 20) {
                 Spacer()
                 logoView()
                 Spacer()
-                
+
                 homeserverInput()
-                loginInput()
-                passwordInput()
+
+                if viewModel.serverSupportsPassword {
+                    loginInput()
+                    passwordInput()
+                }
 
                 if let error = viewModel.errorMessage {
                     Text(error)
@@ -49,8 +52,17 @@ struct AuthView: View {
                         .padding(.horizontal)
                 }
 
-                Spacer().frame(height: 50)
-                signInButton()
+                Spacer().frame(height: 30)
+
+                if viewModel.serverSupportsPassword {
+                    signInButton()
+                }
+
+                if !viewModel.serverSupportsPassword && viewModel.serverSupportsOIDC {
+                    oidcSignInButton()
+                }
+
+                createAccountButton()
             }
             .padding()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -61,21 +73,21 @@ struct AuthView: View {
             viewModel.tryRestoreSession()
         }
     }
-    
+
     // MARK: - View Components
-    
+
     private func logoView() -> some View {
         Group {
             Text("Zyna")
                 .font(.system(size: 88, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(0.85))
                 .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)
-            
-            Text("Safe chats. Stunning vibes.") // Grace meets security
+
+            Text("Safe chats. Stunning vibes.")
                 .foregroundColor(.white).opacity(0.75)
         }
     }
-    
+
     @ViewBuilder private func homeserverInput() -> some View {
         ZStack(alignment: .leading) {
             if homeserver.isEmpty {
@@ -95,6 +107,9 @@ struct AuthView: View {
                 )
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
+                .onChange(of: homeserver) { newValue in
+                    viewModel.checkServerCapabilities(homeserver: newValue)
+                }
         }.padding(.horizontal)
     }
 
@@ -144,7 +159,7 @@ struct AuthView: View {
             .disableAutocorrection(true)
             .padding(.horizontal)
             .transition(.move(edge: .top).combined(with: .opacity))
-            
+
             if password.isEmpty {
                 HStack {
                     Text("Password")
@@ -153,7 +168,7 @@ struct AuthView: View {
                     Spacer()
                 }
             }
-            
+
             Button(action: {
                 showPassword.toggle()
             }) {
@@ -163,7 +178,7 @@ struct AuthView: View {
             }
         }
     }
-    
+
     private func signInButton() -> some View {
         Button(action: {
             viewModel.login(username: username, password: password, homeserver: homeserver)
@@ -185,5 +200,40 @@ struct AuthView: View {
         }
         .disabled(viewModel.isLoading)
         .padding(.horizontal)
+    }
+
+    private func oidcSignInButton() -> some View {
+        Button(action: {
+            viewModel.loginWithOIDC(homeserver: homeserver)
+        }) {
+            Group {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text("Sign In with Browser")
+                        .font(.headline)
+                }
+            }
+            .foregroundColor(.white)
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(.black, in: RoundedRectangle(cornerRadius: 10))
+            .shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 5)
+        }
+        .disabled(viewModel.isLoading)
+        .padding(.horizontal)
+    }
+
+    private func createAccountButton() -> some View {
+        Button(action: {
+            viewModel.register(homeserver: homeserver)
+        }) {
+            Text("Create Account")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+        }
+        .disabled(viewModel.isLoading)
+        .padding(.bottom, 16)
     }
 }

--- a/Zyna/SwiftUIScreens/Auth/AuthViewModel.swift
+++ b/Zyna/SwiftUIScreens/Auth/AuthViewModel.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 import Combine
+import AuthenticationServices
+import MatrixRustSDK
 
 final class AuthViewModel: ObservableObject {
 
@@ -12,8 +14,14 @@ final class AuthViewModel: ObservableObject {
 
     @Published var isLoading = false
     @Published var errorMessage: String?
+    @Published var serverSupportsPassword = true
+    @Published var serverSupportsOIDC = false
 
     private let matrixService = MatrixClientService.shared
+    private var oidcClient: Client?
+    private var oidcAuthData: OAuthAuthorizationData?
+
+    // MARK: - Password Login
 
     func login(username: String, password: String, homeserver: String = "matrix.org") {
         guard !username.isEmpty, !password.isEmpty else {
@@ -44,6 +52,94 @@ final class AuthViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Registration (OIDC)
+
+    func register(homeserver: String) {
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let client = try await matrixService.buildUnauthenticatedClient(homeserver: homeserver)
+                let details = await client.homeserverLoginDetails()
+
+                guard details.supportsOidcLogin() else {
+                    await MainActor.run {
+                        isLoading = false
+                        errorMessage = "This server does not support registration from the app"
+                    }
+                    return
+                }
+
+                let (loginURL, authData) = try await matrixService.startOIDCFlow(client: client)
+                self.oidcClient = client
+                self.oidcAuthData = authData
+
+                await MainActor.run {
+                    isLoading = false
+                    presentOIDCSession(url: loginURL)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    // MARK: - OIDC Login (for servers that only support OIDC)
+
+    func loginWithOIDC(homeserver: String) {
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let client = try await matrixService.buildUnauthenticatedClient(homeserver: homeserver)
+                let (loginURL, authData) = try await matrixService.startOIDCFlow(client: client)
+                self.oidcClient = client
+                self.oidcAuthData = authData
+
+                await MainActor.run {
+                    isLoading = false
+                    presentOIDCSession(url: loginURL)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    // MARK: - Server Capabilities Check
+
+    func checkServerCapabilities(homeserver: String) {
+        let trimmed = homeserver.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        Task {
+            do {
+                let client = try await matrixService.buildUnauthenticatedClient(homeserver: trimmed)
+                let details = await client.homeserverLoginDetails()
+
+                await MainActor.run {
+                    serverSupportsPassword = details.supportsPasswordLogin()
+                    serverSupportsOIDC = details.supportsOidcLogin()
+                }
+            } catch {
+                await MainActor.run {
+                    serverSupportsPassword = true
+                    serverSupportsOIDC = false
+                }
+            }
+        }
+    }
+
+    // MARK: - Session Restore
+
     func tryRestoreSession() {
         guard matrixService.hasStoredSession else { return }
 
@@ -58,9 +154,77 @@ final class AuthViewModel: ObservableObject {
             } catch {
                 await MainActor.run {
                     isLoading = false
-                    // Session expired — show login form
                 }
             }
         }
+    }
+
+    // MARK: - OIDC Browser Session
+
+    private func presentOIDCSession(url: URL) {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else { return }
+
+        let session = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: "zyna"
+        ) { [weak self] callbackURL, error in
+            guard let self else { return }
+
+            if let error {
+                DispatchQueue.main.async {
+                    // User cancelled — not an error
+                    if (error as NSError).code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        return
+                    }
+                    self.errorMessage = error.localizedDescription
+                }
+                return
+            }
+
+            guard let callbackURL else { return }
+
+            self.isLoading = true
+            Task {
+                do {
+                    guard let client = self.oidcClient else { return }
+                    try await self.matrixService.completeOIDCFlow(
+                        client: client,
+                        callbackURL: callbackURL.absoluteString
+                    )
+                    await MainActor.run {
+                        self.isLoading = false
+                        self.oidcClient = nil
+                        self.oidcAuthData = nil
+                        self.onAuthenticated?()
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.isLoading = false
+                        self.errorMessage = error.localizedDescription
+                    }
+                }
+            }
+        }
+
+        // Use the window as presentation context
+        let contextProvider = OIDCPresentationContext(window: window)
+        session.presentationContextProvider = contextProvider
+        session.prefersEphemeralWebBrowserSession = false
+        session.start()
+    }
+}
+
+// MARK: - OIDC Presentation Context
+
+private final class OIDCPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let window: UIWindow
+
+    init(window: UIWindow) {
+        self.window = window
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        window
     }
 }


### PR DESCRIPTION
## Summary
- Image sending via PHPicker with preprocessing (resize, JPEG, GPS strip)
- Matrix SDK migration to v25.11.11 (TimelineDiff enum, UploadParameters, waveform Float)
- Chat/group creation: user search, DM, private groups (3 new screens)
- Voice recording: animated lock indicator, pulse feedback, preview before send
- OIDC registration flow with adaptive auth screen (pending Apple Developer Account)
- Chat input tap fix: mic gesture no longer conflicts with text field

## New screens
- StartChat: user search + "New Group" entry point
- SelectMembers: multi-select with chips
- CreateGroup: name, topic, create

## Note
OIDC registration is implemented but untested — requires Apple Developer Account for Associated Domains and HTTPS redirect URI.
