### PR TITLE
Stage 8: Presence service, profile screen, and authenticated media

### DIFF
--- a/Zyna/App/SceneDelegate.swift
+++ b/Zyna/App/SceneDelegate.swift
@@ -21,4 +21,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         appCoordinator.start()
         window.makeKeyAndVisible()
     }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        PresenceService.shared.stopHeartbeatLoop()
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        appCoordinator.resumeHeartbeatIfNeeded()
+    }
 }

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -12,6 +12,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     var onBack: (() -> Void)?
     var onCallTapped: (() -> Void)?
+    var onTitleTapped: ((String) -> Void)?
 
     private let viewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -106,6 +107,18 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 self?.presenceTitleView.presence = presence
             }
             .store(in: &cancellables)
+
+        viewModel.$partnerUserId
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] userId in
+                self?.presenceTitleView.isTappable = userId != nil
+            }
+            .store(in: &cancellables)
+
+        presenceTitleView.onTapped = { [weak self] in
+            guard let userId = self?.viewModel.partnerUserId else { return }
+            self?.onTitleTapped?(userId)
+        }
 
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -16,6 +16,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let viewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
     private var batchFetchCancellable: AnyCancellable?
+    private let presenceTitleView = PresenceTitleView()
     private let inputAccessory = ChatInputAccessoryView()
     private let audioPlayer = AudioPlayerService()
     private var activeContextMenu: ContextMenuController?
@@ -35,7 +36,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     init(viewModel: ChatViewModel) {
         self.viewModel = viewModel
         super.init(node: ChatNode())
-        title = viewModel.roomName
+        presenceTitleView.name = viewModel.roomName
         hidesBottomBarWhenPushed = true
     }
 
@@ -96,6 +97,15 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         let appearance = UINavigationBarAppearance()
         appearance.configureWithDefaultBackground()
         navigationItem.scrollEdgeAppearance = appearance
+
+        navigationItem.titleView = presenceTitleView
+
+        viewModel.$partnerPresence
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] presence in
+                self?.presenceTitleView.presence = presence
+            }
+            .store(in: &cancellables)
 
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -24,6 +24,7 @@ final class ChatViewModel {
     var onRedactionFailed: ((String, Error) -> Void)?
 
     let roomName: String
+    @Published private(set) var partnerPresence: UserPresence?
 
     // MARK: - Coordinator callback
     var onBack: (() -> Void)?
@@ -33,6 +34,7 @@ final class ChatViewModel {
     let timelineService: TimelineService
     private let coalescer = TimelineCoalescer()
     private var cancellables = Set<AnyCancellable>()
+    private var directUserId: String?
 
     init(room: Room) {
         self.roomName = room.displayName() ?? "Chat"
@@ -90,6 +92,18 @@ final class ChatViewModel {
 
         Task { [weak self] in
             await self?.timelineService.startListening()
+        }
+
+        Task { [weak self] in
+            guard let self else { return }
+            guard let info = try? await room.roomInfo() else { return }
+            guard info.isDirect, let userId = info.heroes.first?.userId else { return }
+            await MainActor.run { self.directUserId = userId }
+            PresenceTracker.shared.register(userIds: [userId], for: "chat")
+            PresenceTracker.shared.$statuses
+                .map { $0[userId] }
+                .receive(on: DispatchQueue.main)
+                .assign(to: &self.$partnerPresence)
         }
     }
 
@@ -152,6 +166,7 @@ final class ChatViewModel {
     }
 
     func cleanup() {
+        PresenceTracker.shared.unregister(for: "chat")
         timelineService.onDiffs = nil
         coalescer.onBatchReady = nil
         timelineService.stopListening()

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -25,6 +25,7 @@ final class ChatViewModel {
 
     let roomName: String
     @Published private(set) var partnerPresence: UserPresence?
+    @Published private(set) var partnerUserId: String?
 
     // MARK: - Coordinator callback
     var onBack: (() -> Void)?
@@ -98,7 +99,10 @@ final class ChatViewModel {
             guard let self else { return }
             guard let info = try? await room.roomInfo() else { return }
             guard info.isDirect, let userId = info.heroes.first?.userId else { return }
-            await MainActor.run { self.directUserId = userId }
+            await MainActor.run {
+                self.directUserId = userId
+                self.partnerUserId = userId
+            }
             PresenceTracker.shared.register(userIds: [userId], for: "chat")
             PresenceTracker.shared.$statuses
                 .map { $0[userId] }

--- a/Zyna/Chat/PresenceTitleView.swift
+++ b/Zyna/Chat/PresenceTitleView.swift
@@ -15,6 +15,14 @@ final class PresenceTitleView: UIView {
         didSet { updateStatus() }
     }
 
+    var isTappable = false {
+        didSet { tapRecognizer.isEnabled = isTappable }
+    }
+
+    var onTapped: (() -> Void)?
+
+    private lazy var tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+
     private let nameLabel = UILabel()
     private let statusLabel = UILabel()
     private let stack = UIStackView()
@@ -51,6 +59,13 @@ final class PresenceTitleView: UIView {
             stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
             stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
         ])
+
+        tapRecognizer.isEnabled = false
+        addGestureRecognizer(tapRecognizer)
+    }
+
+    @objc private func handleTap() {
+        onTapped?()
     }
 
     private func updateStatus() {
@@ -65,21 +80,11 @@ final class PresenceTitleView: UIView {
             statusLabel.text = "online"
             statusLabel.textColor = .systemGreen
         } else if let lastSeen = presence.lastSeen {
-            statusLabel.text = Self.formatLastSeen(lastSeen)
+            statusLabel.text = lastSeen.presenceLastSeenString
             statusLabel.textColor = .secondaryLabel
         } else {
             statusLabel.text = nil
             statusLabel.isHidden = true
-        }
-    }
-
-    private static func formatLastSeen(_ date: Date) -> String {
-        let diff = Date().timeIntervalSince(date)
-        switch diff {
-        case ..<60:       return "last seen just now"
-        case ..<3600:     return "last seen \(Int(diff / 60)) min ago"
-        case ..<86400:    return "last seen today"
-        default:          return "last seen recently"
         }
     }
 

--- a/Zyna/Chat/PresenceTitleView.swift
+++ b/Zyna/Chat/PresenceTitleView.swift
@@ -1,0 +1,89 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+final class PresenceTitleView: UIView {
+
+    var name: String = "" {
+        didSet { nameLabel.text = name }
+    }
+
+    var presence: UserPresence? {
+        didSet { updateStatus() }
+    }
+
+    private let nameLabel = UILabel()
+    private let statusLabel = UILabel()
+    private let stack = UIStackView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        nameLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        nameLabel.textAlignment = .center
+
+        statusLabel.font = .systemFont(ofSize: 12, weight: .regular)
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.textAlignment = .center
+
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 1
+        stack.addArrangedSubview(nameLabel)
+        stack.addArrangedSubview(statusLabel)
+
+        addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
+        ])
+    }
+
+    private func updateStatus() {
+        guard let presence else {
+            statusLabel.text = nil
+            statusLabel.isHidden = true
+            return
+        }
+
+        statusLabel.isHidden = false
+        if presence.online {
+            statusLabel.text = "online"
+            statusLabel.textColor = .systemGreen
+        } else if let lastSeen = presence.lastSeen {
+            statusLabel.text = Self.formatLastSeen(lastSeen)
+            statusLabel.textColor = .secondaryLabel
+        } else {
+            statusLabel.text = nil
+            statusLabel.isHidden = true
+        }
+    }
+
+    private static func formatLastSeen(_ date: Date) -> String {
+        let diff = Date().timeIntervalSince(date)
+        switch diff {
+        case ..<60:       return "last seen just now"
+        case ..<3600:     return "last seen \(Int(diff / 60)) min ago"
+        case ..<86400:    return "last seen today"
+        default:          return "last seen recently"
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: 44)
+    }
+}

--- a/Zyna/Extensions/Date+Extensions.swift
+++ b/Zyna/Extensions/Date+Extensions.swift
@@ -1,0 +1,18 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+extension Date {
+    var presenceLastSeenString: String {
+        let diff = Date().timeIntervalSince(self)
+        switch diff {
+        case ..<60:    return "last seen just now"
+        case ..<3600:  return "last seen \(Int(diff / 60)) min ago"
+        case ..<86400: return "last seen today"
+        default:       return "last seen recently"
+        }
+    }
+}

--- a/Zyna/Navigation/AppCoordinator.swift
+++ b/Zyna/Navigation/AppCoordinator.swift
@@ -49,11 +49,21 @@ final class AppCoordinator {
         coordinator.start()
         self.mainCoordinator = coordinator
 
+        if let userId = MatrixClientService.shared.client.flatMap({ try? $0.userId() }) {
+            PresenceService.shared.startHeartbeatLoop(userId: userId)
+        }
+
         guard let tabBar = coordinator.tabBarController as? UIViewController else { return }
         window?.rootViewController = tabBar
     }
 
+    func resumeHeartbeatIfNeeded() {
+        guard let userId = MatrixClientService.shared.client.flatMap({ try? $0.userId() }) else { return }
+        PresenceService.shared.startHeartbeatLoop(userId: userId)
+    }
+
     private func performLogout() {
+        PresenceService.shared.stopHeartbeatLoop()
         Task { @MainActor in
             await MatrixClientService.shared.logout()
             self.mainCoordinator = nil

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -92,8 +92,16 @@ final class ChatsCoordinator {
         vc.onCallTapped = { [weak self] in
             self?.startCall(in: room, timelineService: viewModel.timelineService)
         }
+        vc.onTitleTapped = { [weak self] userId in
+            self?.showProfile(userId: userId)
+        }
         navigationController.pushViewController(vc, animated: true)
         navigationController.enableFullScreenPopGesture()
+    }
+
+    private func showProfile(userId: String) {
+        let vc = ProfileViewController(mode: .other(userId: userId))
+        navigationController.pushViewController(vc, animated: true)
     }
 
     // MARK: - Calls

--- a/Zyna/Navigation/ProfileCoordinator.swift
+++ b/Zyna/Navigation/ProfileCoordinator.swift
@@ -11,7 +11,7 @@ final class ProfileCoordinator {
     var onLogout: (() -> Void)?
 
     func start() {
-        let vc = ProfileViewController()
+        let vc = ProfileViewController(mode: .own)
         vc.onLogout = { [weak self] in
             self?.onLogout?()
         }

--- a/Zyna/Screens/Profile/ProfileNode.swift
+++ b/Zyna/Screens/Profile/ProfileNode.swift
@@ -7,40 +7,98 @@ import AsyncDisplayKit
 
 final class ProfileNode: BaseNode {
 
+    // MARK: - Callbacks
+
+    var onAvatarTapped: (() -> Void)?
     var onLogoutTapped: (() -> Void)?
+    var onSettingsTapped: (() -> Void)?
+
+    // MARK: - Nodes
 
     private let avatarBackgroundNode = ASDisplayNode()
-    private let avatarImageNode = ASNetworkImageNode()
+    private let avatarImageNode = ASImageNode()
     private let avatarInitialsNode = ASTextNode()
+    private let editAvatarOverlayNode = ASDisplayNode()
+    private let editAvatarIconNode = ASImageNode()
+
     private let displayNameNode = ASTextNode()
+    private let nameEditNode = ASEditableTextNode()
     private let userIdNode = ASTextNode()
+    private let copyButtonNode = ASButtonNode()
+
+    private let presenceNode = ASTextNode()
+
+    private let settingsButtonNode = ASButtonNode()
     private let logoutButtonNode = ASButtonNode()
 
-    private var hasAvatar = false
+    // MARK: - State
+
+    private let mode: ProfileMode
+    private var isEditing = false
+
     var topInset: CGFloat = 40
     var bottomInset: CGFloat = 16
 
-    override init() {
+    var editingName: String? {
+        nameEditNode.attributedText?.string
+    }
+
+    // MARK: - Init
+
+    init(mode: ProfileMode) {
+        self.mode = mode
         super.init()
+        automaticallyManagesSubnodes = true
         setupNodes()
     }
 
     override func didLoad() {
         super.didLoad()
-        avatarBackgroundNode.cornerRadius = 40
+        avatarBackgroundNode.cornerRadius = 50
         avatarBackgroundNode.clipsToBounds = true
-        avatarImageNode.cornerRadius = 40
+        avatarImageNode.cornerRadius = 50
         avatarImageNode.clipsToBounds = true
+        editAvatarOverlayNode.cornerRadius = 50
+        editAvatarOverlayNode.clipsToBounds = true
         logoutButtonNode.cornerRadius = 12
         logoutButtonNode.clipsToBounds = true
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(avatarTapped))
+        editAvatarOverlayNode.view.addGestureRecognizer(tap)
+        editAvatarOverlayNode.view.isUserInteractionEnabled = false // enabled only in edit mode
+
+        let copyTap = UITapGestureRecognizer(target: self, action: #selector(copyUserId))
+        userIdNode.view.addGestureRecognizer(copyTap)
+        userIdNode.view.isUserInteractionEnabled = true
     }
 
-    // MARK: - Public
+    // MARK: - Public update
 
-    func update(displayName: String?, userId: String?, avatarUrl: URL?) {
-        let name = displayName ?? userId ?? ""
+    func update(avatar: AvatarViewModel?, displayName: String?, userId: String) {
+        avatarBackgroundNode.backgroundColor = avatar?.color ?? .systemGray4
+        avatarInitialsNode.attributedText = NSAttributedString(
+            string: avatar?.initials ?? "",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 32, weight: .semibold),
+                .foregroundColor: UIColor.white
+            ]
+        )
 
+        if let mxc = avatar?.mxcAvatarURL {
+            loadAvatarImage(mxcUrl: mxc)
+        } else {
+            avatarImageNode.image = nil
+        }
+
+        let name = displayName ?? userId
         displayNameNode.attributedText = NSAttributedString(
+            string: name,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 22, weight: .bold),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        nameEditNode.attributedText = NSAttributedString(
             string: name,
             attributes: [
                 .font: UIFont.systemFont(ofSize: 22, weight: .bold),
@@ -49,27 +107,57 @@ final class ProfileNode: BaseNode {
         )
 
         userIdNode.attributedText = NSAttributedString(
-            string: userId ?? "",
+            string: userId,
             attributes: [
-                .font: UIFont.systemFont(ofSize: 14, weight: .regular),
+                .font: UIFont.systemFont(ofSize: 13, weight: .regular),
                 .foregroundColor: UIColor.secondaryLabel
             ]
         )
 
-        let initials = Self.initials(from: displayName ?? userId ?? "?")
-        avatarInitialsNode.attributedText = NSAttributedString(
-            string: initials,
-            attributes: [
-                .font: UIFont.systemFont(ofSize: 28, weight: .semibold),
-                .foregroundColor: UIColor.white
-            ]
-        )
+        setNeedsLayout()
+    }
 
-        if let avatarUrl {
-            hasAvatar = true
-            avatarImageNode.url = avatarUrl
+    func updateAvatarLocally(image: UIImage) {
+        avatarImageNode.image = image
+    }
+
+    private func loadAvatarImage(mxcUrl: String) {
+        Task { @MainActor in
+            guard let image = await MediaCache.shared.loadThumbnail(mxcUrl: mxcUrl, size: 200) else { return }
+            self.avatarImageNode.image = image
         }
+    }
 
+    func updatePresence(_ presence: UserPresence?) {
+        guard case .other = mode else { return }
+        if let presence {
+            let text: String
+            let color: UIColor
+            if presence.online {
+                text = "online"
+                color = .systemGreen
+            } else if let lastSeen = presence.lastSeen {
+                text = lastSeen.presenceLastSeenString
+                color = .secondaryLabel
+            } else {
+                presenceNode.attributedText = nil
+                setNeedsLayout()
+                return
+            }
+            presenceNode.attributedText = NSAttributedString(
+                string: text,
+                attributes: [.font: UIFont.systemFont(ofSize: 14), .foregroundColor: color]
+            )
+        } else {
+            presenceNode.attributedText = nil
+        }
+        setNeedsLayout()
+    }
+
+    func setEditing(_ editing: Bool) {
+        isEditing = editing
+        editAvatarOverlayNode.isHidden = !editing
+        editAvatarOverlayNode.view.isUserInteractionEnabled = editing
         setNeedsLayout()
     }
 
@@ -77,18 +165,36 @@ final class ProfileNode: BaseNode {
 
     private func setupNodes() {
         avatarBackgroundNode.backgroundColor = .systemGray4
-
+        avatarImageNode.clipsToBounds = true
         avatarImageNode.contentMode = .scaleAspectFill
-        avatarImageNode.shouldRenderProgressImages = false
+        avatarImageNode.isLayerBacked = true
 
-        let logoutTitle = NSAttributedString(
+        // Edit overlay on avatar
+        editAvatarOverlayNode.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        editAvatarOverlayNode.isHidden = true
+        editAvatarIconNode.image = UIImage(systemName: "camera.fill")
+        editAvatarIconNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(.white)
+        editAvatarIconNode.contentMode = .scaleAspectFit
+
+        // Copy button
+        let copyImage = UIImage(systemName: "doc.on.doc")
+        copyButtonNode.setImage(copyImage, for: .normal)
+        copyButtonNode.imageNode.tintColor = .secondaryLabel
+        copyButtonNode.addTarget(self, action: #selector(copyUserId), forControlEvents: .touchUpInside)
+
+        // Settings (own only)
+        settingsButtonNode.setAttributedTitle(NSAttributedString(
+            string: "Settings",
+            attributes: [.font: UIFont.systemFont(ofSize: 17), .foregroundColor: UIColor.label]
+        ), for: .normal)
+        settingsButtonNode.contentHorizontalAlignment = .left
+        settingsButtonNode.addTarget(self, action: #selector(settingsTapped), forControlEvents: .touchUpInside)
+
+        // Logout (own only)
+        logoutButtonNode.setAttributedTitle(NSAttributedString(
             string: "Выйти",
-            attributes: [
-                .font: UIFont.systemFont(ofSize: 17, weight: .semibold),
-                .foregroundColor: UIColor.white
-            ]
-        )
-        logoutButtonNode.setAttributedTitle(logoutTitle, for: .normal)
+            attributes: [.font: UIFont.systemFont(ofSize: 17, weight: .semibold), .foregroundColor: UIColor.white]
+        ), for: .normal)
         logoutButtonNode.backgroundColor = .systemRed
         logoutButtonNode.contentEdgeInsets = UIEdgeInsets(top: 14, left: 32, bottom: 14, right: 32)
         logoutButtonNode.addTarget(self, action: #selector(logoutTapped), forControlEvents: .touchUpInside)
@@ -98,42 +204,70 @@ final class ProfileNode: BaseNode {
 
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
         // Avatar
-        avatarBackgroundNode.style.preferredSize = CGSize(width: 80, height: 80)
-        avatarImageNode.style.preferredSize = CGSize(width: 80, height: 80)
+        let size = CGSize(width: 100, height: 100)
+        avatarBackgroundNode.style.preferredSize = size
+        avatarImageNode.style.preferredSize = size
+        editAvatarOverlayNode.style.preferredSize = size
+        editAvatarIconNode.style.preferredSize = CGSize(width: 28, height: 28)
 
-        let initialsCenter = ASCenterLayoutSpec(
-            centeringOptions: .XY,
-            sizingOptions: .minimumXY,
-            child: avatarInitialsNode
-        )
-        var avatarSpec: ASLayoutSpec = ASOverlayLayoutSpec(child: avatarBackgroundNode, overlay: initialsCenter)
-        if hasAvatar {
-            avatarSpec = ASOverlayLayoutSpec(child: avatarSpec, overlay: avatarImageNode)
+        let initialsCenter = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: .minimumXY, child: avatarInitialsNode)
+        let withInitials = ASOverlayLayoutSpec(child: avatarBackgroundNode, overlay: initialsCenter)
+        var avatarSpec: ASLayoutSpec = ASOverlayLayoutSpec(child: withInitials, overlay: avatarImageNode)
+        if isEditing {
+            let iconCenter = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: .minimumXY, child: editAvatarIconNode)
+            let overlay = ASOverlayLayoutSpec(child: editAvatarOverlayNode, overlay: iconCenter)
+            avatarSpec = ASOverlayLayoutSpec(child: avatarSpec, overlay: overlay)
         }
 
-        // Profile info
-        let profileStack = ASStackLayoutSpec(
-            direction: .vertical,
-            spacing: 6,
-            justifyContent: .start,
-            alignItems: .center,
-            children: [avatarSpec, displayNameNode, userIdNode]
+        // User ID row
+        copyButtonNode.style.preferredSize = CGSize(width: 20, height: 20)
+        let userIdRow = ASStackLayoutSpec(
+            direction: .horizontal, spacing: 6,
+            justifyContent: .center, alignItems: .center,
+            children: [userIdNode, copyButtonNode]
         )
 
-        // Spacer
+        // Name (editable or static)
+        let nameSpec: ASLayoutSpec
+        if isEditing {
+            nameEditNode.style.minWidth = ASDimension(unit: .points, value: 150)
+            nameSpec = ASWrapperLayoutSpec(layoutElement: nameEditNode)
+        } else {
+            nameSpec = ASWrapperLayoutSpec(layoutElement: displayNameNode)
+        }
+
+        // Profile info stack
+        var infoChildren: [ASLayoutElement] = [avatarSpec, nameSpec, userIdRow]
+        if case .other = mode, presenceNode.attributedText != nil {
+            infoChildren.append(presenceNode)
+        }
+
+        let profileStack = ASStackLayoutSpec(
+            direction: .vertical, spacing: 8,
+            justifyContent: .start, alignItems: .center,
+            children: infoChildren
+        )
+
         let spacer = ASLayoutSpec()
         spacer.style.flexGrow = 1
 
-        // Button
-        logoutButtonNode.style.alignSelf = .stretch
+        var bottomChildren: [ASLayoutElement] = []
+        if case .own = mode {
+            settingsButtonNode.style.alignSelf = .stretch
+            logoutButtonNode.style.alignSelf = .stretch
+            bottomChildren = [settingsButtonNode, logoutButtonNode]
+        }
 
-        // Main stack
+        let bottomStack = ASStackLayoutSpec(
+            direction: .vertical, spacing: 12,
+            justifyContent: .end, alignItems: .stretch,
+            children: bottomChildren
+        )
+
         let mainStack = ASStackLayoutSpec(
-            direction: .vertical,
-            spacing: 0,
-            justifyContent: .start,
-            alignItems: .stretch,
-            children: [profileStack, spacer, logoutButtonNode]
+            direction: .vertical, spacing: 0,
+            justifyContent: .start, alignItems: .stretch,
+            children: [profileStack, spacer, bottomStack]
         )
 
         return ASInsetLayoutSpec(
@@ -144,18 +278,21 @@ final class ProfileNode: BaseNode {
 
     // MARK: - Actions
 
+    @objc private func avatarTapped() {
+        onAvatarTapped?()
+    }
+
+    @objc private func copyUserId() {
+        let text = userIdNode.attributedText?.string ?? ""
+        UIPasteboard.general.string = text
+    }
+
+    @objc private func settingsTapped() {
+        onSettingsTapped?()
+    }
+
     @objc private func logoutTapped() {
         onLogoutTapped?()
     }
 
-    // MARK: - Helpers
-
-    private static func initials(from name: String) -> String {
-        let cleaned = name.hasPrefix("@") ? String(name.dropFirst()) : name
-        let parts = cleaned.components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
-        if parts.count >= 2 {
-            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
-        }
-        return String(cleaned.prefix(2)).uppercased()
-    }
 }

--- a/Zyna/Screens/Profile/ProfileView.swift
+++ b/Zyna/Screens/Profile/ProfileView.swift
@@ -4,23 +4,34 @@
 //
 
 import AsyncDisplayKit
+import Combine
+import PhotosUI
 
 final class ProfileViewController: ASDKViewController<ProfileNode> {
 
     var onLogout: (() -> Void)?
 
-    override init() {
-        super.init(node: ProfileNode())
+    private let viewModel: ProfileViewModel
+    private var cancellables = Set<AnyCancellable>()
 
-        node.onLogoutTapped = { [weak self] in
-            self?.confirmLogout()
-        }
-
-        loadProfileData()
+    init(mode: ProfileMode) {
+        self.viewModel = ProfileViewModel(mode: mode)
+        super.init(node: ProfileNode(mode: mode))
+        viewModel.onLogout = { [weak self] in self?.onLogout?() }
+        setupCallbacks()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationBar()
+        bindViewModel()
+        viewModel.load()
     }
 
     override func viewSafeAreaInsetsDidChange() {
@@ -30,33 +41,121 @@ final class ProfileViewController: ASDKViewController<ProfileNode> {
         node.setNeedsLayout()
     }
 
-    // MARK: - Data
-
-    private func loadProfileData() {
-        guard let client = MatrixClientService.shared.client else { return }
-
-        Task { @MainActor in
-            let userId = try? client.userId()
-            let displayName = try? await client.displayName()
-            let avatarUrlString = try? await client.avatarUrl()
-            let avatarUrl = avatarUrlString.flatMap { URL(string: $0) }
-
-            self.node.update(displayName: displayName, userId: userId, avatarUrl: avatarUrl)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if isMovingFromParent {
+            viewModel.cleanup()
         }
     }
 
-    // MARK: - Actions
+    // MARK: - Navigation Bar
+
+    private func setupNavigationBar() {
+        if case .own = viewModel.mode {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                image: UIImage(systemName: "pencil"),
+                style: .plain,
+                target: self,
+                action: #selector(editTapped)
+            )
+        }
+    }
+
+    @objc private func editTapped() {
+        if viewModel.isEditing {
+            // Save
+            let newName = node.editingName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            viewModel.save(displayName: newName, avatarData: nil)
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                image: UIImage(systemName: "pencil"),
+                style: .plain, target: self, action: #selector(editTapped)
+            )
+        } else {
+            // Enter edit mode
+            viewModel.toggleEditing()
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: "Done", style: .done, target: self, action: #selector(editTapped)
+            )
+        }
+    }
+
+    // MARK: - Bindings
+
+    private func bindViewModel() {
+        Publishers.CombineLatest3(viewModel.$avatar, viewModel.$displayName, viewModel.$userId)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] avatar, displayName, userId in
+                self?.node.update(avatar: avatar, displayName: displayName, userId: userId)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isEditing
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] editing in
+                self?.node.setEditing(editing)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$presence
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] presence in
+                self?.node.updatePresence(presence)
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Callbacks
+
+    private func setupCallbacks() {
+        node.onLogoutTapped = { [weak self] in
+            self?.confirmLogout()
+        }
+        node.onSettingsTapped = {
+            print("[profile] Settings tapped")
+        }
+        node.onAvatarTapped = { [weak self] in
+            self?.presentAvatarPicker()
+        }
+    }
+
+    // MARK: - Avatar Picker
+
+    private func presentAvatarPicker() {
+        var config = PHPickerConfiguration()
+        config.selectionLimit = 1
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    // MARK: - Logout
 
     private func confirmLogout() {
-        let alert = UIAlertController(
-            title: "Выход",
-            message: "Вы уверены, что хотите выйти?",
-            preferredStyle: .alert
-        )
+        let alert = UIAlertController(title: "Выход", message: "Вы уверены?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Отмена", style: .cancel))
         alert.addAction(UIAlertAction(title: "Выйти", style: .destructive) { [weak self] _ in
-            self?.onLogout?()
+            self?.viewModel.logout()
         })
         present(alert, animated: true)
+    }
+}
+
+// MARK: - PHPickerViewControllerDelegate
+
+extension ProfileViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        guard let result = results.first else { return }
+
+        result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] object, error in
+            if let error { print("[profile] picker load error: \(error)"); return }
+            guard let image = object as? UIImage,
+                  let jpeg = image.jpegData(compressionQuality: 0.85) else { return }
+            DispatchQueue.main.async {
+                self?.node.updateAvatarLocally(image: image)
+                self?.viewModel.save(displayName: nil, avatarData: jpeg)
+            }
+        }
     }
 }

--- a/Zyna/Screens/Profile/ProfileViewModel.swift
+++ b/Zyna/Screens/Profile/ProfileViewModel.swift
@@ -1,0 +1,125 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import MatrixRustSDK
+
+enum ProfileMode {
+    case own
+    case other(userId: String)
+}
+
+final class ProfileViewModel {
+
+    let mode: ProfileMode
+
+    @Published private(set) var displayName: String?
+    @Published private(set) var userId: String = ""
+    @Published private(set) var avatar: AvatarViewModel?
+    @Published private(set) var isEditing = false
+    @Published private(set) var isSaving = false
+    @Published private(set) var presence: UserPresence?
+
+    var onLogout: (() -> Void)?
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(mode: ProfileMode) {
+        self.mode = mode
+    }
+
+    // MARK: - Load
+
+    func load() {
+        switch mode {
+        case .own:       loadOwnProfile()
+        case .other(let userId): loadOtherProfile(userId: userId)
+        }
+    }
+
+    private func loadOwnProfile() {
+        guard let client = MatrixClientService.shared.client else { return }
+        Task { @MainActor in
+            let uid = try? client.userId()
+            let name = try? await client.displayName()
+            let mxcUrl = try? await client.avatarUrl()
+            print("[profile] loadOwnProfile uid=\(uid ?? "nil") name=\(name ?? "nil") mxc=\(mxcUrl ?? "nil")")
+            self.userId = uid ?? ""
+            self.displayName = name
+            self.avatar = AvatarViewModel(userId: uid ?? "", displayName: name, mxcAvatarURL: mxcUrl)
+            print("[profile] mxcAvatarURL=\(self.avatar?.mxcAvatarURL ?? "nil")")
+        }
+    }
+
+    private func loadOtherProfile(userId: String) {
+        guard let client = MatrixClientService.shared.client else { return }
+        Task { @MainActor in
+            self.userId = userId
+            let profile = try? await client.getProfile(userId: userId)
+            self.displayName = profile?.displayName
+            self.avatar = AvatarViewModel(
+                userId: userId,
+                displayName: profile?.displayName,
+                mxcAvatarURL: profile?.avatarUrl
+            )
+        }
+
+        PresenceTracker.shared.register(userIds: [userId], for: "profile")
+        PresenceTracker.shared.$statuses
+            .map { $0[userId] }
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$presence)
+    }
+
+    // MARK: - Edit (own profile only)
+
+    func toggleEditing() {
+        guard case .own = mode else { return }
+        isEditing.toggle()
+    }
+
+    func cancelEditing() {
+        isEditing = false
+        load()
+    }
+
+    func save(displayName: String?, avatarData: Data?) {
+        guard case .own = mode, let client = MatrixClientService.shared.client else { return }
+        isSaving = true
+        Task { @MainActor in
+            if let name = displayName {
+                try? await client.setDisplayName(name: name)
+            }
+            if let data = avatarData {
+                do {
+                    try await client.uploadAvatar(mimeType: "image/jpeg", data: data)
+                    print("[profile] avatar uploaded OK")
+                } catch {
+                    print("[profile] avatar upload failed: \(error)")
+                }
+            }
+            self.isSaving = false
+            self.isEditing = false
+            try? await Task.sleep(for: .seconds(1))
+            self.load()
+        }
+    }
+
+    // MARK: - Logout
+
+    func logout() {
+        onLogout?()
+    }
+
+    // MARK: - Cleanup
+
+    func cleanup() {
+        if case .other(let userId) = mode {
+            PresenceTracker.shared.unregister(for: "profile")
+            _ = userId
+        }
+    }
+}

--- a/Zyna/Screens/Rooms/RoomModel.swift
+++ b/Zyna/Screens/Rooms/RoomModel.swift
@@ -12,39 +12,31 @@ struct RoomModel {
     let name: String
     let lastMessage: String
     let timestamp: String
-    let avatarURL: URL?
-    let avatarColor: UIColor
+    let avatar: AvatarViewModel
     var isOnline: Bool
     var lastSeen: Date?
     let unreadCount: Int
-    let avatarInitials: String
     let directUserId: String?
 }
 
 extension RoomModel {
-    private static let avatarColors: [UIColor] = [
-        .systemBlue, .systemGreen, .systemOrange, .systemRed,
-        .systemPurple, .systemTeal, .systemIndigo, .systemPink
-    ]
 
     init(from room: RoomSummary) {
-        let initials = room.displayName
-            .split(separator: " ")
-            .compactMap { $0.first }
-            .map(String.init)
-            .joined()
-
+        let avatarId = room.directUserId ?? room.id
+        let avatar = AvatarViewModel(
+            userId: avatarId,
+            displayName: room.displayName,
+            mxcAvatarURL: room.avatarURL
+        )
         self.init(
             id: room.id,
             name: room.displayName,
             lastMessage: room.lastMessage ?? "",
             timestamp: room.lastMessageTimestamp.map { Self.formatTimestamp($0) } ?? "",
-            avatarURL: room.avatarURL.flatMap { Self.mxcToHTTPS($0) },
-            avatarColor: Self.avatarColors[Self.stableHash(room.id) % Self.avatarColors.count],
+            avatar: avatar,
             isOnline: false,
             lastSeen: nil,
             unreadCount: Int(room.unreadCount),
-            avatarInitials: String(initials.prefix(2)),
             directUserId: room.directUserId
         )
     }
@@ -70,24 +62,5 @@ extension RoomModel {
         } else {
             return dateFormatter.string(from: date)
         }
-    }
-
-    /// djb2 hash — stable across app launches, unlike `hashValue`.
-    private static func stableHash(_ string: String) -> Int {
-        var hash: UInt64 = 5381
-        for byte in string.utf8 {
-            hash = hash &* 33 &+ UInt64(byte)
-        }
-        return Int(hash % UInt64(Int.max))
-    }
-
-    /// Converts `mxc://server_name/media_id` to Matrix media thumbnail URL.
-    /// Uses the server_name from the mxc URI as the media host.
-    private static func mxcToHTTPS(_ mxc: String) -> URL? {
-        guard mxc.hasPrefix("mxc://") else { return nil }
-        let path = String(mxc.dropFirst(6)) // "server_name/media_id"
-        guard let slashIndex = path.firstIndex(of: "/") else { return nil }
-        let serverName = path[path.startIndex..<slashIndex]
-        return URL(string: "https://\(serverName)/_matrix/media/v3/thumbnail/\(path)?width=96&height=96&method=crop")
     }
 }

--- a/Zyna/Screens/Rooms/RoomModel.swift
+++ b/Zyna/Screens/Rooms/RoomModel.swift
@@ -14,9 +14,11 @@ struct RoomModel {
     let timestamp: String
     let avatarURL: URL?
     let avatarColor: UIColor
-    let isOnline: Bool
+    var isOnline: Bool
+    var lastSeen: Date?
     let unreadCount: Int
     let avatarInitials: String
+    let directUserId: String?
 }
 
 extension RoomModel {
@@ -40,8 +42,10 @@ extension RoomModel {
             avatarURL: room.avatarURL.flatMap { Self.mxcToHTTPS($0) },
             avatarColor: Self.avatarColors[Self.stableHash(room.id) % Self.avatarColors.count],
             isOnline: false,
+            lastSeen: nil,
             unreadCount: Int(room.unreadCount),
-            avatarInitials: String(initials.prefix(2))
+            avatarInitials: String(initials.prefix(2)),
+            directUserId: room.directUserId
         )
     }
 

--- a/Zyna/Screens/Rooms/RoomsCellNode.swift
+++ b/Zyna/Screens/Rooms/RoomsCellNode.swift
@@ -8,7 +8,7 @@ import AsyncDisplayKit
 class RoomsCellNode: ASCellNode {
 
     private let chat: RoomModel
-    private let avatarImageNode = ASNetworkImageNode()
+    private let avatarImageNode = ASImageNode()
     private let avatarBackgroundNode = ASDisplayNode()
     private let avatarTextNode = ASTextNode()
     private let nameNode = ASTextNode()
@@ -27,30 +27,28 @@ class RoomsCellNode: ASCellNode {
         setupNodes()
     }
 
-    private var hasAvatar: Bool { chat.avatarURL != nil }
-
     private func setupNodes() {
         // Avatar background (colored circle with initials as fallback)
-        avatarBackgroundNode.backgroundColor = chat.avatarColor
+        avatarBackgroundNode.backgroundColor = chat.avatar.color
         avatarBackgroundNode.cornerRadius = 25
         avatarBackgroundNode.borderWidth = 0.5
         avatarBackgroundNode.borderColor = UIColor.separator.cgColor
 
         avatarTextNode.attributedText = NSAttributedString(
-            string: chat.avatarInitials,
+            string: chat.avatar.initials,
             attributes: [
                 .font: UIFont.systemFont(ofSize: 18, weight: .medium),
                 .foregroundColor: UIColor.white
             ]
         )
 
-        // Avatar image (network loaded, shown on top if URL exists)
-        if let url = chat.avatarURL {
-            avatarImageNode.url = url
-            avatarImageNode.cornerRadius = 25
-            avatarImageNode.clipsToBounds = true
-            avatarImageNode.contentMode = .scaleAspectFill
-            avatarImageNode.shouldRenderProgressImages = false
+        // Avatar image (authenticated media, loaded async)
+        avatarImageNode.cornerRadius = 25
+        avatarImageNode.clipsToBounds = true
+        avatarImageNode.contentMode = .scaleAspectFill
+        avatarImageNode.isLayerBacked = true
+        if chat.avatar.mxcAvatarURL != nil {
+            loadAvatarImage()
         }
 
         // Name
@@ -107,16 +105,21 @@ class RoomsCellNode: ASCellNode {
         separatorNode.backgroundColor = UIColor.separator
     }
 
-    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        // Avatar: colored background with centered initials, image overlaid if available
-        avatarBackgroundNode.style.preferredSize = CGSize(width: 50, height: 50)
-        let initials = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: .minimumXY, child: avatarTextNode)
-        var avatar: ASLayoutSpec = ASOverlayLayoutSpec(child: avatarBackgroundNode, overlay: initials)
-
-        if hasAvatar {
-            avatarImageNode.style.preferredSize = CGSize(width: 50, height: 50)
-            avatar = ASOverlayLayoutSpec(child: avatar, overlay: avatarImageNode)
+    private func loadAvatarImage() {
+        guard let mxc = chat.avatar.mxcAvatarURL else { return }
+        Task { @MainActor in
+            guard let image = await MediaCache.shared.loadThumbnail(mxcUrl: mxc, size: 100) else { return }
+            self.avatarImageNode.image = image
         }
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        // Avatar: colored background with centered initials, image overlaid on top
+        avatarBackgroundNode.style.preferredSize = CGSize(width: 50, height: 50)
+        avatarImageNode.style.preferredSize = CGSize(width: 50, height: 50)
+        let initials = ASCenterLayoutSpec(centeringOptions: .XY, sizingOptions: .minimumXY, child: avatarTextNode)
+        let withInitials = ASOverlayLayoutSpec(child: avatarBackgroundNode, overlay: initials)
+        let avatar: ASLayoutSpec = ASOverlayLayoutSpec(child: withInitials, overlay: avatarImageNode)
 
         // Avatar with optional online indicator
         let avatarSection: ASLayoutSpec

--- a/Zyna/Screens/Rooms/RoomsController.swift
+++ b/Zyna/Screens/Rooms/RoomsController.swift
@@ -60,6 +60,16 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.registerPresence()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        viewModel.unregisterPresence()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Zyna/Screens/Rooms/RoomsViewModel.swift
+++ b/Zyna/Screens/Rooms/RoomsViewModel.swift
@@ -23,8 +23,47 @@ final class RoomsViewModel {
                 return summaries.map { RoomModel(from: $0) }
             }
             .receive(on: DispatchQueue.main)
-            .assign(to: &$chats)
+            .sink { [weak self] rooms in
+                self?.chats = rooms
+                self?.syncRegistration()
+            }
+            .store(in: &cancellables)
+
+        PresenceTracker.shared.$statuses
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] statuses in
+                self?.applyPresence(statuses)
+            }
+            .store(in: &cancellables)
     }
+
+    // MARK: - Presence
+
+    func registerPresence() {
+        syncRegistration()
+    }
+
+    func unregisterPresence() {
+        PresenceTracker.shared.unregister(for: "rooms")
+    }
+
+    private func syncRegistration() {
+        let userIds = chats.compactMap { $0.directUserId }
+        PresenceTracker.shared.register(userIds: userIds, for: "rooms")
+    }
+
+    private func applyPresence(_ statuses: [String: UserPresence]) {
+        guard !statuses.isEmpty else { return }
+        chats = chats.map { chat in
+            guard let userId = chat.directUserId, let status = statuses[userId] else { return chat }
+            var updated = chat
+            updated.isOnline = status.online
+            updated.lastSeen = status.lastSeen
+            return updated
+        }
+    }
+
+    // MARK: - Actions
 
     func selectChat(at index: Int) {
         guard index < chats.count else { return }

--- a/Zyna/Services/Authentication/AuthenticationService.swift
+++ b/Zyna/Services/Authentication/AuthenticationService.swift
@@ -49,7 +49,7 @@ struct SessionData: Codable {
     let oidcData: String?
 }
 
-private let keychainLog = ScopedLog(.keychain)
+private let logKeychain = ScopedLog(.keychain)
 
 // MARK: - Session Delegate
 
@@ -93,18 +93,18 @@ final class DefaultSessionDelegate: ClientSessionDelegate {
             let data = try encoder.encode(sessionData)
             let dataString = String(data: data, encoding: .utf8) ?? ""
             try keychain.set(dataString, key: session.userId)
-            keychainLog("Session saved for user: \(session.userId)")
+            logKeychain("Session saved for user: \(session.userId)")
         } catch {
-            keychainLog("Failed to save session: \(error)")
+            logKeychain("Failed to save session: \(error)")
         }
     }
 
     func clearSession(userId: String) {
         do {
             try keychain.remove(userId)
-            keychainLog("Session cleared for user: \(userId)")
+            logKeychain("Session cleared for user: \(userId)")
         } catch {
-            keychainLog("Failed to clear session: \(error)")
+            logKeychain("Failed to clear session: \(error)")
         }
     }
 }

--- a/Zyna/Services/Call/CallKitService.swift
+++ b/Zyna/Services/Call/CallKitService.swift
@@ -7,7 +7,7 @@ import Foundation
 import CallKit
 import AVFoundation
 
-private let callLog = ScopedLog(.call)
+private let logCall = ScopedLog(.call)
 
 // MARK: - CallKit Service
 
@@ -55,9 +55,9 @@ final class CallKitService: NSObject {
 
         provider.reportNewIncomingCall(with: uuid, update: update) { error in
             if let error {
-                callLog("Failed to report incoming call: \(error)")
+                logCall("Failed to report incoming call: \(error)")
             } else {
-                callLog("Reported incoming call to CallKit (uuid: \(uuid))")
+                logCall("Reported incoming call to CallKit (uuid: \(uuid))")
             }
         }
     }
@@ -74,9 +74,9 @@ final class CallKitService: NSObject {
 
         callController.request(CXTransaction(action: startAction)) { error in
             if let error {
-                callLog("Failed to start outgoing call: \(error)")
+                logCall("Failed to start outgoing call: \(error)")
             } else {
-                callLog("Started outgoing call in CallKit (uuid: \(uuid))")
+                logCall("Started outgoing call in CallKit (uuid: \(uuid))")
             }
         }
 
@@ -121,9 +121,9 @@ final class CallKitService: NSObject {
         do {
             try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth])
             try session.setActive(true)
-            callLog("Audio session configured for voice call")
+            logCall("Audio session configured for voice call")
         } catch {
-            callLog("Failed to configure audio session: \(error)")
+            logCall("Failed to configure audio session: \(error)")
         }
     }
 
@@ -132,7 +132,7 @@ final class CallKitService: NSObject {
         do {
             try session.setActive(false, options: .notifyOthersOnDeactivation)
         } catch {
-            callLog("Failed to deactivate audio session: \(error)")
+            logCall("Failed to deactivate audio session: \(error)")
         }
     }
 }
@@ -142,20 +142,20 @@ final class CallKitService: NSObject {
 extension CallKitService: CXProviderDelegate {
 
     func providerDidReset(_ provider: CXProvider) {
-        callLog("CallKit provider did reset")
+        logCall("CallKit provider did reset")
         currentCallUUID = nil
         deactivateAudioSession()
     }
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
-        callLog("CallKit: answer call")
+        logCall("CallKit: answer call")
         configureAudioSession()
         onAnswerCall?()
         action.fulfill()
     }
 
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
-        callLog("CallKit: end call")
+        logCall("CallKit: end call")
         onEndCall?()
         deactivateAudioSession()
         currentCallUUID = nil
@@ -163,16 +163,16 @@ extension CallKitService: CXProviderDelegate {
     }
 
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
-        callLog("CallKit: mute = \(action.isMuted)")
+        logCall("CallKit: mute = \(action.isMuted)")
         onMuteToggle?(action.isMuted)
         action.fulfill()
     }
 
     func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
-        callLog("CallKit: audio session activated")
+        logCall("CallKit: audio session activated")
     }
 
     func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
-        callLog("CallKit: audio session deactivated")
+        logCall("CallKit: audio session deactivated")
     }
 }

--- a/Zyna/Services/Call/CallService.swift
+++ b/Zyna/Services/Call/CallService.swift
@@ -8,7 +8,7 @@ import Combine
 import MatrixRustSDK
 import AVFoundation
 
-private let callLog = ScopedLog(.call)
+private let logCall = ScopedLog(.call)
 
 // MARK: - Call Service Delegate (WebRTC integration point)
 
@@ -61,7 +61,7 @@ final class CallService {
     /// After calling this, provide the SDP offer via `sendOffer(sdp:)`.
     func startCall(room: Room, timelineService: TimelineService) {
         guard !state.isActive else {
-            callLog("Cannot start call: already active")
+            logCall("Cannot start call: already active")
             return
         }
 
@@ -76,7 +76,7 @@ final class CallService {
 
         configureAudioSession()
         stateSubject.send(.outgoingRinging(callId: callId, roomId: room.id()))
-        callLog("Starting outgoing call \(callId) in room \(room.id())")
+        logCall("Starting outgoing call \(callId) in room \(room.id())")
 
         startRingTimeout(callId: callId)
     }
@@ -84,7 +84,7 @@ final class CallService {
     /// Send SDP offer to the remote peer (called by WebRTC layer after creating offer).
     func sendOffer(sdp: String) async {
         guard case .outgoingRinging(let callId, _) = state else {
-            callLog("Cannot send offer: not in outgoingRinging state")
+            logCall("Cannot send offer: not in outgoingRinging state")
             return
         }
 
@@ -92,7 +92,7 @@ final class CallService {
         do {
             try await signalingService?.sendInvite(content)
         } catch {
-            callLog("Failed to send offer: \(error)")
+            logCall("Failed to send offer: \(error)")
             endCall(reason: .normal)
         }
     }
@@ -100,7 +100,7 @@ final class CallService {
     /// Send SDP answer to the remote peer (called by WebRTC layer after creating answer).
     func sendAnswer(sdp: String) async {
         guard let callId = state.callId else {
-            callLog("Cannot send answer: no active call")
+            logCall("Cannot send answer: no active call")
             return
         }
 
@@ -111,7 +111,7 @@ final class CallService {
                 stateSubject.send(.connecting(callId: cid, roomId: rid))
             }
         } catch {
-            callLog("Failed to send answer: \(error)")
+            logCall("Failed to send answer: \(error)")
             endCall(reason: .normal)
         }
     }
@@ -124,7 +124,7 @@ final class CallService {
         do {
             try await signalingService?.sendCandidates(content)
         } catch {
-            callLog("Failed to send ICE candidates: \(error)")
+            logCall("Failed to send ICE candidates: \(error)")
         }
     }
 
@@ -134,21 +134,21 @@ final class CallService {
 
         cancelRingTimeout()
         stateSubject.send(.connected(callId: callId, roomId: roomId))
-        callLog("Call \(callId) connected")
+        logCall("Call \(callId) connected")
     }
 
     // MARK: - Accept Incoming Call
 
     func acceptCall() {
         guard case .incomingRinging(let callId, let roomId, _) = state else {
-            callLog("Cannot accept: not in incomingRinging state")
+            logCall("Cannot accept: not in incomingRinging state")
             return
         }
 
         cancelRingTimeout()
         configureAudioSession()
         stateSubject.send(.connecting(callId: callId, roomId: roomId))
-        callLog("Accepted call \(callId)")
+        logCall("Accepted call \(callId)")
     }
 
     // MARK: - End Call
@@ -172,7 +172,7 @@ final class CallService {
         deactivateAudioSession()
 
         stateSubject.send(.ended(callId: callId, reason: reason))
-        callLog("Call \(callId) ended: \(reason.rawValue)")
+        logCall("Call \(callId) ended: \(reason.rawValue)")
 
         // Reset to idle after a short delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
@@ -186,7 +186,7 @@ final class CallService {
 
     func handleIncomingCall(room: Room, callId: String, callerName: String?, offerSDP: String?, timelineService: TimelineService) {
         guard !state.isActive else {
-            callLog("Ignoring incoming call: already active")
+            logCall("Ignoring incoming call: already active")
             // TODO: Send busy hangup
             return
         }
@@ -200,12 +200,12 @@ final class CallService {
         signaling.subscribe(to: timelineService)
 
         stateSubject.send(.incomingRinging(callId: callId, roomId: room.id(), callerName: callerName))
-        callLog("Incoming call \(callId) from \(callerName ?? "unknown") in room \(room.id())")
+        logCall("Incoming call \(callId) from \(callerName ?? "unknown") in room \(room.id())")
 
         // Deliver offer SDP directly — the invite event was already published
         // before signaling subscribed (PassthroughSubject race condition)
         if let sdp = offerSDP {
-            callLog("Delivering offer SDP directly (\(sdp.count) bytes)")
+            logCall("Delivering offer SDP directly (\(sdp.count) bytes)")
             delegate?.callService(self, didReceiveOffer: sdp, callId: callId)
         }
 
@@ -261,7 +261,7 @@ final class CallService {
             guard self?.state.callId == callId else { return }
 
             await MainActor.run {
-                callLog("Call \(callId) timed out")
+                logCall("Call \(callId) timed out")
                 self?.endCall(reason: .timeout)
             }
         }
@@ -279,9 +279,9 @@ final class CallService {
         do {
             try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth])
             try session.setActive(true)
-            callLog("Audio session configured")
+            logCall("Audio session configured")
         } catch {
-            callLog("Failed to configure audio session: \(error)")
+            logCall("Failed to configure audio session: \(error)")
         }
     }
 
@@ -289,9 +289,9 @@ final class CallService {
         let session = AVAudioSession.sharedInstance()
         do {
             try session.setActive(false, options: .notifyOthersOnDeactivation)
-            callLog("Audio session deactivated")
+            logCall("Audio session deactivated")
         } catch {
-            callLog("Failed to deactivate audio session: \(error)")
+            logCall("Failed to deactivate audio session: \(error)")
         }
     }
 }

--- a/Zyna/Services/Call/CallSignalingService.swift
+++ b/Zyna/Services/Call/CallSignalingService.swift
@@ -7,7 +7,7 @@ import Foundation
 import Combine
 import MatrixRustSDK
 
-private let callLog = ScopedLog(.call)
+private let logCall = ScopedLog(.call)
 
 // MARK: - Call Signaling Service
 
@@ -52,34 +52,34 @@ final class CallSignalingService {
                 self?.processItems(items)
             }
             .store(in: &cancellables)
-        callLog("Signaling subscribed to TimelineService for room \(roomId)")
+        logCall("Signaling subscribed to TimelineService for room \(roomId)")
     }
 
     // MARK: - Send Events
 
     func sendInvite(_ content: CallInviteContent) async throws {
         guard let json = CallEventJSON.encode(content) else {
-            callLog("Failed to encode call invite")
+            logCall("Failed to encode call invite")
             return
         }
         // Send as native m.call.invite — SDK delivers as .callInvite in timeline
         try await room.sendRaw(eventType: "m.call.invite", content: json)
-        callLog("Sent m.call.invite (callId: \(content.callId))")
+        logCall("Sent m.call.invite (callId: \(content.callId))")
     }
 
     func sendAnswer(_ content: CallAnswerContent) async throws {
         try await sendViaTimeline(type: "m.call.answer", content: content)
-        callLog("Sent m.call.answer (callId: \(content.callId))")
+        logCall("Sent m.call.answer (callId: \(content.callId))")
     }
 
     func sendCandidates(_ content: CallCandidatesContent) async throws {
         try await sendViaTimeline(type: "m.call.candidates", content: content)
-        callLog("Sent m.call.candidates (callId: \(content.callId), count: \(content.candidates.count))")
+        logCall("Sent m.call.candidates (callId: \(content.callId), count: \(content.candidates.count))")
     }
 
     func sendHangup(_ content: CallHangupContent) async throws {
         try await sendViaTimeline(type: "m.call.hangup", content: content)
-        callLog("Sent m.call.hangup (callId: \(content.callId))")
+        logCall("Sent m.call.hangup (callId: \(content.callId))")
     }
 
     // MARK: - Stop
@@ -87,7 +87,7 @@ final class CallSignalingService {
     func stop() {
         cancellables.removeAll()
         timelineService = nil
-        callLog("Signaling stopped for room \(roomId)")
+        logCall("Signaling stopped for room \(roomId)")
     }
 
     // MARK: - Private — Send
@@ -144,16 +144,16 @@ final class CallSignalingService {
     /// Handle native m.call.invite (delivered as .callInvite by SDK)
     private func handleCallInvite(_ event: EventTimelineItem) {
         guard let contentDict = extractEventContent(event) else {
-            callLog("Failed to extract content from call invite")
+            logCall("Failed to extract content from call invite")
             return
         }
 
         guard let content = CallEventJSON.decode(CallInviteContent.self, from: contentDict) else {
-            callLog("Failed to decode CallInviteContent from raw JSON")
+            logCall("Failed to decode CallInviteContent from raw JSON")
             return
         }
 
-        callLog("Received call invite: callId=\(content.callId), sdp=\(content.offer.sdp.count) bytes")
+        logCall("Received call invite: callId=\(content.callId), sdp=\(content.offer.sdp.count) bytes")
         incomingEventSubject.send(.invite(content))
     }
 
@@ -167,14 +167,14 @@ final class CallSignalingService {
         let type = String(payload[payload.startIndex..<colonIndex])
         let jsonString = String(payload[payload.index(after: colonIndex)...])
 
-        callLog("Received signaling via text: \(type)")
+        logCall("Received signaling via text: \(type)")
         parseCallData(type: type, jsonString: jsonString)
     }
 
     /// Handle legacy/failedToParse call events (from other clients using VoIP v1, etc.)
     private func handleLegacyCallEvent(_ event: EventTimelineItem, eventType: String) {
         guard let contentDict = extractEventContent(event) else { return }
-        callLog("Parsed legacy call event type: \(eventType)")
+        logCall("Parsed legacy call event type: \(eventType)")
         parseCallData(type: eventType, dict: contentDict)
     }
 
@@ -190,17 +190,17 @@ final class CallSignalingService {
         switch type {
         case "m.call.answer":
             guard let content = CallEventJSON.decode(CallAnswerContent.self, from: dict) else { return }
-            callLog("Received call answer: callId=\(content.callId)")
+            logCall("Received call answer: callId=\(content.callId)")
             incomingEventSubject.send(.answer(content))
 
         case "m.call.candidates":
             guard let content = CallEventJSON.decode(CallCandidatesContent.self, from: dict) else { return }
-            callLog("Received ICE candidates: callId=\(content.callId), count=\(content.candidates.count)")
+            logCall("Received ICE candidates: callId=\(content.callId), count=\(content.candidates.count)")
             incomingEventSubject.send(.candidates(content))
 
         case "m.call.hangup":
             guard let content = CallEventJSON.decode(CallHangupContent.self, from: dict) else { return }
-            callLog("Received call hangup: callId=\(content.callId)")
+            logCall("Received call hangup: callId=\(content.callId)")
             incomingEventSubject.send(.hangup(content))
 
         default:

--- a/Zyna/Services/Call/WebRTC/WebRTCClient.swift
+++ b/Zyna/Services/Call/WebRTC/WebRTCClient.swift
@@ -7,7 +7,7 @@ import Foundation
 import Combine
 import WebRTC
 
-private let callLog = ScopedLog(.call)
+private let logCall = ScopedLog(.call)
 
 // MARK: - WebRTC Client
 
@@ -82,7 +82,7 @@ final class WebRTCClient: NSObject {
             // User accepted incoming call — process buffered offer
             if let sdp = pendingOfferSDP {
                 pendingOfferSDP = nil
-                callLog("User accepted — processing buffered offer")
+                logCall("User accepted — processing buffered offer")
                 Task { await handleRemoteOffer(sdp: sdp) }
             }
 
@@ -98,7 +98,7 @@ final class WebRTCClient: NSObject {
 
     private func createOfferAndSend() async {
         guard peerConnection == nil else {
-            callLog("Ignoring duplicate createOffer — peer connection already exists")
+            logCall("Ignoring duplicate createOffer — peer connection already exists")
             return
         }
 
@@ -111,11 +111,11 @@ final class WebRTCClient: NSObject {
             let offer = try await pc.offer(for: WebRTCAudioConfig.offerConstraints)
             try await pc.setLocalDescription(offer)
 
-            callLog("Created SDP offer (\(offer.sdp.count) bytes)")
+            logCall("Created SDP offer (\(offer.sdp.count) bytes)")
             await callService?.sendOffer(sdp: offer.sdp)
             flushLocalCandidates()
         } catch {
-            callLog("Failed to create offer: \(error)")
+            logCall("Failed to create offer: \(error)")
             callService?.endCall(reason: .normal)
         }
     }
@@ -125,7 +125,7 @@ final class WebRTCClient: NSObject {
     private func handleRemoteOffer(sdp: String) async {
         // Guard against duplicate offers — only create if no active peer connection
         guard peerConnection == nil else {
-            callLog("Ignoring duplicate offer — peer connection already exists")
+            logCall("Ignoring duplicate offer — peer connection already exists")
             return
         }
 
@@ -143,11 +143,11 @@ final class WebRTCClient: NSObject {
             let answer = try await pc.answer(for: WebRTCAudioConfig.offerConstraints)
             try await pc.setLocalDescription(answer)
 
-            callLog("Created SDP answer (\(answer.sdp.count) bytes)")
+            logCall("Created SDP answer (\(answer.sdp.count) bytes)")
             await callService?.sendAnswer(sdp: answer.sdp)
             flushLocalCandidates()
         } catch {
-            callLog("Failed to handle offer / create answer: \(error)")
+            logCall("Failed to handle offer / create answer: \(error)")
             callService?.endCall(reason: .normal)
         }
     }
@@ -160,9 +160,9 @@ final class WebRTCClient: NSObject {
             try await peerConnection?.setRemoteDescription(remoteDesc)
             setHasRemoteDescription(true)
             processPendingICECandidates()
-            callLog("Set remote answer")
+            logCall("Set remote answer")
         } catch {
-            callLog("Failed to set remote answer: \(error)")
+            logCall("Failed to set remote answer: \(error)")
         }
     }
 
@@ -180,7 +180,7 @@ final class WebRTCClient: NSObject {
                 do {
                     try await peerConnection?.add(rtcCandidate)
                 } catch {
-                    callLog("Failed to add ICE candidate: \(error)")
+                    logCall("Failed to add ICE candidate: \(error)")
                 }
             } else {
                 pendingICECandidates.append(rtcCandidate)
@@ -201,7 +201,7 @@ final class WebRTCClient: NSObject {
         let config = WebRTCAudioConfig.peerConnectionConfig()
         let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
         peerConnection = factory.peerConnection(with: config, constraints: constraints, delegate: self)
-        callLog("Peer connection created")
+        logCall("Peer connection created")
     }
 
     // MARK: - Audio Track
@@ -213,7 +213,7 @@ final class WebRTCClient: NSObject {
         localAudioTrack = audioTrack
 
         peerConnection?.add(audioTrack, streamIds: ["local_stream"])
-        callLog("Local audio track added")
+        logCall("Local audio track added")
 
         // Configure audio gain after a short delay for sender parameters to settle
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
@@ -231,7 +231,7 @@ final class WebRTCClient: NSObject {
                 encoding.minBitrateBps = NSNumber(value: 64_000)
             }
             transceiver.sender.parameters = parameters
-            callLog("Audio gain configured (64-128 kbps)")
+            logCall("Audio gain configured (64-128 kbps)")
             break
         }
     }
@@ -248,7 +248,7 @@ final class WebRTCClient: NSObject {
         let candidates = pendingICECandidates
         pendingICECandidates.removeAll()
 
-        callLog("Processing \(candidates.count) pending ICE candidates")
+        logCall("Processing \(candidates.count) pending ICE candidates")
 
         Task {
             for candidate in candidates {
@@ -271,7 +271,7 @@ final class WebRTCClient: NSObject {
         let candidates = pendingLocalCandidates
         pendingLocalCandidates.removeAll()
 
-        callLog("Flushing \(candidates.count) queued local ICE candidates")
+        logCall("Flushing \(candidates.count) queued local ICE candidates")
         Task {
             await callService?.sendICECandidates(candidates)
         }
@@ -294,11 +294,11 @@ final class WebRTCClient: NSObject {
 extension WebRTCClient: CallServiceDelegate {
 
     func callService(_ service: CallService, didReceiveOffer sdp: String, callId: String) {
-        callLog("Received remote offer for call \(callId) (state: \(service.state))")
+        logCall("Received remote offer for call \(callId) (state: \(service.state))")
 
         // For incoming calls: buffer the offer until user accepts (state → .connecting)
         if case .incomingRinging = service.state {
-            callLog("Buffering offer — waiting for user to accept")
+            logCall("Buffering offer — waiting for user to accept")
             pendingOfferSDP = sdp
             return
         }
@@ -307,17 +307,17 @@ extension WebRTCClient: CallServiceDelegate {
     }
 
     func callService(_ service: CallService, didReceiveAnswer sdp: String, callId: String) {
-        callLog("Received remote answer for call \(callId)")
+        logCall("Received remote answer for call \(callId)")
         Task { await handleRemoteAnswer(sdp: sdp) }
     }
 
     func callService(_ service: CallService, didReceiveICECandidates candidates: [ICECandidate], callId: String) {
-        callLog("Received \(candidates.count) remote ICE candidates")
+        logCall("Received \(candidates.count) remote ICE candidates")
         Task { await handleRemoteICECandidates(candidates) }
     }
 
     func callService(_ service: CallService, didEndCall callId: String, reason: CallHangupReason) {
-        callLog("Call ended: \(reason.rawValue)")
+        logCall("Call ended: \(reason.rawValue)")
         cleanup()
     }
 }
@@ -327,22 +327,22 @@ extension WebRTCClient: CallServiceDelegate {
 extension WebRTCClient: RTCPeerConnectionDelegate {
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {
-        callLog("Signaling state: \(stateChanged.rawValue)")
+        logCall("Signaling state: \(stateChanged.rawValue)")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
         for audioTrack in stream.audioTracks {
             audioTrack.isEnabled = true
         }
-        callLog("Remote stream added (audio tracks: \(stream.audioTracks.count))")
+        logCall("Remote stream added (audio tracks: \(stream.audioTracks.count))")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {
-        callLog("Remote stream removed")
+        logCall("Remote stream removed")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {
-        callLog("ICE connection state: \(newState.rawValue)")
+        logCall("ICE connection state: \(newState.rawValue)")
 
         switch newState {
         case .connected, .completed:
@@ -351,14 +351,14 @@ extension WebRTCClient: RTCPeerConnectionDelegate {
             }
 
         case .failed:
-            callLog("ICE failed — attempting restart")
+            logCall("ICE failed — attempting restart")
             peerConnection.restartIce()
 
         case .disconnected:
             // Wait briefly then restart if still in call
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
                 guard self?.callService?.state.isActive == true else { return }
-                callLog("ICE still disconnected — restarting")
+                logCall("ICE still disconnected — restarting")
                 peerConnection.restartIce()
             }
 
@@ -390,25 +390,25 @@ extension WebRTCClient: RTCPeerConnectionDelegate {
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {
-        callLog("ICE candidates removed: \(candidates.count)")
+        logCall("ICE candidates removed: \(candidates.count)")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {
-        callLog("ICE gathering state: \(newState.rawValue)")
+        logCall("ICE gathering state: \(newState.rawValue)")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didAdd rtpReceiver: RTCRtpReceiver) {
         if let track = rtpReceiver.track {
             track.isEnabled = true
-            callLog("RTP receiver added: \(track.kind)")
+            logCall("RTP receiver added: \(track.kind)")
         }
     }
 
     func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {
-        callLog("Renegotiation needed")
+        logCall("Renegotiation needed")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {
-        callLog("Data channel opened: \(dataChannel.label)")
+        logCall("Data channel opened: \(dataChannel.label)")
     }
 }

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -18,8 +18,8 @@ enum MatrixClientState {
     case error(Error)
 }
 
-private let authLog = ScopedLog(.auth)
-private let syncLog = ScopedLog(.sync)
+private let logAuth = ScopedLog(.auth)
+private let logSync = ScopedLog(.sync)
 
 // MARK: - Matrix Client Service
 
@@ -119,14 +119,14 @@ final class MatrixClientService {
             let session = try client.session()
             sessionDelegate.saveSessionInKeychain(session: session)
 
-            authLog("Logged in as \(userId)")
+            logAuth("Logged in as \(userId)")
 
             self.client = client
             stateSubject.send(.loggedIn)
 
             try await startSync()
         } catch {
-            authLog("Login failed: \(error)")
+            logAuth("Login failed: \(error)")
             stateSubject.send(.error(error))
             throw error
         }
@@ -136,7 +136,7 @@ final class MatrixClientService {
 
     func restoreSession() async throws {
         guard let userId = UserDefaults.standard.string(forKey: userIdKey) else {
-            authLog("No stored userId found")
+            logAuth("No stored userId found")
             throw AuthenticationError.sessionNotFound
         }
 
@@ -156,14 +156,14 @@ final class MatrixClientService {
                 .build()
 
             try await client.restoreSession(session: session)
-            authLog("Session restored for \(userId)")
+            logAuth("Session restored for \(userId)")
 
             self.client = client
             stateSubject.send(.loggedIn)
 
             try await startSync()
         } catch {
-            authLog("Session restore failed: \(error)")
+            logAuth("Session restore failed: \(error)")
             stateSubject.send(.error(error))
             throw error
         }
@@ -182,14 +182,14 @@ final class MatrixClientService {
 
         await syncService.start()
         stateSubject.send(.syncing)
-        syncLog("Sync started")
+        logSync("Sync started")
     }
 
     func stopSync() async {
         await syncService?.stop()
         syncService = nil
         roomListService = nil
-        syncLog("Sync stopped")
+        logSync("Sync stopped")
     }
 
     // MARK: - Logout
@@ -202,7 +202,7 @@ final class MatrixClientService {
             try? await client.logout()
             sessionDelegate.clearSession(userId: userId)
             UserDefaults.standard.removeObject(forKey: userIdKey)
-            authLog("Logged out")
+            logAuth("Logged out")
         }
 
         self.client = nil
@@ -266,7 +266,7 @@ final class MatrixClientService {
         let session = try client.session()
         sessionDelegate.saveSessionInKeychain(session: session)
 
-        authLog("OIDC login successful as \(userId)")
+        logAuth("OIDC login successful as \(userId)")
 
         self.client = client
         stateSubject.send(.loggedIn)

--- a/Zyna/Services/MediaCache.swift
+++ b/Zyna/Services/MediaCache.swift
@@ -49,6 +49,20 @@ final class MediaCache {
         }
     }
 
+    func loadThumbnail(mxcUrl: String, size: Int) async -> UIImage? {
+        let key = mxcUrl as NSString
+
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        guard let source = try? MediaSource.fromUrl(url: mxcUrl) else { return nil }
+        let px = UInt64(size)
+        guard let image = await loadThumbnail(source: source, width: px, height: px) else { return nil }
+        cache.setObject(image, forKey: key)
+        return image
+    }
+
     // MARK: - Private
 
     private func cacheKey(_ source: MediaSource) -> NSString {

--- a/Zyna/Services/Presence/PresenceService.swift
+++ b/Zyna/Services/Presence/PresenceService.swift
@@ -1,0 +1,124 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import CryptoKit
+
+private let logPresence = ScopedLog(.presence)
+
+struct UserPresence {
+    let online: Bool
+    let lastSeen: Date?
+}
+
+final class PresenceService {
+
+    static let shared = PresenceService()
+
+    // TODO: Move to config / environment before production
+    private let baseURL = "http://localhost:8080"
+    private let hmacSecret = "my-test-secret"
+
+    private var heartbeatTask: Task<Void, Never>?
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    private static let isoDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private init() {}
+
+    // MARK: - Heartbeat
+
+    func startHeartbeatLoop(userId: String) {
+        stopHeartbeatLoop()
+        logPresence("Heartbeat loop started for \(userId)")
+        heartbeatTask = Task {
+            while !Task.isCancelled {
+                await sendHeartbeat(userId: userId)
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+    }
+
+    func stopHeartbeatLoop() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        logPresence("Heartbeat loop stopped")
+    }
+
+    private func sendHeartbeat(userId: String) async {
+        let encoded = userId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? userId
+        guard let url = URL(string: "\(baseURL)/presence/\(encoded)") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue(computeApiKey(), forHTTPHeaderField: "X-API-Key")
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            logPresence("Heartbeat → \(code)")
+        } catch {
+            logPresence("Heartbeat error: \(error)")
+        }
+    }
+
+    // MARK: - Batch Status
+
+    func batchStatus(userIds: [String]) async -> [String: UserPresence] {
+        logPresence("batchStatus requested for \(userIds.count) users: \(userIds)")
+        guard !userIds.isEmpty, let url = URL(string: "\(baseURL)/presence/status") else { return [:] }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(computeApiKey(), forHTTPHeaderField: "X-API-Key")
+        request.httpBody = try? JSONEncoder().encode(["user_ids": userIds])
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            logPresence("batchStatus response → \(code)")
+            let decoded = try Self.isoDecoder.decode(PresenceBatchResponse.self, from: data)
+            let result = decoded.users.mapValues { UserPresence(online: $0.online, lastSeen: $0.lastSeen) }
+            logPresence("batchStatus parsed: \(result.map { "\($0.key)=\($0.value.online)" }.joined(separator: ", "))")
+            return result
+        } catch {
+            logPresence("batchStatus error: \(error)")
+            return [:]
+        }
+    }
+
+    // MARK: - API Key
+
+    private func computeApiKey() -> String {
+        let dateString = Self.dateFormatter.string(from: Date())
+        let key = SymmetricKey(data: Data(hmacSecret.utf8))
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(dateString.utf8), using: key)
+        return Data(mac).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Response Models
+
+private struct PresenceBatchResponse: Decodable {
+    let users: [String: PresenceUserDTO]
+}
+
+private struct PresenceUserDTO: Decodable {
+    let online: Bool
+    let lastSeen: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case online
+        case lastSeen = "last_seen"
+    }
+}

--- a/Zyna/Services/Presence/PresenceTracker.swift
+++ b/Zyna/Services/Presence/PresenceTracker.swift
@@ -1,0 +1,68 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+
+private let logPresence = ScopedLog(.presence)
+
+/// Centralized presence tracker. ViewModels register which userIds they care about
+/// (identified by a tag). The tracker maintains a single polling loop and publishes
+/// a merged `statuses` dictionary that all subscribers read from.
+final class PresenceTracker {
+
+    static let shared = PresenceTracker()
+
+    @Published private(set) var statuses: [String: UserPresence] = [:]
+
+    private var registrations: [String: Set<String>] = [:]
+    private var pollingTask: Task<Void, Never>?
+
+    private init() {}
+
+    // MARK: - Registration
+
+    func register(userIds: [String], for tag: String) {
+        let incoming = Set(userIds)
+        guard registrations[tag] != incoming else { return }
+        registrations[tag] = incoming
+        logPresence("[\(tag)] registered \(userIds.count) users")
+        startPollingIfNeeded()
+        Task { await poll() }
+    }
+
+    func unregister(for tag: String) {
+        guard registrations[tag] != nil else { return }
+        registrations.removeValue(forKey: tag)
+        logPresence("[\(tag)] unregistered, active tags: \(registrations.keys.joined(separator: ", "))")
+        if registrations.isEmpty {
+            pollingTask?.cancel()
+            pollingTask = nil
+        }
+    }
+
+    // MARK: - Polling
+
+    private func startPollingIfNeeded() {
+        guard pollingTask == nil else { return }
+        pollingTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(15))
+                guard !Task.isCancelled else { return }
+                await self?.poll()
+            }
+        }
+    }
+
+    @MainActor
+    func poll() async {
+        let ids = Array(registrations.values.reduce(into: Set<String>()) { $0.formUnion($1) })
+        guard !ids.isEmpty else { return }
+        let result = await PresenceService.shared.batchStatus(userIds: ids)
+        for (id, presence) in result {
+            statuses[id] = presence
+        }
+    }
+}

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -132,10 +132,16 @@ final class ZynaRoomListService: NSObject {
 
                 let directUserId: String? = info.isDirect ? info.heroes.first?.userId : nil
 
+                var avatarURL = room.avatarUrl()
+                if avatarURL == nil, let partnerId = directUserId,
+                   let client = MatrixClientService.shared.client {
+                    avatarURL = (try? await client.getProfile(userId: partnerId))?.avatarUrl
+                }
+
                 summaries.append(RoomSummary(
                     id: room.id(),
                     displayName: room.displayName() ?? "Unknown",
-                    avatarURL: room.avatarUrl(),
+                    avatarURL: avatarURL,
                     lastMessage: lastMessage,
                     lastMessageTimestamp: lastTimestamp,
                     unreadCount: info.notificationCount,

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -17,6 +17,8 @@ struct RoomSummary: Identifiable {
     let lastMessageTimestamp: Date?
     let unreadCount: UInt64
     let isEncrypted: Bool
+    /// Matrix user ID of the other person in a DM room, nil for group rooms.
+    let directUserId: String?
 }
 
 private let roomsLog = ScopedLog(.rooms)
@@ -128,6 +130,8 @@ final class ZynaRoomListService: NSObject {
 
                 let (lastMessage, lastTimestamp) = Self.extractLastMessage(from: await room.latestEvent())
 
+                let directUserId: String? = info.isDirect ? info.heroes.first?.userId : nil
+
                 summaries.append(RoomSummary(
                     id: room.id(),
                     displayName: room.displayName() ?? "Unknown",
@@ -135,7 +139,8 @@ final class ZynaRoomListService: NSObject {
                     lastMessage: lastMessage,
                     lastMessageTimestamp: lastTimestamp,
                     unreadCount: info.notificationCount,
-                    isEncrypted: room.encryptionState() != .notEncrypted
+                    isEncrypted: room.encryptionState() != .notEncrypted,
+                    directUserId: directUserId
                 ))
             }
 

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -21,7 +21,7 @@ struct RoomSummary: Identifiable {
     let directUserId: String?
 }
 
-private let roomsLog = ScopedLog(.rooms)
+private let logRooms = ScopedLog(.rooms)
 
 // MARK: - Room List Service
 
@@ -51,7 +51,7 @@ final class ZynaRoomListService: NSObject {
     private func observeClientState() {
         matrixService.stateSubject
             .sink { [weak self] state in
-                roomsLog("Client state changed: \(state)")
+                logRooms("Client state changed: \(state)")
                 if case .syncing = state {
                     self?.startListening()
                 }
@@ -63,12 +63,12 @@ final class ZynaRoomListService: NSObject {
 
     private func startListening() {
         guard let sdkRoomListService = matrixService.roomListService else {
-            roomsLog("roomListService is nil, cannot start listening")
+            logRooms("roomListService is nil, cannot start listening")
             return
         }
 
         guard !isListening else {
-            roomsLog("Already listening, skipping")
+            logRooms("Already listening, skipping")
             return
         }
         isListening = true
@@ -76,7 +76,7 @@ final class ZynaRoomListService: NSObject {
 
         // Observe RoomListService state
         let stateListener = ServiceStateListener { state in
-            roomsLog("RoomListService state: \(state)")
+            logRooms("RoomListService state: \(state)")
         }
         self.serviceStateHandle = sdkRoomListService.state(listener: stateListener)
 
@@ -90,7 +90,7 @@ final class ZynaRoomListService: NSObject {
                     pageSize: 200,
                     listener: EntriesListener { [weak self] updates in
                         guard let self else { return }
-                        roomsLog("Received \(updates.count) room list entry updates")
+                        logRooms("Received \(updates.count) room list entry updates")
                         self.applyUpdates(updates)
                     }
                 )
@@ -101,14 +101,14 @@ final class ZynaRoomListService: NSObject {
 
                 // Observe loading state — store stateStream handle to keep it alive
                 let loadingResult = try roomList.loadingState(listener: LoadingStateListener { state in
-                    roomsLog("RoomList loading state: \(state)")
+                    logRooms("RoomList loading state: \(state)")
                 })
                 self.loadingStateStreamHandle = loadingResult.stateStream
-                roomsLog("Initial loading state: \(loadingResult.state)")
+                logRooms("Initial loading state: \(loadingResult.state)")
 
-                roomsLog("Room list listener started")
+                logRooms("Room list listener started")
             } catch {
-                roomsLog("Failed to start room list listener: \(error)")
+                logRooms("Failed to start room list listener: \(error)")
             }
         }
     }
@@ -121,7 +121,7 @@ final class ZynaRoomListService: NSObject {
         }
 
         let currentRooms = rooms
-        roomsLog("Room count after diffs: \(currentRooms.count)")
+        logRooms("Room count after diffs: \(currentRooms.count)")
 
         Task {
             var summaries: [RoomSummary] = []
@@ -148,7 +148,7 @@ final class ZynaRoomListService: NSObject {
                 self?.roomsSubject.send(summaries)
             }
 
-            roomsLog("Rooms updated: \(summaries.count) rooms")
+            logRooms("Rooms updated: \(summaries.count) rooms")
         }
     }
 

--- a/Zyna/Services/SessionVerificationService.swift
+++ b/Zyna/Services/SessionVerificationService.swift
@@ -35,7 +35,7 @@ enum VerificationStep: Equatable {
     }
 }
 
-private let verifyLog = ScopedLog(.auth)
+private let logVerify = ScopedLog(.auth)
 
 // MARK: - Session Verification Service
 
@@ -71,7 +71,7 @@ final class SessionVerificationService {
         controller.setDelegate(delegate: delegate)
         self.delegate = delegate
 
-        verifyLog("Verification controller ready")
+        logVerify("Verification controller ready")
     }
 
     private var delegate: VerificationDelegate?
@@ -82,25 +82,25 @@ final class SessionVerificationService {
         guard let controller else { throw VerificationError.controllerNotReady }
         stepSubject.send(.requestingVerification)
         try await controller.requestDeviceVerification()
-        verifyLog("Device verification requested")
+        logVerify("Device verification requested")
     }
 
     func approveVerification() async throws {
         guard let controller else { throw VerificationError.controllerNotReady }
         try await controller.approveVerification()
-        verifyLog("Verification approved")
+        logVerify("Verification approved")
     }
 
     func declineVerification() async throws {
         guard let controller else { throw VerificationError.controllerNotReady }
         try await controller.declineVerification()
-        verifyLog("Verification declined")
+        logVerify("Verification declined")
     }
 
     func cancelVerification() async throws {
         guard let controller else { throw VerificationError.controllerNotReady }
         try await controller.cancelVerification()
-        verifyLog("Verification cancelled")
+        logVerify("Verification cancelled")
     }
 }
 
@@ -133,11 +133,11 @@ private final class VerificationDelegate: SessionVerificationControllerDelegate 
     }
 
     func didReceiveVerificationRequest(details: SessionVerificationRequestDetails) {
-        verifyLog("Received verification request from \(details.deviceId)")
+        logVerify("Received verification request from \(details.deviceId)")
     }
 
     func didAcceptVerificationRequest() {
-        verifyLog("Verification request accepted, starting SAS")
+        logVerify("Verification request accepted, starting SAS")
         onStep(.waitingForAcceptance)
         Task {
             try? await controller?.startSasVerification()
@@ -145,13 +145,13 @@ private final class VerificationDelegate: SessionVerificationControllerDelegate 
     }
 
     func didStartSasVerification() {
-        verifyLog("SAS verification started, waiting for emojis")
+        logVerify("SAS verification started, waiting for emojis")
     }
 
     func didReceiveVerificationData(data: SessionVerificationData) {
         switch data {
         case .emojis(let emojis, _):
-            verifyLog("Received \(emojis.count) verification emojis")
+            logVerify("Received \(emojis.count) verification emojis")
             onStep(.showingEmojis(emojis))
         case .decimals:
             break
@@ -159,17 +159,17 @@ private final class VerificationDelegate: SessionVerificationControllerDelegate 
     }
 
     func didFail() {
-        verifyLog("Verification failed")
+        logVerify("Verification failed")
         onStep(.failed)
     }
 
     func didCancel() {
-        verifyLog("Verification cancelled")
+        logVerify("Verification cancelled")
         onStep(.cancelled)
     }
 
     func didFinish() {
-        verifyLog("Verification finished successfully")
+        logVerify("Verification finished successfully")
         onStep(.verified)
     }
 }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -7,7 +7,7 @@ import Foundation
 import Combine
 import MatrixRustSDK
 
-private let timelineLog = ScopedLog(.timeline)
+private let logTimeline = ScopedLog(.timeline)
 
 // MARK: - Timeline Service
 
@@ -42,9 +42,9 @@ final class TimelineService {
             }
             self.listenerHandle = await timeline.addListener(listener: listener)
 
-            timelineLog("Timeline listener started for room \(room.id())")
+            logTimeline("Timeline listener started for room \(room.id())")
         } catch {
-            timelineLog("Failed to start timeline: \(error)")
+            logTimeline("Failed to start timeline: \(error)")
         }
     }
 
@@ -86,7 +86,7 @@ final class TimelineService {
         // Forward raw diffs to the coalescer
         onDiffs?(diffs)
 
-        timelineLog("Timeline diffs forwarded: \(diffs.count) diffs")
+        logTimeline("Timeline diffs forwarded: \(diffs.count) diffs")
     }
 
     // MARK: - Map SDK Item -> ChatMessage
@@ -206,9 +206,9 @@ final class TimelineService {
 
         do {
             try await timeline.paginateBackwards(numEvents: 20)
-            timelineLog("Paginated backwards successfully")
+            logTimeline("Paginated backwards successfully")
         } catch {
-            timelineLog("Pagination failed: \(error)")
+            logTimeline("Pagination failed: \(error)")
         }
 
         await MainActor.run { isPaginatingSubject.send(false) }
@@ -220,9 +220,9 @@ final class TimelineService {
         guard let timeline else { return }
         do {
             try await timeline.send(msg: messageEventContentFromMarkdown(md: text))
-            timelineLog("Message sent")
+            logTimeline("Message sent")
         } catch {
-            timelineLog("Send failed: \(error)")
+            logTimeline("Send failed: \(error)")
         }
     }
 
@@ -238,9 +238,9 @@ final class TimelineService {
             _ = try timeline.sendVoiceMessage(
                 params: params, audioInfo: audioInfo, waveform: waveform
             )
-            timelineLog("Voice message sent, duration=\(String(format: "%.1f", duration))s")
+            logTimeline("Voice message sent, duration=\(String(format: "%.1f", duration))s")
         } catch {
-            timelineLog("Voice send failed: \(error)")
+            logTimeline("Voice send failed: \(error)")
         }
     }
 
@@ -249,7 +249,7 @@ final class TimelineService {
 
         let imageURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".jpg")
         do { try imageData.write(to: imageURL) } catch {
-            timelineLog("Image write to temp failed: \(error)")
+            logTimeline("Image write to temp failed: \(error)")
             return
         }
 
@@ -264,25 +264,25 @@ final class TimelineService {
         )
         do {
             _ = try timeline.sendFile(params: params, fileInfo: fileInfo)
-            timelineLog("Image sent via sendFile, \(width)×\(height)")
+            logTimeline("Image sent via sendFile, \(width)×\(height)")
         } catch {
-            timelineLog("Image send failed: \(error)")
+            logTimeline("Image send failed: \(error)")
         }
     }
 
     func redactEvent(_ itemId: ChatItemIdentifier, reason: String? = nil) async throws {
         guard let timeline else { return }
         try await timeline.redactEvent(eventOrTransactionId: itemId.toSDK(), reason: reason)
-        timelineLog("Redacted event \(itemId)")
+        logTimeline("Redacted event \(itemId)")
     }
 
     func toggleReaction(_ key: String, to itemId: ChatItemIdentifier) async {
         guard let timeline else { return }
         do {
             try await timeline.toggleReaction(itemId: itemId.toSDK(), key: key)
-            timelineLog("Toggled reaction \(key)")
+            logTimeline("Toggled reaction \(key)")
         } catch {
-            timelineLog("Toggle reaction failed: \(error)")
+            logTimeline("Toggle reaction failed: \(error)")
         }
     }
 
@@ -292,7 +292,7 @@ final class TimelineService {
         do {
             _ = try await timeline.send(msg: messageEventContentFromMarkdown(md: text))
         } catch {
-            timelineLog("Call signaling send failed: \(error)")
+            logTimeline("Call signaling send failed: \(error)")
         }
     }
 
@@ -318,7 +318,7 @@ final class TimelineService {
                   let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let content = dict["content"] as? [String: Any],
                   let callId = content["call_id"] as? String else {
-                timelineLog("Call invite detected but failed to extract callId")
+                logTimeline("Call invite detected but failed to extract callId")
                 continue
             }
 
@@ -336,7 +336,7 @@ final class TimelineService {
                 return nil
             }()
 
-            timelineLog("Incoming call invite detected: callId=\(callId) from \(callerName ?? event.sender), sdp=\(offerSDP?.count ?? 0) bytes")
+            logTimeline("Incoming call invite detected: callId=\(callId) from \(callerName ?? event.sender), sdp=\(offerSDP?.count ?? 0) bytes")
 
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }

--- a/Zyna/UIComponents/AvatarViewModel.swift
+++ b/Zyna/UIComponents/AvatarViewModel.swift
@@ -1,0 +1,63 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+struct AvatarViewModel {
+
+    let userId: String
+    let displayName: String?
+    let mxcAvatarURL: String?
+
+    var color: UIColor {
+        Self.colors[Self.stableHash(userId) % Self.colors.count]
+    }
+
+    var initials: String {
+        let name = displayName ?? userId
+        let cleaned = name.hasPrefix("@") ? String(name.dropFirst()) : name
+        let parts = cleaned
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(cleaned.prefix(2)).uppercased()
+    }
+
+    var avatarURL: URL? {
+        guard let mxc = mxcAvatarURL else { return nil }
+        return Self.mxcToHTTPS(mxc, size: 96)
+    }
+
+    func avatarURL(size: Int) -> URL? {
+        guard let mxc = mxcAvatarURL else { return nil }
+        return Self.mxcToHTTPS(mxc, size: size)
+    }
+
+    // MARK: - Private
+
+    private static let colors: [UIColor] = [
+        .systemBlue, .systemGreen, .systemOrange, .systemRed,
+        .systemPurple, .systemTeal, .systemIndigo, .systemPink
+    ]
+
+    /// djb2 hash — stable across app launches, unlike `hashValue`.
+    private static func stableHash(_ string: String) -> Int {
+        var hash: UInt64 = 5381
+        for byte in string.utf8 {
+            hash = hash &* 33 &+ UInt64(byte)
+        }
+        return Int(hash % UInt64(Int.max))
+    }
+
+    private static func mxcToHTTPS(_ mxc: String, size: Int) -> URL? {
+        guard mxc.hasPrefix("mxc://") else { return nil }
+        let path = String(mxc.dropFirst(6))
+        guard let slashIndex = path.firstIndex(of: "/") else { return nil }
+        let serverName = path[path.startIndex..<slashIndex]
+        return URL(string: "https://\(serverName)/_matrix/media/v3/thumbnail/\(path)?width=\(size)&height=\(size)&method=crop")
+    }
+}

--- a/Zyna/Utils/ScopedLog.swift
+++ b/Zyna/Utils/ScopedLog.swift
@@ -36,6 +36,7 @@ struct LogScope: OptionSet {
     static let call        = LogScope(rawValue: bit(9))
     static let displayLink      = LogScope(rawValue: bit(10))
     static let voiceRecording   = LogScope(rawValue: bit(11))
+    static let presence         = LogScope(rawValue: bit(12))
 
     // MARK: - Presets
 
@@ -51,7 +52,8 @@ struct LogScope: OptionSet {
         .ui,
         .call,
         .displayLink,
-        .voiceRecording
+        .voiceRecording,
+        .presence
     ]
 
     static let none: LogScope = []
@@ -76,7 +78,7 @@ enum LogConfig {
     /// - [.messageSend, .calls]
     /// - .all.subtracting(.network)
     /// - .all.subtracting([.network, .calls])
-    static var enabled: LogScope = Dmitry.calls
+    static var enabled: LogScope = [.presence, .rooms]
 
     static func enableAll() { enabled = .all }
     static func disableAll() { enabled = .none }
@@ -142,6 +144,7 @@ private extension LogScope {
         if contains(.call)       { names.append("call") }
         if contains(.displayLink){ names.append("displayLink") }
         if contains(.voiceRecording){ names.append("voiceRecording") }
+        if contains(.presence)      { names.append("presence") }
         return names.isEmpty ? "NONE" : names.joined(separator: "|")
     }
 }

--- a/Zyna/Utils/ScopedLog.swift
+++ b/Zyna/Utils/ScopedLog.swift
@@ -78,7 +78,7 @@ enum LogConfig {
     /// - [.messageSend, .calls]
     /// - .all.subtracting(.network)
     /// - .all.subtracting([.network, .calls])
-    static var enabled: LogScope = [.presence, .rooms]
+    static var enabled: LogScope = .all.subtracting(.presence)
 
     static func enableAll() { enabled = .all }
     static func disableAll() { enabled = .none }


### PR DESCRIPTION
## Summary
- Add real-time presence via custom `zyna-presence` server (Go + Redis): 
  daily-rotated HMAC-SHA256 API key, 10s heartbeat, 15s batch polling via 
  `PresenceTracker` singleton. Standard Matrix presence not used as matrix.org 
  has it disabled for federation.

- Online indicator in chat list and "online / last seen X min ago" in chat nav bar
- Profile screen for own account (edit name, change avatar) and other users 
  (view name, user ID, presence)
- Fix avatar loading: replaced unauthenticated media URLs with SDK-authenticated 
  requests (`client.getMediaThumbnail`) — fixes 404 on matrix.org (MSC3916)
- For DM rooms without explicit room avatar, fetch partner profile avatar 
  via `client.getProfile`
- Extract shared `AvatarViewModel` (color hash, initials, mxc URL handling)
- Extract `Date.presenceLastSeenString` to remove duplication