### PR TITLE
Stage 10: background history sync, in-chat search, custom message attributes, send-colour UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# Zyna — Instructions for Claude
+
+## Architecture
+- iOS messenger on top of matrix-rust-sdk via FFI (typed path)
+- UI: AsyncDisplayKit (Texture) throughout chat & lists
+- Persistence: GRDB as the UI source of truth; SDK Timeline diffs
+  flow into GRDB via TimelineDiffBatcher
+- Custom Zyna features travel via formatted_body HTML carrier
+  (see Messaging/ZynaHTMLCodec)
+
+## Performance principles
+
+This is a high-performance messenger. One of the core mindsets:
+**don't lose Texture's advantages** — study its APIs, understand
+what each one gives you, and lean on them rather than
+side-stepping into vanilla UIKit.
+
+**Main thread is sacred.** Anything that can run off-main should
+run off-main. That includes DB reads, JSON/text parsing, image
+decoding, model construction, sort/merge, and anything else that
+isn't strictly a UIKit call. Treat `DispatchQueue.main` as
+precious budget — spend it only on the actual UI mutation step.
+
+Texture-way is the default for anything rendered in cells:
+- Prefer `ASImageNode` with shared cached `UIImage`s over per-cell
+  `draw(_:withParameters:)` Core Graphics. Cell reuse is
+  aggressive; regenerating CGImages per reuse costs CPU. Render
+  once into a shared image, tint via `imageModificationBlock` or
+  template-rendering + `tintColor` for per-cell variations.
+- `draw(_:withParameters:isCancelled:isRasterizing:)` is a valid
+  Texture API for async rendering, but it's the right tool only
+  when the drawing is genuinely per-instance (unique content).
+- Never use UIView subclasses for drawing inside cell bodies —
+  they'd pull rendering onto the main thread.
+- Use `ASImageNode` for raster images, `ASTextNode` for text.
+- `CABasicAnimation` on layer transforms for runtime animation;
+  it runs on the GPU compositor and is cheap.
+- Background thread for pixel data (Texture), GPU for compositing.
+- Avoid main-thread CGContext drawing in scrolling paths.
+
+## Threading with Texture
+
+Texture calls some delegate methods on background queues
+**on purpose** — it gives you free concurrency so main stays
+smooth. Examples: `willBeginBatchFetchWith`,
+`nodeBlockForRowAt`, batch-fetch hooks, preloading callbacks.
+
+Rule for those entry points:
+1. Keep the heavy work (DB queries, parsing, model building,
+   merge/sort) on the bg queue Texture hands you.
+2. Marshal to main **only** for the UIKit-touching step:
+   table updates, `performBatchAnimated`, cell mutations,
+   observable state the UI subscribes to.
+
+Anti-pattern: wrapping the whole handler in
+`DispatchQueue.main.async { … }` — that throws away the bg
+capacity Texture gave you and moves GRDB reads to main. Split
+the work instead: bg query → (result) → main apply.
+
+## Pitfalls / lessons learned
+
+- **Never use self-rescheduling `DispatchQueue.main.async`
+  loops** to "wait until X is ready". They burn CPU if the
+  condition never flips. Use proper lifecycle hooks instead
+  (`didLoad()`, observation, closures called by framework).
+- **`SDK uniqueId` is not stable across Timeline recreation**
+  (opening/closing a chat gives the same event a new
+  `uniqueId`). TimelineDiffBatcher relies on collision
+  resolution by `eventId` for correctness.
+
+## Code style
+- Documentation comments ~72 chars wide (reads well side-by-side)
+- ScopedLog (ScopedLog.swift) for all logging — pick a scope
+  (.timeline, .database, .ui, etc.)
+- Prefer small pure functions + enums over class hierarchies
+- Tests: Swift Testing framework in ZynaTests target
+
+## Matrix SDK constraints
+- Using typed `timeline.send(msg:)` path — gives SendHandle with
+  `.abort()` and SDK-native retry/queue for free
+- `sendRaw` is NOT used for user messages (no cancel, no retry)
+- Custom event data rides in `formatted_body` as hidden
+  `<span data-zyna="{...}"></span>` — Zyna parses raw event JSON
+  (bypassing SDK's HTML sanitiser); other clients render only body
+- See ZynaMessageAttributes + ZynaHTMLCodec for the extensible
+  attribute system
+
+## File organization
+- `Chat/` — UI (ChatView, cells, input nodes)
+- `Core/` — infrastructure utilities (Concurrency, Network, Theme)
+- `Messaging/` — Zyna-specific domain (attributes, codec, sender)
+- `Services/` — SDK-facing services (MatrixClient, Timeline, Rooms)
+- `Services/Database/` — GRDB layer
+
+## Git / commits
+- Commit messages: conventional style (`feat:`, `fix:`, `chore:`,
+  `refactor:`)
+- Commit title ≤ 72 chars; body optional but welcome for context
+- User commits manually; Claude does NOT commit unless asked
+
+## On breaking these rules
+Every rule above is breakable — but not silently. If you believe
+a specific case warrants a deviation, stop and ask first, with:
+  1. Which rule you want to bend and why
+  2. Concrete evidence that the deviation doesn't hurt (e.g.
+     "UIView here is fine: the view is static, outside scroll
+     paths, and avoids a wrapper node for trivial drawing")
+  3. What you gain (simplicity, readability, fewer files)
+
+Never bend a rule without user confirmation. When in doubt,
+default to the stricter option.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,14 @@ precious budget — spend it only on the actual UI mutation step.
 Texture-way is the default for anything rendered in cells:
 - Prefer `ASImageNode` with shared cached `UIImage`s over per-cell
   `draw(_:withParameters:)` Core Graphics. Texture does not recycle
-  cells like UIKit — it creates a new ASCellNode per index path,
-  and recreates them on batch updates / reloads. A custom `draw()`
-  fires on every new node, which adds up during rapid scrolling.
-  A shared `UIImage` costs zero per node: just a pointer to the
-  same CGImage. Tint via `imageModificationBlock` or template-
-  rendering + `tintColor` for per-cell colour variations.
+  cells like UIKit — it creates a new ASCellNode per index path
+  and does not recycle them. Nodes are deallocated only when
+  removed from the container (via deletion or reloadData). A
+  custom `draw()` fires on every new node, which adds up during
+  rapid scrolling. A shared `UIImage` costs zero per node: just
+  a pointer to the same CGImage. Tint via `imageModificationBlock`
+  or template-rendering + `tintColor` for per-cell colour
+  variations.
 - `draw(_:withParameters:isCancelled:isRasterizing:)` is a valid
   Texture API for async rendering, but it's the right tool only
   when the drawing is genuinely per-instance (unique content).
@@ -66,6 +68,10 @@ the work instead: bg query → (result) → main apply.
   loops** to "wait until X is ready". They burn CPU if the
   condition never flips. Use proper lifecycle hooks instead
   (`didLoad()`, observation, closures called by framework).
+- **ASDisplayNode `init()` runs off-main**; `didLoad()` fires
+  when the backing UIView/CALayer is loaded. Put gesture
+  recognisers, `view`/`layer` configuration, and anything
+  that touches UIKit into `didLoad()`, never `init()`.
 - **`SDK uniqueId` is not stable across Timeline recreation**
   (opening/closing a chat gives the same event a new
   `uniqueId`). TimelineDiffBatcher relies on collision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,13 @@ precious budget — spend it only on the actual UI mutation step.
 
 Texture-way is the default for anything rendered in cells:
 - Prefer `ASImageNode` with shared cached `UIImage`s over per-cell
-  `draw(_:withParameters:)` Core Graphics. Cell reuse is
-  aggressive; regenerating CGImages per reuse costs CPU. Render
-  once into a shared image, tint via `imageModificationBlock` or
-  template-rendering + `tintColor` for per-cell variations.
+  `draw(_:withParameters:)` Core Graphics. Texture does not recycle
+  cells like UIKit — it creates a new ASCellNode per index path,
+  and recreates them on batch updates / reloads. A custom `draw()`
+  fires on every new node, which adds up during rapid scrolling.
+  A shared `UIImage` costs zero per node: just a pointer to the
+  same CGImage. Tint via `imageModificationBlock` or template-
+  rendering + `tintColor` for per-cell colour variations.
 - `draw(_:withParameters:isCancelled:isRasterizing:)` is a valid
   Texture API for async rendering, but it's the right tool only
   when the drawing is genuinely per-instance (unique content).
@@ -75,6 +78,16 @@ the work instead: bg query → (result) → main apply.
 - Prefer small pure functions + enums over class hierarchies
 - Tests: Swift Testing framework in ZynaTests target
 
+## Git / PR conventions
+- Commit messages: conventional style (`feat:`, `fix:`, `chore:`,
+  `refactor:`, `perf:`, `docs:`)
+- Commit title ≤ 72 chars; body optional but welcome for context
+- PR titles do NOT use conventional prefixes — just a clear
+  human-readable title (GitHub categorises PRs via labels/status)
+- PR descriptions are markdown rendered by GitHub — do NOT wrap
+  paragraphs at 72 chars there. Let GitHub handle reflow.
+  (The 72-char rule is for source-file comments only.)
+
 ## Matrix SDK constraints
 - Using typed `timeline.send(msg:)` path — gives SendHandle with
   `.abort()` and SDK-native retry/queue for free
@@ -92,10 +105,7 @@ the work instead: bg query → (result) → main apply.
 - `Services/` — SDK-facing services (MatrixClient, Timeline, Rooms)
 - `Services/Database/` — GRDB layer
 
-## Git / commits
-- Commit messages: conventional style (`feat:`, `fix:`, `chore:`,
-  `refactor:`)
-- Commit title ≤ 72 chars; body optional but welcome for context
+## Git behaviour
 - User commits manually; Claude does NOT commit unless asked
 
 ## On breaking these rules

--- a/Zyna.xcodeproj/project.pbxproj
+++ b/Zyna.xcodeproj/project.pbxproj
@@ -21,6 +21,16 @@
 		32F7D31A2E3EE41A009282C3 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 32F7D3192E3EE41A009282C3 /* KeychainAccess */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		326E0A972F81CA82008567E5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 324E194E2DAD578A00CB5769 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 324E19552DAD578A00CB5769;
+			remoteInfo = Zyna;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		322E76DA2DADAA72003921EC /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -44,6 +54,7 @@
 		322E76DE2DADAA8B003921EC /* PINOperation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PINOperation.xcframework; path = Carthage/Build/PINOperation.xcframework; sourceTree = "<group>"; };
 		322E76E12DADAA97003921EC /* PINRemoteImage.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PINRemoteImage.xcframework; path = Carthage/Build/PINRemoteImage.xcframework; sourceTree = "<group>"; };
 		324E19562DAD578A00CB5769 /* Zyna.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Zyna.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		326E0A932F81CA82008567E5 /* ZynaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZynaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		32A89B5E2DB46A3D0051DCE9 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -61,6 +72,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		326E0A942F81CA82008567E5 /* ZynaTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ZynaTests;
+			sourceTree = "<group>";
+		};
 		32ED2CC32F58F2580080ED2A /* Zyna */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -87,6 +103,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		326E0A902F81CA82008567E5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -107,6 +130,7 @@
 			children = (
 				32ED2CC32F58F2580080ED2A /* Zyna */,
 				32F7D3142E3E80DB009282C3 /* Secrets */,
+				326E0A942F81CA82008567E5 /* ZynaTests */,
 				322E76D62DADAA72003921EC /* Frameworks */,
 				324E19572DAD578A00CB5769 /* Products */,
 			);
@@ -116,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				324E19562DAD578A00CB5769 /* Zyna.app */,
+				326E0A932F81CA82008567E5 /* ZynaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -157,6 +182,29 @@
 			productReference = 324E19562DAD578A00CB5769 /* Zyna.app */;
 			productType = "com.apple.product-type.application";
 		};
+		326E0A922F81CA82008567E5 /* ZynaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 326E0A9B2F81CA82008567E5 /* Build configuration list for PBXNativeTarget "ZynaTests" */;
+			buildPhases = (
+				326E0A8F2F81CA82008567E5 /* Sources */,
+				326E0A902F81CA82008567E5 /* Frameworks */,
+				326E0A912F81CA82008567E5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				326E0A982F81CA82008567E5 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				326E0A942F81CA82008567E5 /* ZynaTests */,
+			);
+			name = ZynaTests;
+			packageProductDependencies = (
+			);
+			productName = ZynaTests;
+			productReference = 326E0A932F81CA82008567E5 /* ZynaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -164,12 +212,16 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 2630;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					324E19552DAD578A00CB5769 = {
 						CreatedOnToolsVersion = 16.2;
 						LastSwiftMigration = 1620;
+					};
+					326E0A922F81CA82008567E5 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 324E19552DAD578A00CB5769;
 					};
 				};
 			};
@@ -194,12 +246,20 @@
 			projectRoot = "";
 			targets = (
 				324E19552DAD578A00CB5769 /* Zyna */,
+				326E0A922F81CA82008567E5 /* ZynaTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		324E19542DAD578A00CB5769 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		326E0A912F81CA82008567E5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -216,7 +276,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		326E0A8F2F81CA82008567E5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		326E0A982F81CA82008567E5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 324E19552DAD578A00CB5769 /* Zyna */;
+			targetProxy = 326E0A972F81CA82008567E5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		324E196A2DAD578C00CB5769 /* Debug */ = {
@@ -225,9 +300,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2ZL4A7F4SY;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UM3QPHF8E3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Zyna/App/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -242,6 +319,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Zyna;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -260,9 +339,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2ZL4A7F4SY;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UM3QPHF8E3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Zyna/App/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -277,6 +358,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Zyna;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -407,6 +490,50 @@
 			};
 			name = Release;
 		};
+		326E0A992F81CA82008567E5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2ZL4A7F4SY;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna.ZynaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zyna.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zyna";
+			};
+			name = Debug;
+		};
+		326E0A9A2F81CA82008567E5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2ZL4A7F4SY;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna.ZynaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zyna.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zyna";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -424,6 +551,15 @@
 			buildConfigurations = (
 				324E196A2DAD578C00CB5769 /* Debug */,
 				324E196B2DAD578C00CB5769 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		326E0A9B2F81CA82008567E5 /* Build configuration list for PBXNativeTarget "ZynaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				326E0A992F81CA82008567E5 /* Debug */,
+				326E0A9A2F81CA82008567E5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Zyna.xcodeproj/xcshareddata/xcschemes/Zyna.xcscheme
+++ b/Zyna.xcodeproj/xcshareddata/xcschemes/Zyna.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "326E0A922F81CA82008567E5"
+               BuildableName = "ZynaTests.xctest"
+               BlueprintName = "ZynaTests"
+               ReferencedContainer = "container:Zyna.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Zyna/App/ScreenNode.swift
+++ b/Zyna/App/ScreenNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-class BaseNode: ASDisplayNode {
+class ScreenNode: ASDisplayNode {
     
     override init() {
         super.init()

--- a/Zyna/Chat/CellNodes/MessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/MessageCellNode.swift
@@ -65,8 +65,10 @@ class MessageCellNode: ASCellNode, ContextMenuCellNode {
         automaticallyManagesSubnodes = true
         selectionStyle = .none
 
-        // Bubble defaults
-        bubbleNode.backgroundColor = isOutgoing ? .systemBlue : .systemGray5
+        // Bubble defaults — custom color from Zyna attributes wins if set.
+        let customColor = message.zynaAttributes.color
+        bubbleNode.backgroundColor = customColor
+            ?? (isOutgoing ? .systemBlue : .systemGray5)
         bubbleNode.cornerRadius = 18
         bubbleNode.clipsToBounds = true
         bubbleNode.automaticallyManagesSubnodes = true

--- a/Zyna/Chat/CellNodes/MessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/MessageCellNode.swift
@@ -42,6 +42,7 @@ class MessageCellNode: ASCellNode, ContextMenuCellNode {
     let bubbleNode = ASDisplayNode()
     let contextSourceNode: ContextSourceNode
     let timeNode = ASTextNode()
+    let statusIconNode: MessageStatusIconNode?
     let senderNameNode = ASTextNode()
     private(set) var reactionsNode: ReactionsNode?
 
@@ -56,6 +57,18 @@ class MessageCellNode: ASCellNode, ContextMenuCellNode {
         self.isOutgoing = message.isOutgoing
         self.showSenderName = !message.isOutgoing && isGroupChat
         self.contextSourceNode = ContextSourceNode(contentNode: bubbleNode)
+
+        // Status icon only on the sender's own bubbles. For incoming
+        // messages it carries no information and would just clutter.
+        if message.isOutgoing,
+           let iconState = MessageStatusIcon.from(sendStatus: message.sendStatus) {
+            let node = MessageStatusIconNode()
+            node.icon = iconState
+            node.tintColour = UIColor.white.withAlphaComponent(0.7)
+            self.statusIconNode = node
+        } else {
+            self.statusIconNode = nil
+        }
         super.init()
 
         contextSourceNode.activated = { [weak self] _ in

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIcon.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIcon.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+/// Visual state of the status indicator shown next to a message
+/// timestamp. Independent of the storage-level `sendStatus` string.
+enum MessageStatusIcon: Equatable {
+
+    /// Not yet confirmed by the server. Rendered as a rotating clock.
+    case pending
+
+    /// Server acknowledged receipt (one checkmark).
+    case sent
+
+    /// Sync echoed the event back and it is considered delivered
+    /// (two overlapping checkmarks).
+    case delivered
+
+    /// Terminal failure. Red circle with a white exclamation mark.
+    case failed
+
+    /// Maps the storage-level `sendStatus` raw string to a visual
+    /// state. Returns nil when no indicator should be shown
+    /// (e.g. historical / other-user messages).
+    static func from(sendStatus: String) -> MessageStatusIcon? {
+        switch sendStatus {
+        case "queued", "sending", "retrying":
+            return .pending
+        case "sent":
+            return .sent
+        case "synced":
+            return .delivered
+        case "failed":
+            return .failed
+        default:
+            return nil
+        }
+    }
+}

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconConfig.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconConfig.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+/// Single source of truth for message status icon geometry and style.
+/// All dimensions scale with `size` (passed to the icon view).
+enum MessageStatusIconConfig {
+
+    /// Default icon size (pt). Matches the timestamp font size so the
+    /// icon sits on the baseline. Callers may override per-use.
+    static let defaultSize: CGFloat = 11
+
+    /// Line thickness for checkmark strokes and clock outline,
+    /// expressed as a fraction of the icon size.
+    static let strokeWidthRatio: CGFloat = 0.16
+
+    /// Horizontal offset of the front checkmark when drawing the
+    /// double-check "delivered" state, as a fraction of icon size.
+    static let doubleCheckOffsetRatio: CGFloat = 0.35
+
+    /// One full rotation of the clock hand, in seconds.
+    static let clockRotationPeriod: CFTimeInterval = 1.2
+
+    /// White border width around the failed (red) circle icon.
+    static let failedRingWidth: CGFloat = 1.0
+
+    /// Fill colour for the failed state circle.
+    static let failedFillColor: UIColor = .systemRed
+
+    /// Colour of the "!" glyph on the failed circle.
+    static let failedGlyphColor: UIColor = .white
+
+    /// Border colour around the failed circle (separates from any
+    /// bubble colour).
+    static let failedBorderColor: UIColor = .white
+}

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconImages.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconImages.swift
@@ -1,0 +1,173 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+/// Shared `UIImage` bank for message status indicators. Each image
+/// is rendered once with Core Graphics at app startup and reused by
+/// every message cell. Images are authored in black and always
+/// returned with `.alwaysTemplate` rendering mode so callers can
+/// tint them per-bubble via `tintColor` on an `ASImageNode`.
+///
+/// Why a shared bank (vs per-cell `draw(_:)`): cells in a chat list
+/// reuse aggressively; generating CGImages per-cell wastes CPU on
+/// scroll and balloons memory. A pool of four-to-five shared images
+/// costs ~1 KB total and lets every cell be a no-op `ASImageNode`.
+enum MessageStatusIconImages {
+
+    // MARK: - Public
+
+    static let clockFrame: UIImage = generateClockFrame()
+    static let clockHand: UIImage = generateClockHand()
+    static let check: UIImage = generateCheck()
+    static let failedBadge: UIImage = generateFailedBadge()
+
+    // MARK: - Geometry (canonical size: 11pt)
+
+    /// All images are rendered at this canonical size. Callers scale
+    /// via the ASImageNode preferredSize — UIKit handles bilinear
+    /// interpolation for small downsizes.
+    static let canonicalSize: CGFloat = 11
+
+    // MARK: - Generators
+
+    /// Outline circle + short vertical hand pointing up (minute hand).
+    /// Black template. Caller tints via `tintColor`.
+    private static func generateClockFrame() -> UIImage {
+        let size = canonicalSize
+        let stroke: CGFloat = 1.0
+        return generate(size: CGSize(width: size, height: size)) { ctx, bounds in
+            ctx.setStrokeColor(UIColor.black.cgColor)
+            ctx.setFillColor(UIColor.black.cgColor)
+            ctx.setLineWidth(stroke)
+            ctx.strokeEllipse(in: CGRect(
+                x: stroke / 2, y: stroke / 2,
+                width: bounds.width - stroke, height: bounds.height - stroke
+            ))
+            // 12-o'clock hand: vertical stroke from ~3pt to centre.
+            ctx.fill(CGRect(
+                x: (bounds.width - stroke) / 2,
+                y: stroke * 3,
+                width: stroke,
+                height: bounds.height / 2 - stroke * 3
+            ))
+        }
+    }
+
+    /// Short horizontal bar through the centre — second hand.
+    /// Rotated by CABasicAnimation; the pivot point is the image centre.
+    private static func generateClockHand() -> UIImage {
+        let size = canonicalSize
+        let stroke: CGFloat = 1.0
+        return generate(size: CGSize(width: size, height: size)) { ctx, bounds in
+            ctx.setFillColor(UIColor.black.cgColor)
+            ctx.fill(CGRect(
+                x: (bounds.width - stroke) / 2,
+                y: (bounds.height - stroke) / 2,
+                width: bounds.width / 2 - stroke,
+                height: stroke
+            ))
+        }
+    }
+
+    /// Full V-shape checkmark. The "delivered" state is built by
+    /// layering two of these with a horizontal offset — no separate
+    /// "partial" image needed. Stroke width is a fraction of size
+    /// so downscaling stays crisp.
+    private static func generateCheck() -> UIImage {
+        let size = canonicalSize
+        let stroke: CGFloat = size * MessageStatusIconConfig.strokeWidthRatio
+        return generate(size: CGSize(width: size, height: size)) { ctx, bounds in
+            ctx.setStrokeColor(UIColor.black.cgColor)
+            ctx.setLineWidth(stroke)
+            ctx.setLineCap(.round)
+            ctx.setLineJoin(.round)
+            // Canonical V: short leg ~1/3 of long leg.
+            let w = bounds.width
+            let h = bounds.height
+            let start = CGPoint(x: w * 0.10, y: h * 0.55)
+            let apex  = CGPoint(x: w * 0.38, y: h * 0.80)
+            let end   = CGPoint(x: w * 0.92, y: h * 0.22)
+            ctx.move(to: start)
+            ctx.addLine(to: apex)
+            ctx.addLine(to: end)
+            ctx.strokePath()
+        }
+    }
+
+    /// Red filled circle with a thin white border ring and a white
+    /// "!" glyph. Authored in full colour (NOT a template), so it
+    /// reads against any bubble colour without tinting.
+    private static func generateFailedBadge() -> UIImage {
+        let size = canonicalSize + 2  // Slightly larger than checks
+        return generateColour(size: CGSize(width: size, height: size)) { ctx, bounds in
+            let centre = CGPoint(x: bounds.midX, y: bounds.midY)
+            let ringWidth: CGFloat = 1.0
+            let outerR = min(bounds.width, bounds.height) / 2
+            let fillR = outerR - ringWidth
+
+            // White border ring
+            ctx.setFillColor(UIColor.white.cgColor)
+            ctx.fillEllipse(in: CGRect(
+                x: centre.x - outerR, y: centre.y - outerR,
+                width: outerR * 2, height: outerR * 2
+            ))
+
+            // Red fill
+            ctx.setFillColor(UIColor.systemRed.cgColor)
+            ctx.fillEllipse(in: CGRect(
+                x: centre.x - fillR, y: centre.y - fillR,
+                width: fillR * 2, height: fillR * 2
+            ))
+
+            // Exclamation mark
+            ctx.setFillColor(UIColor.white.cgColor)
+            let barW: CGFloat = 1.3
+            let barH = fillR * 0.72
+            let barTop = centre.y - barH / 2 - fillR * 0.08
+            ctx.fill(CGRect(
+                x: centre.x - barW / 2,
+                y: barTop,
+                width: barW,
+                height: barH
+            ))
+            let dotSize: CGFloat = barW
+            ctx.fillEllipse(in: CGRect(
+                x: centre.x - dotSize / 2,
+                y: barTop + barH + fillR * 0.18,
+                width: dotSize,
+                height: dotSize
+            ))
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Template image (black-only, tintable).
+    private static func generate(
+        size: CGSize,
+        draw: (CGContext, CGRect) -> Void
+    ) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { ctx in
+            ctx.cgContext.clear(CGRect(origin: .zero, size: size))
+            draw(ctx.cgContext, CGRect(origin: .zero, size: size))
+        }
+        return image.withRenderingMode(.alwaysTemplate)
+    }
+
+    /// Full-colour image (NOT tintable).
+    private static func generateColour(
+        size: CGSize,
+        draw: (CGContext, CGRect) -> Void
+    ) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { ctx in
+            ctx.cgContext.clear(CGRect(origin: .zero, size: size))
+            draw(ctx.cgContext, CGRect(origin: .zero, size: size))
+        }
+        return image.withRenderingMode(.alwaysOriginal)
+    }
+}

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconImages.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconImages.swift
@@ -6,15 +6,15 @@
 import UIKit
 
 /// Shared `UIImage` bank for message status indicators. Each image
-/// is rendered once with Core Graphics at app startup and reused by
-/// every message cell. Images are authored in black and always
+/// is rendered once with Core Graphics at app startup and shared by
+/// every message cell's `ASImageNode`. Images are authored in black and always
 /// returned with `.alwaysTemplate` rendering mode so callers can
 /// tint them per-bubble via `tintColor` on an `ASImageNode`.
 ///
-/// Why a shared bank (vs per-cell `draw(_:)`): cells in a chat list
-/// reuse aggressively; generating CGImages per-cell wastes CPU on
-/// scroll and balloons memory. A pool of four-to-five shared images
-/// costs ~1 KB total and lets every cell be a no-op `ASImageNode`.
+/// Why a shared bank (vs per-cell `draw(_:)`): Texture creates a
+/// new ASCellNode per index path; a custom `draw()` fires on each.
+/// A pool of shared UIImages costs ~1 KB total and lets every
+/// cell use a no-op `ASImageNode` with zero rendering overhead.
 enum MessageStatusIconImages {
 
     // MARK: - Public

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconNode.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconNode.swift
@@ -13,8 +13,8 @@ import UIKit
 /// a `CABasicAnimation` on the clock-hand layer, which runs entirely
 /// on the GPU compositor.
 ///
-/// Cells reusing this node pay no CPU cost at scroll time: image
-/// contents are shared CGImages across every chat bubble.
+/// New cell nodes created by Texture pay no CPU cost: image contents
+/// are shared CGImages across every chat bubble.
 final class MessageStatusIconNode: ASDisplayNode {
 
     // MARK: - Public

--- a/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconNode.swift
+++ b/Zyna/Chat/CellNodes/MessageStatus/MessageStatusIconNode.swift
@@ -1,0 +1,182 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import UIKit
+
+/// Compact status indicator composed of shared pre-rendered UIImages
+/// (see `MessageStatusIconImages`). The node itself does no custom
+/// drawing — each state is simply zero-to-two `ASImageNode`s sized
+/// and positioned inside a small square. The only per-frame work is
+/// a `CABasicAnimation` on the clock-hand layer, which runs entirely
+/// on the GPU compositor.
+///
+/// Cells reusing this node pay no CPU cost at scroll time: image
+/// contents are shared CGImages across every chat bubble.
+final class MessageStatusIconNode: ASDisplayNode {
+
+    // MARK: - Public
+
+    /// Tint colour applied to template images (clock + checks). No
+    /// effect on the failed badge, which is authored in full colour.
+    var tintColour: UIColor = .secondaryLabel {
+        didSet {
+            guard tintColour != oldValue else { return }
+            applyTintColour()
+        }
+    }
+
+    /// Current visual state. Assigning rebuilds the subnode set.
+    var icon: MessageStatusIcon? = nil {
+        didSet {
+            guard icon != oldValue else { return }
+            rebuildSubnodes()
+        }
+    }
+
+    /// Icon side length (pt).
+    let iconSize: CGFloat
+
+    // MARK: - Subnodes
+
+    private var imageNodes: [ASImageNode] = []
+    private var rotatingNode: ASImageNode?
+
+    // MARK: - Init
+
+    init(size: CGFloat = MessageStatusIconConfig.defaultSize) {
+        self.iconSize = size
+        super.init()
+        style.preferredSize = CGSize(width: size * 1.6, height: size)
+        automaticallyManagesSubnodes = true
+        backgroundColor = .clear
+        isOpaque = false
+        isLayerBacked = true
+    }
+
+    // MARK: - Lifecycle
+
+    override func didLoad() {
+        super.didLoad()
+        startRotationIfNeeded()
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        // Absolute layout honours the `layoutPosition` we set on each
+        // subnode when we build them. Wrapper/stack specs would
+        // re-flow them and collapse the overlapping offset.
+        return ASAbsoluteLayoutSpec(
+            sizing: .sizeToFit,
+            children: imageNodes
+        )
+    }
+
+    // MARK: - Subnode graph
+
+    private func rebuildSubnodes() {
+        imageNodes.forEach { $0.removeFromSupernode() }
+        imageNodes.removeAll()
+        rotatingNode = nil
+
+        guard let icon else {
+            setNeedsLayout()
+            return
+        }
+
+        switch icon {
+        case .pending:
+            addPendingClockNodes()
+        case .sent:
+            addCheckNode(offset: 0)
+        case .delivered:
+            addDoubleCheckNodes()
+        case .failed:
+            addFailedBadgeNode()
+        }
+
+        applyTintColour()
+        setNeedsLayout()
+        startRotationIfNeeded()
+    }
+
+    private func addPendingClockNodes() {
+        let frame = makeTemplateImageNode(image: MessageStatusIconImages.clockFrame)
+        let hand = makeTemplateImageNode(image: MessageStatusIconImages.clockHand)
+        let square = CGSize(width: iconSize, height: iconSize)
+        frame.style.preferredSize = square
+        frame.style.layoutPosition = .zero
+        hand.style.preferredSize = square
+        hand.style.layoutPosition = .zero
+        imageNodes = [frame, hand]
+        rotatingNode = hand
+    }
+
+    private func addCheckNode(offset: CGFloat) {
+        let image = MessageStatusIconImages.check
+        let node = makeTemplateImageNode(image: image)
+        node.style.preferredSize = image.size
+        node.style.layoutPosition = CGPoint(x: offset, y: 0)
+        imageNodes.append(node)
+    }
+
+    private func addDoubleCheckNodes() {
+        // Two full V-ticks layered with a horizontal offset — the
+        // second one lands on top of the first's ascending leg, so
+        // they read as one "delivered" glyph.
+        let offset = iconSize * MessageStatusIconConfig.doubleCheckOffsetRatio
+        addCheckNode(offset: 0)
+        addCheckNode(offset: offset)
+    }
+
+    private func addFailedBadgeNode() {
+        let image = MessageStatusIconImages.failedBadge
+        let node = ASImageNode()
+        node.image = image
+        node.contentMode = .center
+        node.isLayerBacked = true
+        node.style.preferredSize = image.size
+        node.style.layoutPosition = CGPoint(
+            x: (iconSize - image.size.width) / 2,
+            y: (iconSize - image.size.height) / 2
+        )
+        imageNodes.append(node)
+    }
+
+    private func makeTemplateImageNode(image: UIImage) -> ASImageNode {
+        let node = ASImageNode()
+        node.image = image
+        node.contentMode = .center
+        node.isLayerBacked = true
+        return node
+    }
+
+    // MARK: - Tint
+
+    private func applyTintColour() {
+        let cg = tintColour
+        for node in imageNodes where node.image?.renderingMode == .alwaysTemplate {
+            // imageModificationBlock tints the image at display time
+            // without touching the shared CGImage.
+            node.imageModificationBlock = ASImageNodeTintColorModificationBlock(cg)
+        }
+    }
+
+    // MARK: - Rotation
+
+    private static let rotationKey = "clockRotation"
+
+    private func startRotationIfNeeded() {
+        guard isNodeLoaded, let rotatingNode else { return }
+        guard rotatingNode.layer.animation(forKey: Self.rotationKey) == nil else { return }
+        let anim = CABasicAnimation(keyPath: "transform.rotation.z")
+        anim.fromValue = 0
+        anim.toValue = 2 * CGFloat.pi
+        anim.duration = MessageStatusIconConfig.clockRotationPeriod
+        anim.repeatCount = .infinity
+        anim.isRemovedOnCompletion = false
+        anim.timingFunction = CAMediaTimingFunction(name: .linear)
+        rotatingNode.layer.add(anim, forKey: Self.rotationKey)
+    }
+}

--- a/Zyna/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/TextMessageCellNode.swift
@@ -61,7 +61,14 @@ final class TextMessageCellNode: MessageCellNode {
             else { return ASLayoutSpec() }
 
             let metrics = Self.textMetrics(for: attributedText, maxWidth: maxContentWidth)
-            let timeSize = Self.singleLineSize(for: timeText)
+            let timeTextSize = Self.singleLineSize(for: timeText)
+            let statusIconWidth: CGFloat = self.statusIconNode.map {
+                $0.iconSize + 4  // 4pt gap between time and icon
+            } ?? 0
+            let timeSize = CGSize(
+                width: timeTextSize.width + statusIconWidth,
+                height: timeTextSize.height
+            )
 
             let fitsInline = metrics.trailingLineWidth + Self.timeSpacing + timeSize.width
                 <= maxContentWidth
@@ -108,12 +115,26 @@ final class TextMessageCellNode: MessageCellNode {
                 : timeSize.width
             mainContent.style.minWidth = ASDimension(unit: .points, value: minWidth)
 
+            // Time + optional status icon glued together as a row.
+            let timeGroup: ASLayoutElement
+            if let iconNode = self.statusIconNode {
+                timeGroup = ASStackLayoutSpec(
+                    direction: .horizontal,
+                    spacing: 4,
+                    justifyContent: .end,
+                    alignItems: .center,
+                    children: [self.timeNode, iconNode]
+                )
+            } else {
+                timeGroup = self.timeNode
+            }
+
             // Overlay time at bottom-right of entire content
             let timeCorner = ASRelativeLayoutSpec(
                 horizontalPosition: .end,
                 verticalPosition: .end,
                 sizingOption: [],
-                child: self.timeNode
+                child: timeGroup
             )
             let result = ASOverlayLayoutSpec(child: mainContent, overlay: timeCorner)
 

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -100,6 +100,10 @@ struct ChatMessage: Identifiable, Equatable, Hashable {
     let content: ChatMessageContent
     let reactions: [MessageReaction]
     let replyInfo: ReplyInfo?
+    /// Zyna-specific attributes decoded from formatted_body. Always
+    /// present (empty struct if none) so UI code has no optional
+    /// unwrap noise.
+    let zynaAttributes: ZynaMessageAttributes
 
     static func == (lhs: ChatMessage, rhs: ChatMessage) -> Bool {
         lhs.id == rhs.id
@@ -111,6 +115,7 @@ struct ChatMessage: Identifiable, Equatable, Hashable {
             && lhs.content == rhs.content
             && lhs.reactions == rhs.reactions
             && lhs.replyInfo == rhs.replyInfo
+            && lhs.zynaAttributes == rhs.zynaAttributes
     }
 
     func hash(into hasher: inout Hasher) {

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -104,6 +104,10 @@ struct ChatMessage: Identifiable, Equatable, Hashable {
     /// present (empty struct if none) so UI code has no optional
     /// unwrap noise.
     let zynaAttributes: ZynaMessageAttributes
+    /// Delivery pipeline status. For now populated as "synced" for
+    /// every message that comes off the SDK timeline; proper
+    /// per-stage tracking lands once we wire SendHandle observation.
+    let sendStatus: String
 
     static func == (lhs: ChatMessage, rhs: ChatMessage) -> Bool {
         lhs.id == rhs.id
@@ -116,6 +120,7 @@ struct ChatMessage: Identifiable, Equatable, Hashable {
             && lhs.reactions == rhs.reactions
             && lhs.replyInfo == rhs.replyInfo
             && lhs.zynaAttributes == rhs.zynaAttributes
+            && lhs.sendStatus == rhs.sendStatus
     }
 
     func hash(into hasher: inout Hasher) {

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -409,14 +409,26 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     func tableNode(_ tableNode: ASTableNode, willBeginBatchFetchWith context: ASBatchContext) {
-        // Try GRDB first (synchronous)
-        let loadedFromDB = viewModel.loadOlderFromDB()
-        if loadedFromDB {
-            context.completeBatchFetching(true)
+        // Texture invokes this hook on a background queue — use it!
+        // The GRDB query + merge/sort stays on bg; we only marshal
+        // the UI-mutating apply step back to main.
+        if let page = viewModel.queryOlderFromDB() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.viewModel.applyOlderPageFromDB(page)
+                context.completeBatchFetching(true)
+            }
             return
         }
 
-        // Fall back to SDK pagination (async)
+        // No GRDB data available — fall back to SDK pagination.
+        // These methods already manage their own threading.
+        DispatchQueue.main.async { [weak self] in
+            self?.runServerBatchFetch(context: context)
+        }
+    }
+
+    private func runServerBatchFetch(context: ASBatchContext) {
         viewModel.loadOlderFromServer()
 
         batchFetchCancellable = viewModel.$isPaginating

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -13,6 +13,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     var onBack: (() -> Void)?
     var onCallTapped: (() -> Void)?
     var onTitleTapped: ((String) -> Void)?
+    var onRoomDetailsTapped: (() -> Void)?
 
     private let viewModel: ChatViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -70,8 +71,12 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         glassNavBar.onBack = { [weak self] in self?.onBack?() }
         glassNavBar.onCall = { [weak self] in self?.onCallTapped?() }
         glassNavBar.onTitleTapped = { [weak self] in
-            guard let userId = self?.viewModel.partnerUserId else { return }
-            self?.onTitleTapped?(userId)
+            guard let self else { return }
+            if let userId = self.viewModel.partnerUserId {
+                self.onTitleTapped?(userId)
+            } else {
+                self.onRoomDetailsTapped?()
+            }
         }
         view.addSubview(glassNavBar)
 
@@ -145,7 +150,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         viewModel.$partnerUserId
             .receive(on: DispatchQueue.main)
             .sink { [weak self] userId in
-                self?.glassNavBar.isTappable = userId != nil
+                if userId != nil { self?.glassNavBar.isTappable = true }
             }
             .store(in: &cancellables)
 
@@ -153,6 +158,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             .receive(on: DispatchQueue.main)
             .sink { [weak self] count in
                 self?.glassNavBar.memberCount = count
+                if count != nil { self?.glassNavBar.isTappable = true }
             }
             .store(in: &cancellables)
     }

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -256,8 +256,8 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func bindInput() {
-        glassInputBar.inputNode.onSend = { [weak self] text in
-            self?.viewModel.sendMessage(text)
+        glassInputBar.inputNode.onSend = { [weak self] text, color in
+            self?.viewModel.sendMessage(text, color: color)
         }
 
         glassInputBar.inputNode.onVoiceRecordingFinished = { [weak self] fileURL, duration, waveform in

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -20,6 +20,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private var batchFetchCancellable: AnyCancellable?
     private let glassNavBar = GlassNavBar()
     private let glassInputBar = GlassInputBar()
+    private let searchBar = SearchBarView()
     
     /// Flip to `true` to show Apple vs Custom glass comparison overlay (iOS 26+)
     private static let showGlassComparison = false
@@ -80,6 +81,24 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
         view.addSubview(glassNavBar)
 
+        // Search bar (hidden by default)
+        searchBar.isHidden = true
+        searchBar.onQueryChanged = { [weak self] text in
+            self?.viewModel.updateSearchQuery(text)
+        }
+        searchBar.onNext = { [weak self] in
+            self?.viewModel.nextSearchResult()
+            self?.navigateToCurrentSearchResult()
+        }
+        searchBar.onPrevious = { [weak self] in
+            self?.viewModel.previousSearchResult()
+            self?.navigateToCurrentSearchResult()
+        }
+        searchBar.onCancel = { [weak self] in
+            self?.deactivateSearch()
+        }
+        view.addSubview(searchBar)
+
         // Glass input bar
         view.addSubview(glassInputBar)
 
@@ -104,6 +123,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         super.viewDidLayoutSubviews()
 
         glassNavBar.updateLayout(in: view)
+        searchBar.frame = CGRect(
+            x: 0, y: glassNavBar.coveredHeight,
+            width: view.bounds.width, height: 44
+        )
         if Self.showGlassComparison {
             glassComparison.updateLayout(in: view)
             glassTuning.frame = CGRect(
@@ -161,8 +184,33 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 if count != nil { self?.glassNavBar.isTappable = true }
             }
             .store(in: &cancellables)
+
+        viewModel.$searchState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self, let state else { return }
+                self.searchBar.updateStatus(state.statusText, hasResults: !state.results.isEmpty)
+            }
+            .store(in: &cancellables)
     }
 
+    // MARK: - Search
+
+    func activateSearch() {
+        viewModel.activateSearch()
+        searchBar.isHidden = false
+        searchBar.activate()
+    }
+
+    private func deactivateSearch() {
+        viewModel.deactivateSearch()
+        searchBar.isHidden = true
+    }
+
+    private func navigateToCurrentSearchResult() {
+        guard let result = viewModel.searchState?.currentResult else { return }
+        navigateToMessage(eventId: result.eventId)
+    }
 
     // MARK: - Bindings
 

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -260,42 +260,21 @@ final class ChatViewModel {
 
     // MARK: - Actions
 
-    func sendMessage(_ text: String) {
+    func sendMessage(_ text: String, color: UIColor? = nil) {
         if let replyTarget = replyingTo, let eventId = replyTarget.eventId {
             replyingTo = nil
+            // TODO: thread color through sendReply once we want coloured replies.
             Task { await timelineService.sendReply(text, to: eventId) }
             return
         }
 
-        // Debug: "!<colorName> text" → send with Zyna color attribute.
-        // Temporary until we have a proper color picker UI.
-        if let (body, color) = Self.parseDebugColorPrefix(text) {
+        if let color {
             let attrs = ZynaMessageAttributes(color: color)
-            Task { await timelineService.sendMessage(body, zynaAttributes: attrs) }
+            Task { await timelineService.sendMessage(text, zynaAttributes: attrs) }
             return
         }
 
         Task { await timelineService.sendMessage(text) }
-    }
-
-    private static func parseDebugColorPrefix(_ text: String) -> (String, UIColor)? {
-        let palette: [String: UIColor] = [
-            "red":    .systemRed,
-            "green":  .systemGreen,
-            "blue":   .systemBlue,
-            "orange": .systemOrange,
-            "purple": .systemPurple,
-            "pink":   .systemPink,
-            "yellow": .systemYellow
-        ]
-        guard text.hasPrefix("!") else { return nil }
-        let afterBang = text.dropFirst()
-        guard let spaceIdx = afterBang.firstIndex(of: " ") else { return nil }
-        let name = String(afterBang[..<spaceIdx]).lowercased()
-        guard let color = palette[name] else { return nil }
-        let body = String(afterBang[afterBang.index(after: spaceIdx)...])
-        guard !body.isEmpty else { return nil }
-        return (body, color)
     }
 
     func sendVoiceMessage(fileURL: URL, duration: TimeInterval, waveform: [Float]) {

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -221,6 +221,19 @@ final class ChatViewModel {
         window.loadOlder()
     }
 
+    /// Query-only part of older-page load. Safe to call from any
+    /// thread; returns merged+sorted rows or nil when exhausted.
+    /// Caller is expected to pair this with `applyOlderPageFromDB`
+    /// on the main thread.
+    func queryOlderFromDB() -> MessageWindow.OlderPage? {
+        window.queryOlder()
+    }
+
+    /// Main-thread apply step paired with `queryOlderFromDB`.
+    func applyOlderPageFromDB(_ page: MessageWindow.OlderPage) {
+        window.applyOlder(page)
+    }
+
     /// Paginate from server when GRDB is exhausted.
     func loadOlderFromServer() {
         guard !isPaginating else { return }

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -29,6 +29,7 @@ final class ChatViewModel {
     @Published private(set) var partnerPresence: UserPresence?
     @Published private(set) var partnerUserId: String?
     @Published private(set) var memberCount: Int?
+    @Published private(set) var searchState: ChatSearchState?
 
     // MARK: - Coordinator callback
     var onBack: (() -> Void)?
@@ -317,6 +318,56 @@ final class ChatViewModel {
             updates: [],
             animated: false
         ))
+    }
+
+    // MARK: - Search
+
+    func activateSearch() {
+        searchState = ChatSearchState()
+    }
+
+    func deactivateSearch() {
+        searchState = nil
+    }
+
+    func updateSearchQuery(_ text: String) {
+        guard searchState != nil else { return }
+        searchState?.query = text
+
+        guard !text.isEmpty else {
+            searchState?.results = []
+            searchState?.currentIndex = 0
+            return
+        }
+
+        let rid = roomId
+        let pattern = "%\(text)%"
+        let results: [ChatSearchResult] = (try? DatabaseService.shared.dbQueue.read { db in
+            try StoredMessage
+                .filter(Column("roomId") == rid)
+                .filter(Column("contentBody").like(pattern))
+                .order(Column("timestamp").desc)
+                .fetchAll(db)
+                .compactMap { msg -> ChatSearchResult? in
+                    guard let eventId = msg.eventId, let body = msg.contentBody else { return nil }
+                    return ChatSearchResult(eventId: eventId, body: body)
+                }
+        }) ?? []
+
+        searchState?.results = results
+        searchState?.currentIndex = 0
+    }
+
+    func nextSearchResult() {
+        guard var state = searchState, !state.results.isEmpty else { return }
+        state.currentIndex = (state.currentIndex + 1) % state.results.count
+        searchState = state
+    }
+
+    func previousSearchResult() {
+        guard var state = searchState, !state.results.isEmpty else { return }
+        state.currentIndex = (state.currentIndex - 1 + state.results.count) % state.results.count
+        searchState = state
     }
 
     func cleanup() {

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 import Combine
+import GRDB
 import MatrixRustSDK
 
 final class ChatViewModel {
@@ -37,22 +38,26 @@ final class ChatViewModel {
     let timelineService: TimelineService
     private let diffBatcher: TimelineDiffBatcher
     private let window: MessageWindow
+    private let roomId: String
     private var hiddenIds = Set<String>()
     private var cancellables = Set<AnyCancellable>()
     private var directUserId: String?
+    private var historySyncTask: Task<Void, Never>?
 
     /// Whether the window is at the live edge (newest messages visible).
     var isAtLiveEdge: Bool { window.isAtLiveEdge }
 
     init(room: Room) {
+        let roomId = room.id()
+        self.roomId = roomId
         self.roomName = room.displayName() ?? "Chat"
         self.timelineService = TimelineService(room: room)
         self.diffBatcher = TimelineDiffBatcher(
-            roomId: room.id(),
+            roomId: roomId,
             dbQueue: DatabaseService.shared.dbQueue
         )
         self.window = MessageWindow(
-            roomId: room.id(),
+            roomId: roomId,
             dbQueue: DatabaseService.shared.dbQueue
         )
 
@@ -104,6 +109,13 @@ final class ChatViewModel {
                     self.memberCount = count
                 }
             }
+        }
+
+        // Background sync: paginate full history into GRDB
+        historySyncTask = Task { [weak self] in
+            // Let initial load and listener settle first
+            try? await Task.sleep(for: .seconds(1))
+            await self?.syncFullHistory()
         }
     }
 
@@ -308,10 +320,33 @@ final class ChatViewModel {
     }
 
     func cleanup() {
+        historySyncTask?.cancel()
         PresenceTracker.shared.unregister(for: "chat")
         timelineService.onDiffs = nil
         diffBatcher.onFlush = nil
         timelineService.stopListening()
+    }
+
+    // MARK: - Background History Sync
+
+    private func syncFullHistory() async {
+        while !Task.isCancelled {
+            let countBefore = storedMessageCount()
+            await timelineService.paginateBackwards(numEvents: 50)
+            // Wait for batcher debounce (50ms) + margin
+            try? await Task.sleep(for: .milliseconds(150))
+            let countAfter = storedMessageCount()
+            if countAfter <= countBefore { break }
+        }
+    }
+
+    private func storedMessageCount() -> Int {
+        let rid = roomId
+        return (try? DatabaseService.shared.dbQueue.read { db in
+            try StoredMessage
+                .filter(Column("roomId") == rid)
+                .fetchCount(db)
+        }) ?? 0
     }
 
     // MARK: - Prefetch

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -264,9 +264,38 @@ final class ChatViewModel {
         if let replyTarget = replyingTo, let eventId = replyTarget.eventId {
             replyingTo = nil
             Task { await timelineService.sendReply(text, to: eventId) }
-        } else {
-            Task { await timelineService.sendMessage(text) }
+            return
         }
+
+        // Debug: "!<colorName> text" → send with Zyna color attribute.
+        // Temporary until we have a proper color picker UI.
+        if let (body, color) = Self.parseDebugColorPrefix(text) {
+            let attrs = ZynaMessageAttributes(color: color)
+            Task { await timelineService.sendMessage(body, zynaAttributes: attrs) }
+            return
+        }
+
+        Task { await timelineService.sendMessage(text) }
+    }
+
+    private static func parseDebugColorPrefix(_ text: String) -> (String, UIColor)? {
+        let palette: [String: UIColor] = [
+            "red":    .systemRed,
+            "green":  .systemGreen,
+            "blue":   .systemBlue,
+            "orange": .systemOrange,
+            "purple": .systemPurple,
+            "pink":   .systemPink,
+            "yellow": .systemYellow
+        ]
+        guard text.hasPrefix("!") else { return nil }
+        let afterBang = text.dropFirst()
+        guard let spaceIdx = afterBang.firstIndex(of: " ") else { return nil }
+        let name = String(afterBang[..<spaceIdx]).lowercased()
+        guard let color = palette[name] else { return nil }
+        let body = String(afterBang[afterBang.index(after: spaceIdx)...])
+        guard !body.isEmpty else { return nil }
+        return (body, color)
     }
 
     func sendVoiceMessage(fileURL: URL, duration: TimeInterval, waveform: [Float]) {

--- a/Zyna/Chat/Nodes/ChatInputNode.swift
+++ b/Zyna/Chat/Nodes/ChatInputNode.swift
@@ -36,7 +36,14 @@ final class ChatInputNode: ASDisplayNode {
     private let lockSlideDistance: CGFloat = 80
     private let slideDeadZone: CGFloat = 15
 
-    var onSend: ((String) -> Void)?
+    // MARK: - Send-colour palette
+
+    private var colorPalette: SendColorPaletteView?
+    private var colorPaletteLongPress: UILongPressGestureRecognizer?
+    private var pendingFlashTask: DispatchWorkItem?
+    private static let sendButtonDefaultTint: UIColor = .systemBlue
+
+    var onSend: ((String, UIColor?) -> Void)?
     var onVoiceRecordingFinished: ((URL, TimeInterval, [Float]) -> Void)?
     var onAttachTapped: (() -> Void)?
     var onSizeChanged: (() -> Void)?
@@ -163,6 +170,15 @@ final class ChatInputNode: ASDisplayNode {
         longPress.allowableMovement = 20
         longPress.delegate = self
         view.addGestureRecognizer(longPress)
+
+        let colorPress = UILongPressGestureRecognizer(
+            target: self, action: #selector(handleSendColorGesture(_:))
+        )
+        colorPress.minimumPressDuration = 0.3
+        colorPress.allowableMovement = .greatestFiniteMagnitude
+        colorPress.delegate = self
+        view.addGestureRecognizer(colorPress)
+        self.colorPaletteLongPress = colorPress
     }
 
     // MARK: - Layout
@@ -535,13 +551,103 @@ final class ChatInputNode: ASDisplayNode {
     }
 
     @objc private func sendTapped() {
+        sendCurrentText(color: nil)
+    }
+
+    private func sendCurrentText(color: UIColor?) {
         let text = textInputNode.textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
-        onSend?(text)
+        onSend?(text, color)
         textInputNode.textView.text = ""
         updateTextEmptyState()
         setNeedsLayout()
         onSizeChanged?()
+    }
+
+    // MARK: - Send Colour Palette
+
+    @objc private func handleSendColorGesture(_ gesture: UILongPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            presentColorPalette()
+        case .changed:
+            guard let palette = colorPalette, let window = view.window else { return }
+            let pointInPalette = gesture.location(in: window)
+            let color = palette.updateHighlight(forPoint: pointInPalette)
+            applySendButtonTint(color ?? Self.sendButtonDefaultTint)
+        case .ended:
+            guard let palette = colorPalette, let window = view.window else { return }
+            let pointInPalette = gesture.location(in: window)
+            if let color = palette.colorAt(point: pointInPalette) {
+                // Released on a colour — send with that colour.
+                commitSendWithColor(color)
+            } else {
+                // Drag-off: enter sticky mode. Palette stays, waits
+                // for tap-on-color or tap-outside.
+                palette.updateHighlight(forPoint: nil)
+                applySendButtonTint(Self.sendButtonDefaultTint)
+            }
+        case .cancelled, .failed:
+            dismissColorPalette()
+        default:
+            break
+        }
+    }
+
+    private func presentColorPalette() {
+        guard colorPalette == nil, let window = view.window else { return }
+        let palette = SendColorPaletteView()
+        palette.onColorTapped = { [weak self] color in
+            self?.commitSendWithColor(color)
+        }
+        palette.onDismissTapped = { [weak self] in
+            self?.dismissColorPalette()
+        }
+        let sendCenter = window.convert(sendButtonNode.view.center,
+                                        from: sendButtonNode.view.superview)
+        palette.present(inWindow: window, pivotInWindow: sendCenter)
+        colorPalette = palette
+    }
+
+    private func dismissColorPalette() {
+        colorPalette?.dismiss { [weak self] in
+            self?.colorPalette = nil
+        }
+        applySendButtonTint(Self.sendButtonDefaultTint)
+    }
+
+    private func commitSendWithColor(_ color: UIColor) {
+        applySendButtonTint(color)
+        dismissColorPalette()
+        sendCurrentText(color: color)
+        scheduleSendButtonFlashBack()
+    }
+
+    private func applySendButtonTint(_ color: UIColor) {
+        sendButtonNode.setImage(
+            AppIcon.send.rendered(size: 24, weight: .semibold, color: color),
+            for: .normal
+        )
+    }
+
+    private func scheduleSendButtonFlashBack() {
+        pendingFlashTask?.cancel()
+        let task = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            UIView.transition(
+                with: self.sendButtonNode.view,
+                duration: SendColorPaletteConfig.sendFlashFadeOut,
+                options: [.transitionCrossDissolve],
+                animations: {
+                    self.applySendButtonTint(Self.sendButtonDefaultTint)
+                },
+                completion: nil
+            )
+        }
+        pendingFlashTask = task
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + SendColorPaletteConfig.sendFlashHold, execute: task
+        )
     }
 
     private func updateTextEmptyState() {
@@ -559,11 +665,25 @@ final class ChatInputNode: ASDisplayNode {
 
 extension ChatInputNode: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard isTextEmpty, !isRecording, voicePreview == nil else { return false }
         let point = touch.location(in: view)
+
+        // Send-colour palette long-press: only when text is non-empty and
+        // the touch is over the Send button.
+        if gestureRecognizer === colorPaletteLongPress {
+            guard !isTextEmpty, !isRecording, voicePreview == nil else { return false }
+            return sendButtonHitRect.contains(point)
+        }
+
+        // Mic recording long-press: only when text is empty.
+        guard isTextEmpty, !isRecording, voicePreview == nil else { return false }
         let micFrame = micButtonNode.view.frame.insetBy(dx: -20, dy: -20)
         let micFrameInSelf = view.convert(micFrame, from: micButtonNode.supernode?.view ?? view)
         return micFrameInSelf.contains(point)
+    }
+
+    private var sendButtonHitRect: CGRect {
+        let frame = sendButtonNode.view.frame.insetBy(dx: -12, dy: -12)
+        return view.convert(frame, from: sendButtonNode.supernode?.view ?? view)
     }
 }
 

--- a/Zyna/Chat/Nodes/SendColorPalette/SendColorPaletteConfig.swift
+++ b/Zyna/Chat/Nodes/SendColorPalette/SendColorPaletteConfig.swift
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+/// Single source of truth for the Send-button colour palette. Tune
+/// colours, geometry and animation here without touching the view code.
+enum SendColorPaletteConfig {
+
+    // MARK: - Colours
+
+    /// 6 preset colours shown when long-pressing Send.
+    /// Order matters: index 0 is the first item along the arc (top of
+    /// fan), last is closest to the Send button (inner end).
+    static let colors: [UIColor] = [
+        .systemRed,
+        .systemOrange,
+        .systemYellow,
+        .systemGreen,
+        .systemIndigo,
+        .systemPurple
+    ]
+
+    // MARK: - Geometry
+
+    /// Radius (pt) from the Send button centre to each colour circle.
+    /// With 6 circles across a 90° arc and 44pt diameter, this yields
+    /// ~9pt gap between adjacent circles (arc-distance ≈ 53pt).
+    static let arcRadius: CGFloat = 170
+
+    /// Diameter (pt) of each colour circle.
+    static let circleDiameter: CGFloat = 44
+
+    /// Scale factor applied to the currently-highlighted circle.
+    static let highlightScale: CGFloat = 1.3
+
+    /// Angle (radians) where the arc begins — 0 is "due east" in math
+    /// convention; we build a fan that sweeps from "up" to "left".
+    static let arcStartAngle: CGFloat = .pi / 2            // straight up
+    static let arcEndAngle: CGFloat = .pi                  // straight left
+
+    // MARK: - Animation
+
+    /// Show/hide animation duration.
+    static let animationDuration: TimeInterval = 0.22
+
+    /// Stagger between circle appearances (for fan open-out).
+    static let stagger: TimeInterval = 0.02
+
+    /// After send, how long the Send button stays tinted before fading back.
+    static let sendFlashHold: TimeInterval = 0.8
+
+    /// Fade duration for Send button returning to its default tint.
+    static let sendFlashFadeOut: TimeInterval = 0.4
+}

--- a/Zyna/Chat/Nodes/SendColorPalette/SendColorPaletteView.swift
+++ b/Zyna/Chat/Nodes/SendColorPalette/SendColorPaletteView.swift
@@ -1,0 +1,239 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+/// Arc-shaped ("fan") colour picker that springs out from the Send
+/// button on long-press. Adds itself to the host window as an overlay
+/// so tap-outside dismissal is trivial.
+///
+/// Lifecycle:
+///   1. `present(inWindow:pivot:)` — adds self as subview, animates
+///      circles along the arc.
+///   2. `updateHighlight(forPoint:)` — call during drag to move the
+///      1.3x scale to the circle under finger (or clear).
+///   3. `colorAt(point:)` — hit-test; returns `UIColor` if point hits
+///      a circle, nil otherwise.
+///   4. `dismiss(completion:)` — reverse animation, removes from
+///      superview.
+final class SendColorPaletteView: UIView {
+
+    // MARK: - Callbacks
+
+    /// Fired when the user taps a circle while the palette is in
+    /// sticky mode (presentation outlived the initial long-press).
+    var onColorTapped: ((UIColor) -> Void)?
+
+    /// Fired when the user taps anywhere else (outside any circle).
+    var onDismissTapped: (() -> Void)?
+
+    // MARK: - State
+
+    private var circles: [PaletteCircle] = []
+    private var pivotInSelf: CGPoint = .zero
+    private var highlightedIndex: Int?
+    private let haptic = UISelectionFeedbackGenerator()
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        addGestureRecognizer(tap)
+        haptic.prepare()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Presentation
+
+    /// Adds the palette as a window overlay and animates the circles out.
+    /// - Parameters:
+    ///   - window: target window (must exist).
+    ///   - pivotInWindow: Send button centre in window coords.
+    func present(inWindow window: UIWindow, pivotInWindow: CGPoint) {
+        frame = window.bounds
+        window.addSubview(self)
+        pivotInSelf = pivotInWindow
+        layoutCircles()
+        animateIn()
+    }
+
+    func dismiss(completion: (() -> Void)? = nil) {
+        UIView.animate(
+            withDuration: SendColorPaletteConfig.animationDuration,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: { [self] in
+                for circle in circles {
+                    circle.alpha = 0
+                    circle.transform = .init(scaleX: 0.2, y: 0.2)
+                        .translatedBy(
+                            x: (pivotInSelf.x - circle.center.x) / 0.2,
+                            y: (pivotInSelf.y - circle.center.y) / 0.2
+                        )
+                }
+            },
+            completion: { [weak self] _ in
+                self?.removeFromSuperview()
+                completion?()
+            }
+        )
+    }
+
+    // MARK: - Drag tracking
+
+    /// Returns the colour at the given point (palette coord space), or
+    /// nil. Also updates the visual highlight. Pass nil to clear.
+    @discardableResult
+    func updateHighlight(forPoint point: CGPoint?) -> UIColor? {
+        guard let point else {
+            setHighlightedIndex(nil)
+            return nil
+        }
+        guard let index = circleIndex(at: point) else {
+            setHighlightedIndex(nil)
+            return nil
+        }
+        setHighlightedIndex(index)
+        return SendColorPaletteConfig.colors[index]
+    }
+
+    /// Hit-test without mutating highlight state. Used after release.
+    func colorAt(point: CGPoint) -> UIColor? {
+        guard let index = circleIndex(at: point) else { return nil }
+        return SendColorPaletteConfig.colors[index]
+    }
+
+    // MARK: - Private
+
+    private func layoutCircles() {
+        circles.forEach { $0.removeFromSuperview() }
+        circles.removeAll()
+
+        let count = SendColorPaletteConfig.colors.count
+        let startAngle = SendColorPaletteConfig.arcStartAngle
+        let endAngle = SendColorPaletteConfig.arcEndAngle
+        let step = (endAngle - startAngle) / CGFloat(max(1, count - 1))
+        let radius = SendColorPaletteConfig.arcRadius
+        let size = SendColorPaletteConfig.circleDiameter
+
+        for (i, color) in SendColorPaletteConfig.colors.enumerated() {
+            let theta = startAngle + step * CGFloat(i)
+            // UIKit y-axis is flipped — subtract the sin component.
+            let cx = pivotInSelf.x + radius * cos(theta)
+            let cy = pivotInSelf.y - radius * sin(theta)
+            let frame = CGRect(
+                x: cx - size / 2, y: cy - size / 2,
+                width: size, height: size
+            )
+            let circle = PaletteCircle(frame: frame, color: color)
+            circle.alpha = 0
+            // Start compressed at pivot, then animate out.
+            let dx = pivotInSelf.x - circle.center.x
+            let dy = pivotInSelf.y - circle.center.y
+            circle.transform = .init(scaleX: 0.2, y: 0.2)
+                .translatedBy(x: dx / 0.2, y: dy / 0.2)
+            addSubview(circle)
+            circles.append(circle)
+        }
+    }
+
+    private func animateIn() {
+        for (i, circle) in circles.enumerated() {
+            UIView.animate(
+                withDuration: SendColorPaletteConfig.animationDuration,
+                delay: Double(circles.count - 1 - i) * SendColorPaletteConfig.stagger,
+                usingSpringWithDamping: 0.75,
+                initialSpringVelocity: 0.6,
+                options: [.curveEaseOut],
+                animations: {
+                    circle.alpha = 1
+                    circle.transform = .identity
+                },
+                completion: nil
+            )
+        }
+    }
+
+    /// Finds the circle whose centre is closest to `point`, within
+    /// half-diameter. Returns its index.
+    private func circleIndex(at point: CGPoint) -> Int? {
+        let maxDist = SendColorPaletteConfig.circleDiameter / 2
+        var bestIndex: Int?
+        var bestDist: CGFloat = .infinity
+        for (i, circle) in circles.enumerated() {
+            let dx = circle.center.x - point.x
+            let dy = circle.center.y - point.y
+            let dist = sqrt(dx * dx + dy * dy)
+            if dist < maxDist, dist < bestDist {
+                bestDist = dist
+                bestIndex = i
+            }
+        }
+        return bestIndex
+    }
+
+    private func setHighlightedIndex(_ newIndex: Int?) {
+        guard newIndex != highlightedIndex else { return }
+        if let old = highlightedIndex, circles.indices.contains(old) {
+            circles[old].setHighlighted(false)
+        }
+        if let new = newIndex, circles.indices.contains(new) {
+            circles[new].setHighlighted(true)
+            haptic.selectionChanged()
+            haptic.prepare()
+        }
+        highlightedIndex = newIndex
+    }
+
+    // MARK: - Tap handling (sticky mode)
+
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        let point = gesture.location(in: self)
+        if let color = colorAt(point: point) {
+            onColorTapped?(color)
+        } else {
+            onDismissTapped?()
+        }
+    }
+}
+
+// MARK: - PaletteCircle
+
+/// Single colour swatch with highlight animation.
+private final class PaletteCircle: UIView {
+
+    let color: UIColor
+
+    init(frame: CGRect, color: UIColor) {
+        self.color = color
+        super.init(frame: frame)
+        backgroundColor = color
+        layer.cornerRadius = frame.width / 2
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.25
+        layer.shadowRadius = 6
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func setHighlighted(_ highlighted: Bool) {
+        UIView.animate(
+            withDuration: 0.12,
+            delay: 0,
+            options: [.curveEaseOut, .beginFromCurrentState],
+            animations: { [self] in
+                let scale = highlighted ? SendColorPaletteConfig.highlightScale : 1.0
+                transform = .init(scaleX: scale, y: scale)
+            },
+            completion: nil
+        )
+    }
+}

--- a/Zyna/Chat/Search/ChatSearchState.swift
+++ b/Zyna/Chat/Search/ChatSearchState.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+struct ChatSearchResult {
+    let eventId: String
+    let body: String
+}
+
+struct ChatSearchState {
+    var query: String = ""
+    var results: [ChatSearchResult] = []
+    var currentIndex: Int = 0
+
+    var currentResult: ChatSearchResult? {
+        guard !results.isEmpty, currentIndex >= 0, currentIndex < results.count else { return nil }
+        return results[currentIndex]
+    }
+
+    var statusText: String {
+        guard !results.isEmpty else {
+            return query.isEmpty ? "" : "No results"
+        }
+        return "\(currentIndex + 1) of \(results.count)"
+    }
+}

--- a/Zyna/Chat/Search/SearchBarView.swift
+++ b/Zyna/Chat/Search/SearchBarView.swift
@@ -1,0 +1,124 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+final class SearchBarView: UIView {
+
+    var onQueryChanged: ((String) -> Void)?
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    var onCancel: (() -> Void)?
+
+    private let textField = UITextField()
+    private let statusLabel = UILabel()
+    private let upButton = UIButton(type: .system)
+    private let downButton = UIButton(type: .system)
+    private let cancelButton = UIButton(type: .system)
+
+    private let hPad: CGFloat = 16
+    private let btnSize: CGFloat = 32
+    private let spacing: CGFloat = 4
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        backgroundColor = .systemBackground
+
+        textField.placeholder = "Search messages"
+        textField.font = .systemFont(ofSize: 16)
+        textField.returnKeyType = .search
+        textField.autocorrectionType = .no
+        textField.clearButtonMode = .whileEditing
+        textField.addTarget(self, action: #selector(textChanged), for: .editingChanged)
+
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.textAlignment = .right
+
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        upButton.setImage(UIImage(systemName: "chevron.up", withConfiguration: symbolConfig), for: .normal)
+        upButton.addTarget(self, action: #selector(upTapped), for: .touchUpInside)
+
+        downButton.setImage(UIImage(systemName: "chevron.down", withConfiguration: symbolConfig), for: .normal)
+        downButton.addTarget(self, action: #selector(downTapped), for: .touchUpInside)
+
+        cancelButton.setImage(UIImage(systemName: "xmark", withConfiguration: symbolConfig), for: .normal)
+        cancelButton.tintColor = .secondaryLabel
+        cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+
+        addSubview(textField)
+        addSubview(statusLabel)
+        addSubview(upButton)
+        addSubview(downButton)
+        addSubview(cancelButton)
+
+        updateArrows(hasResults: false)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let h = bounds.height
+        let cy = h / 2
+
+        // Right to left: cancel, down, up, status
+        let cancelX = bounds.width - hPad - btnSize
+        cancelButton.frame = CGRect(x: cancelX, y: cy - btnSize / 2, width: btnSize, height: btnSize)
+
+        let downX = cancelX - spacing - btnSize
+        downButton.frame = CGRect(x: downX, y: cy - btnSize / 2, width: btnSize, height: btnSize)
+
+        let upX = downX - spacing - btnSize
+        upButton.frame = CGRect(x: upX, y: cy - btnSize / 2, width: btnSize, height: btnSize)
+
+        let statusW: CGFloat = 50
+        let statusX = upX - spacing - statusW
+        statusLabel.frame = CGRect(x: statusX, y: 0, width: statusW, height: h)
+
+        textField.frame = CGRect(x: hPad, y: 0, width: statusX - spacing - hPad, height: h)
+    }
+
+    // MARK: - Public
+
+    func activate() {
+        textField.text = nil
+        statusLabel.text = nil
+        updateArrows(hasResults: false)
+        textField.becomeFirstResponder()
+    }
+
+    func updateStatus(_ text: String, hasResults: Bool) {
+        statusLabel.text = text
+        updateArrows(hasResults: hasResults)
+    }
+
+    // MARK: - Private
+
+    private func updateArrows(hasResults: Bool) {
+        upButton.isEnabled = hasResults
+        downButton.isEnabled = hasResults
+        upButton.alpha = hasResults ? 1 : 0.3
+        downButton.alpha = hasResults ? 1 : 0.3
+    }
+
+    // MARK: - Actions
+
+    @objc private func textChanged() {
+        onQueryChanged?(textField.text ?? "")
+    }
+
+    @objc private func upTapped() { onPrevious?() }
+    @objc private func downTapped() { onNext?() }
+
+    @objc private func cancelTapped() {
+        textField.resignFirstResponder()
+        onCancel?()
+    }
+}

--- a/Zyna/Core/Concurrency/Atomic.swift
+++ b/Zyna/Core/Concurrency/Atomic.swift
@@ -1,0 +1,71 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import os.lock
+
+/// Thread-safe container for a value of type `T`, backed by
+/// `OSAllocatedUnfairLock`. Manual synchronisation via the lock
+/// justifies `@unchecked Sendable` / `nonisolated(unsafe)`.
+final class Atomic<T>: @unchecked Sendable {
+
+    private nonisolated(unsafe) var value: T
+    private let lock = OSAllocatedUnfairLock()
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    var wrappedValue: T {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+
+    /// Performs a compound mutation inside the critical section.
+    func modify(_ transform: (inout T) -> Void) {
+        lock.withLock { transform(&value) }
+    }
+
+    /// Like `modify` but returns a value out of the closure.
+    func withValue<Result>(_ transform: (inout T) -> Result) -> Result {
+        lock.withLock { transform(&value) }
+    }
+
+    /// Compare-and-swap. Returns true if the swap happened.
+    func compareAndSwap(expected: T, desired: T) -> Bool where T: Equatable {
+        lock.withLock {
+            if value == expected {
+                value = desired
+                return true
+            }
+            return false
+        }
+    }
+}
+
+// MARK: - Boolean flag helpers
+
+extension Atomic where T == Bool {
+
+    /// If flag is false, sets it to true and returns true.
+    /// Returns false if already set.
+    func tryToSetFlag() -> Bool {
+        var success = false
+        modify { v in
+            if !v { v = true; success = true }
+        }
+        return success
+    }
+
+    /// If flag is true, clears it and returns true.
+    @discardableResult
+    func tryToClearFlag() -> Bool {
+        var success = false
+        modify { v in
+            if v { v = false; success = true }
+        }
+        return success
+    }
+}

--- a/Zyna/Core/Network/NetworkReachability.swift
+++ b/Zyna/Core/Network/NetworkReachability.swift
@@ -1,0 +1,93 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Network
+
+/// Observes network reachability via NWPathMonitor. Singleton —
+/// a single monitor instance is sufficient for the whole app.
+///
+/// Usage:
+/// ```
+/// NetworkReachability.shared.onRestored = { /* retry pending work */ }
+/// NetworkReachability.shared.start()
+/// ```
+///
+/// ## Important limitations
+///
+/// `isReachable` reflects only whether the OS has a routable network
+/// interface — **not** whether any specific server is actually
+/// reachable. In particular:
+///
+/// - **VPN**: when a VPN tunnel is up, `NWPathMonitor` reports the path
+///   as `.satisfied` regardless of whether the underlying physical
+///   network works. A device in Airplane Mode with a stale VPN
+///   configuration can still appear "online" here. Do **not** treat
+///   `isReachable == true` as a guarantee that outgoing requests
+///   will succeed — always combine with a per-request timeout or
+///   rely on actual request outcomes.
+///
+/// - **Captive portals / dead uplinks**: the OS can report satisfied
+///   even when the uplink is present but unusable (needs sign-in,
+///   packet loss, DNS broken).
+///
+/// Use this class as a *hint* for scheduling retries and gating
+/// background work, not as authoritative connectivity truth.
+final class NetworkReachability {
+
+    static let shared = NetworkReachability()
+
+    // MARK: - State
+
+    /// True if a usable network path is currently available.
+    /// Reads are thread-safe (protected by the monitor's queue).
+    private(set) var isReachable: Bool = true
+
+    // MARK: - Callbacks
+
+    /// Called on a background queue when the network transitions from
+    /// unreachable → reachable. Intended for retry-on-reconnect logic.
+    var onRestored: (() -> Void)?
+
+    /// Called on a background queue when the network transitions from
+    /// reachable → unreachable.
+    var onLost: (() -> Void)?
+
+    // MARK: - Private
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.zyna.network.reachability")
+    private var started = false
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Starts observing network paths. Safe to call multiple times.
+    func start() {
+        guard !started else { return }
+        started = true
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let nowReachable = path.status == .satisfied
+            let wasReachable = self.isReachable
+            self.isReachable = nowReachable
+
+            if !wasReachable && nowReachable {
+                self.onRestored?()
+            } else if wasReachable && !nowReachable {
+                self.onLost?()
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    func stop() {
+        guard started else { return }
+        monitor.cancel()
+        started = false
+    }
+}

--- a/Zyna/Messaging/OutgoingAttributesCache.swift
+++ b/Zyna/Messaging/OutgoingAttributesCache.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+/// Short-lived in-memory cache of Zyna attributes we just sent.
+///
+/// Problem it solves: the typed `timeline.send` path produces local-echo
+/// events and first sync confirmations without the raw original JSON
+/// prepared by the SDK's lazy provider. During that window
+/// `TimelineService.extractZynaAttributes` returns empty attributes,
+/// which makes a coloured bubble momentarily render as the default
+/// blue before the proper raw JSON arrives and the cell is redrawn.
+///
+/// This cache stores attributes keyed by (roomId, body, senderId) for
+/// a short TTL right after we issue a send. When the typed event
+/// surfaces as our own (`isOwn == true`) without raw JSON, we look it
+/// up here and return the cached attributes as an optimistic fallback.
+///
+/// Entries expire by TTL; the cache also self-cleans opportunistically.
+final class OutgoingAttributesCache {
+
+    static let shared = OutgoingAttributesCache()
+
+    /// How long a pending send keeps its optimistic attributes alive.
+    /// Long enough to cover sync delays, short enough to avoid cross-
+    /// contamination with an unrelated later message of the same body.
+    private static let ttl: TimeInterval = 8
+
+    private struct Entry {
+        let attributes: ZynaMessageAttributes
+        let expiresAt: Date
+    }
+
+    private struct Key: Hashable {
+        let body: String
+        let senderId: String
+    }
+
+    private let queue = DispatchQueue(label: "com.zyna.outgoingAttributesCache")
+    private var entries: [Key: Entry] = [:]
+
+    // MARK: - API
+
+    /// Stores attributes for a message just handed to `timeline.send`.
+    func remember(
+        attributes: ZynaMessageAttributes,
+        body: String,
+        senderId: String
+    ) {
+        let key = Key(body: body, senderId: senderId)
+        queue.sync {
+            entries[key] = Entry(
+                attributes: attributes,
+                expiresAt: Date().addingTimeInterval(Self.ttl)
+            )
+            pruneExpiredLocked()
+        }
+    }
+
+    /// Returns previously-remembered attributes for an own event whose
+    /// raw JSON has not arrived yet. Does not remove the entry —
+    /// multiple timeline diffs may hit the same row.
+    func peek(body: String, senderId: String) -> ZynaMessageAttributes? {
+        let key = Key(body: body, senderId: senderId)
+        return queue.sync {
+            guard let entry = entries[key], entry.expiresAt > Date() else { return nil }
+            return entry.attributes
+        }
+    }
+
+    // MARK: - Private
+
+    private func pruneExpiredLocked() {
+        let now = Date()
+        entries = entries.filter { $0.value.expiresAt > now }
+    }
+}

--- a/Zyna/Messaging/ZynaHTMLCodec.swift
+++ b/Zyna/Messaging/ZynaHTMLCodec.swift
@@ -1,0 +1,180 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import UIKit
+
+/// Encodes and decodes `ZynaMessageAttributes` as an HTML `<span>` carrier
+/// inside Matrix `formatted_body`. All Zyna-specific data rides in a
+/// single hidden element:
+///
+/// ```html
+/// Hello<span data-zyna='{"v":1,"color":"#FF0000",...}'></span>
+/// ```
+///
+/// Why one span with a JSON blob (rather than many `data-zyna-*` atomic
+/// attributes): unified parsing, trivial round-trip, easy versioning,
+/// stable against HTML sanitisers in foreign clients.
+///
+/// Foreign Matrix clients (Element, SchildiChat, …) render only the
+/// text before the span — the empty span with an unknown `data-zyna`
+/// attribute is ignored visually. The raw event content is preserved
+/// through federation intact, so Zyna can always recover the data.
+enum ZynaHTMLCodec {
+
+    /// Current schema version. Bump only on breaking changes to the
+    /// JSON shape (rename of a field, changed semantics). Additive
+    /// changes (new optional field) do not need a bump — older readers
+    /// ignore unknown keys naturally.
+    static let currentVersion = 1
+
+    /// The HTML attribute name used on the carrier `<span>`.
+    static let dataAttributeName = "data-zyna"
+
+    // MARK: - Encode
+
+    /// Appends a hidden carrier `<span>` with Zyna attributes to the
+    /// existing HTML body. Returns `userHTML` unchanged if attributes
+    /// are empty.
+    static func encode(
+        userHTML: String,
+        attributes: ZynaMessageAttributes
+    ) -> String {
+        guard !attributes.isEmpty else { return userHTML }
+        guard let json = buildJSON(from: attributes) else { return userHTML }
+        let escaped = escapeForHTMLAttribute(json)
+        return userHTML + "<span \(dataAttributeName)=\"\(escaped)\"></span>"
+    }
+
+    // MARK: - Decode
+
+    /// Extracts Zyna attributes from the raw HTML of a received event's
+    /// `formatted_body`. Returns an empty struct if no carrier found
+    /// or the payload is malformed.
+    static func decode(htmlBody: String) -> ZynaMessageAttributes {
+        guard let raw = extractDataZynaValue(from: htmlBody),
+              let json = unescapeFromHTMLAttribute(raw).data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: json) as? [String: Any]
+        else { return ZynaMessageAttributes() }
+
+        return buildAttributes(from: root)
+    }
+
+    // MARK: - JSON shape
+
+    /// JSON keys used inside the carrier. One source of truth.
+    private enum JSONKey {
+        static let version = "v"
+        static let color = "color"
+        static let checklist = "checklist"
+        static let callSignal = "call"
+    }
+
+    private static func buildJSON(from attrs: ZynaMessageAttributes) -> String? {
+        var obj: [String: Any] = [JSONKey.version: currentVersion]
+
+        if let color = attrs.color {
+            obj[JSONKey.color] = color.hexString
+        }
+
+        if let checklist = attrs.checklist, !checklist.isEmpty {
+            obj[JSONKey.checklist] = checklist.map {
+                ["text": $0.text, "checked": $0.checked]
+            }
+        }
+
+        if let signal = attrs.callSignal {
+            var s: [String: Any] = ["type": signal.type, "callId": signal.callId]
+            if let sdp = signal.sdp { s["sdp"] = sdp }
+            if let candidate = signal.candidate { s["candidate"] = candidate }
+            obj[JSONKey.callSignal] = s
+        }
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: obj, options: [.sortedKeys]
+        ), let string = String(data: data, encoding: .utf8) else { return nil }
+        return string
+    }
+
+    private static func buildAttributes(from obj: [String: Any]) -> ZynaMessageAttributes {
+        var result = ZynaMessageAttributes()
+
+        if let hex = obj[JSONKey.color] as? String {
+            result.color = UIColor.fromHexString(hex)
+        }
+
+        if let arr = obj[JSONKey.checklist] as? [[String: Any]] {
+            result.checklist = arr.compactMap { dict -> ChecklistItem? in
+                guard let text = dict["text"] as? String,
+                      let checked = dict["checked"] as? Bool else { return nil }
+                return ChecklistItem(text: text, checked: checked)
+            }
+        }
+
+        if let s = obj[JSONKey.callSignal] as? [String: Any],
+           let type = s["type"] as? String,
+           let callId = s["callId"] as? String {
+            result.callSignal = CallSignalData(
+                type: type,
+                callId: callId,
+                sdp: s["sdp"] as? String,
+                candidate: s["candidate"] as? String
+            )
+        }
+
+        return result
+    }
+
+    // MARK: - HTML attribute escaping
+
+    /// Escapes a string for safe use as an HTML attribute value
+    /// enclosed in double quotes.
+    static func escapeForHTMLAttribute(_ s: String) -> String {
+        var result = s
+        result = result.replacingOccurrences(of: "&", with: "&amp;")
+        result = result.replacingOccurrences(of: "\"", with: "&quot;")
+        result = result.replacingOccurrences(of: "<", with: "&lt;")
+        result = result.replacingOccurrences(of: ">", with: "&gt;")
+        return result
+    }
+
+    static func unescapeFromHTMLAttribute(_ s: String) -> String {
+        var result = s
+        result = result.replacingOccurrences(of: "&quot;", with: "\"")
+        result = result.replacingOccurrences(of: "&lt;", with: "<")
+        result = result.replacingOccurrences(of: "&gt;", with: ">")
+        result = result.replacingOccurrences(of: "&apos;", with: "'")
+        result = result.replacingOccurrences(of: "&amp;", with: "&")
+        return result
+    }
+
+    // MARK: - Extraction from raw HTML
+
+    /// Finds a `<span data-zyna="VALUE" …>` (or with single-quoted value)
+    /// anywhere in the HTML body and returns VALUE (still HTML-escaped).
+    /// Uses a regex scoped to the data-zyna attribute only, to avoid
+    /// false matches inside user-authored attribute values.
+    static func extractDataZynaValue(from html: String) -> String? {
+        // Matches: data-zyna="..." or data-zyna='...'
+        // We look inside any tag; Zyna puts this on a `<span>` but the
+        // regex is attribute-scoped so it works regardless of tag.
+        let pattern = #"data-zyna\s*=\s*(?:"([^"]*)"|'([^']*)')"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let nsRange = NSRange(html.startIndex..<html.endIndex, in: html)
+        guard let match = regex.firstMatch(in: html, range: nsRange) else {
+            return nil
+        }
+        // Group 1 is double-quoted value, group 2 is single-quoted.
+        for i in 1...2 {
+            let range = match.range(at: i)
+            if range.location != NSNotFound, let r = Range(range, in: html) {
+                return String(html[r])
+            }
+        }
+        return nil
+    }
+}

--- a/Zyna/Messaging/ZynaMessageAttributes.swift
+++ b/Zyna/Messaging/ZynaMessageAttributes.swift
@@ -1,0 +1,97 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import UIKit
+
+/// Bag of Zyna-specific attributes attached to a chat message.
+/// These are transport-agnostic: the same struct is used on both
+/// send and receive paths, persisted in GRDB, and passed to UI.
+///
+/// Serialised into a single hidden `<span data-zyna="...">` element at
+/// the end of `formatted_body` when sending, and extracted from the
+/// raw HTML of incoming events on receive. See `ZynaHTMLCodec`.
+///
+/// Adding a new feature:
+/// 1. Add a field here (optional — always opt-in).
+/// 2. Add a case in `ZynaHTMLCodec` encode/decode.
+/// 3. Bump `ZynaHTMLCodec.currentVersion` only on breaking changes.
+struct ZynaMessageAttributes: Equatable {
+
+    /// Custom bubble color. Rendered as the message bubble background in Zyna.
+    /// Other Matrix clients ignore this (it lives in the hidden span).
+    var color: UIColor?
+
+    /// Checklist items (future feature).
+    var checklist: [ChecklistItem]?
+
+    /// Call signalling payload (future feature — replaces `ZYNA_CALL:` prefix).
+    var callSignal: CallSignalData?
+
+    init(
+        color: UIColor? = nil,
+        checklist: [ChecklistItem]? = nil,
+        callSignal: CallSignalData? = nil
+    ) {
+        self.color = color
+        self.checklist = checklist
+        self.callSignal = callSignal
+    }
+
+    /// True when no Zyna attributes are present. Used by the codec
+    /// to skip emitting the hidden span entirely.
+    var isEmpty: Bool {
+        color == nil
+            && (checklist == nil || checklist?.isEmpty == true)
+            && callSignal == nil
+    }
+
+    static func == (lhs: ZynaMessageAttributes, rhs: ZynaMessageAttributes) -> Bool {
+        lhs.color?.hexString == rhs.color?.hexString
+            && lhs.checklist == rhs.checklist
+            && lhs.callSignal == rhs.callSignal
+    }
+}
+
+// MARK: - Nested types
+
+struct ChecklistItem: Codable, Equatable {
+    var text: String
+    var checked: Bool
+}
+
+struct CallSignalData: Codable, Equatable {
+    var type: String          // "offer" / "answer" / "ice-candidate" / "hangup"
+    var callId: String
+    var sdp: String?
+    var candidate: String?
+}
+
+// MARK: - UIColor hex helper
+
+extension UIColor {
+
+    /// Returns the color as an uppercase "#RRGGBB" string.
+    /// Alpha is ignored.
+    var hexString: String {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        getRed(&r, green: &g, blue: &b, alpha: &a)
+        let ri = Int((max(0, min(1, r)) * 255).rounded())
+        let gi = Int((max(0, min(1, g)) * 255).rounded())
+        let bi = Int((max(0, min(1, b)) * 255).rounded())
+        return String(format: "#%02X%02X%02X", ri, gi, bi)
+    }
+
+    /// Parses "#RRGGBB" or "RRGGBB". Returns nil on invalid input.
+    static func fromHexString(_ hex: String) -> UIColor? {
+        var s = hex.uppercased()
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
+        let r = CGFloat((value >> 16) & 0xFF) / 255
+        let g = CGFloat((value >> 8) & 0xFF) / 255
+        let b = CGFloat(value & 0xFF) / 255
+        return UIColor(red: r, green: g, blue: b, alpha: 1)
+    }
+}

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -105,8 +105,7 @@ final class ChatsCoordinator {
     private func showProfile(userId: String) {
         let vc = ProfileViewController(mode: .other(userId: userId))
         vc.onSearchTapped = { [weak self] in
-            self?.navigationController.popViewController(animated: true)
-            // TODO: activate search mode in chat
+            self?.popAndActivateSearch()
         }
         navigationController.pushViewController(vc, animated: true)
     }
@@ -114,10 +113,17 @@ final class ChatsCoordinator {
     private func showRoomDetails(room: Room, memberCount: Int?) {
         let vc = RoomDetailsViewController(room: room, memberCount: memberCount)
         vc.onSearchTapped = { [weak self] in
-            self?.navigationController.popViewController(animated: true)
-            // TODO: activate search mode in chat
+            self?.popAndActivateSearch()
         }
         navigationController.pushViewController(vc, animated: true)
+    }
+
+    private func popAndActivateSearch() {
+        navigationController.popViewController(animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let chatVC = self?.navigationController.topViewController as? ChatViewController else { return }
+            chatVC.activateSearch()
+        }
     }
 
     // MARK: - Calls

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -95,12 +95,28 @@ final class ChatsCoordinator {
         vc.onTitleTapped = { [weak self] userId in
             self?.showProfile(userId: userId)
         }
+        vc.onRoomDetailsTapped = { [weak self] in
+            self?.showRoomDetails(room: room, memberCount: viewModel.memberCount)
+        }
         navigationController.pushViewController(vc, animated: true)
         navigationController.enableFullScreenPopGesture()
     }
 
     private func showProfile(userId: String) {
         let vc = ProfileViewController(mode: .other(userId: userId))
+        vc.onSearchTapped = { [weak self] in
+            self?.navigationController.popViewController(animated: true)
+            // TODO: activate search mode in chat
+        }
+        navigationController.pushViewController(vc, animated: true)
+    }
+
+    private func showRoomDetails(room: Room, memberCount: Int?) {
+        let vc = RoomDetailsViewController(room: room, memberCount: memberCount)
+        vc.onSearchTapped = { [weak self] in
+            self?.navigationController.popViewController(animated: true)
+            // TODO: activate search mode in chat
+        }
         navigationController.pushViewController(vc, animated: true)
     }
 

--- a/Zyna/Screens/CreateGroup/CreateGroupNode.swift
+++ b/Zyna/Screens/CreateGroup/CreateGroupNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class CreateGroupNode: BaseNode {
+final class CreateGroupNode: ScreenNode {
 
     let nameInputNode = ASEditableTextNode()
     let topicInputNode = ASEditableTextNode()

--- a/Zyna/Screens/CreateGroup/SelectMembersNode.swift
+++ b/Zyna/Screens/CreateGroup/SelectMembersNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class SelectMembersNode: BaseNode {
+final class SelectMembersNode: ScreenNode {
 
     let tableNode = ASTableNode()
 

--- a/Zyna/Screens/Profile/ProfileNode.swift
+++ b/Zyna/Screens/Profile/ProfileNode.swift
@@ -12,6 +12,7 @@ final class ProfileNode: BaseNode {
     var onAvatarTapped: (() -> Void)?
     var onLogoutTapped: (() -> Void)?
     var onSettingsTapped: (() -> Void)?
+    var onSearchTapped: (() -> Void)?
 
     // MARK: - Nodes
 
@@ -28,6 +29,7 @@ final class ProfileNode: BaseNode {
 
     private let presenceNode = ASTextNode()
 
+    private let searchButtonNode = ASButtonNode()
     private let settingsButtonNode = ASButtonNode()
     private let logoutButtonNode = ASButtonNode()
 
@@ -182,6 +184,19 @@ final class ProfileNode: BaseNode {
         copyButtonNode.imageNode.tintColor = .secondaryLabel
         copyButtonNode.addTarget(self, action: #selector(copyUserId), forControlEvents: .touchUpInside)
 
+        // Search messages
+        let searchIcon = UIImage(
+            systemName: "magnifyingglass",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .medium)
+        )
+        searchButtonNode.setImage(searchIcon, for: .normal)
+        searchButtonNode.setAttributedTitle(NSAttributedString(
+            string: "  Search Messages",
+            attributes: [.font: UIFont.systemFont(ofSize: 17), .foregroundColor: UIColor.label]
+        ), for: .normal)
+        searchButtonNode.contentHorizontalAlignment = .middle
+        searchButtonNode.addTarget(self, action: #selector(searchTapped), forControlEvents: .touchUpInside)
+
         // Settings (own only)
         settingsButtonNode.setAttributedTitle(NSAttributedString(
             string: "Settings",
@@ -252,10 +267,14 @@ final class ProfileNode: BaseNode {
         spacer.style.flexGrow = 1
 
         var bottomChildren: [ASLayoutElement] = []
+        if case .other = mode {
+            searchButtonNode.style.alignSelf = .stretch
+            bottomChildren.append(searchButtonNode)
+        }
         if case .own = mode {
             settingsButtonNode.style.alignSelf = .stretch
             logoutButtonNode.style.alignSelf = .stretch
-            bottomChildren = [settingsButtonNode, logoutButtonNode]
+            bottomChildren.append(contentsOf: [settingsButtonNode, logoutButtonNode])
         }
 
         let bottomStack = ASStackLayoutSpec(
@@ -289,6 +308,10 @@ final class ProfileNode: BaseNode {
 
     @objc private func settingsTapped() {
         onSettingsTapped?()
+    }
+
+    @objc private func searchTapped() {
+        onSearchTapped?()
     }
 
     @objc private func logoutTapped() {

--- a/Zyna/Screens/Profile/ProfileNode.swift
+++ b/Zyna/Screens/Profile/ProfileNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class ProfileNode: BaseNode {
+final class ProfileNode: ScreenNode {
 
     // MARK: - Callbacks
 

--- a/Zyna/Screens/Profile/ProfileView.swift
+++ b/Zyna/Screens/Profile/ProfileView.swift
@@ -10,6 +10,7 @@ import PhotosUI
 final class ProfileViewController: ASDKViewController<ProfileNode> {
 
     var onLogout: (() -> Void)?
+    var onSearchTapped: (() -> Void)?
 
     private let viewModel: ProfileViewModel
     private var cancellables = Set<AnyCancellable>()
@@ -115,6 +116,9 @@ final class ProfileViewController: ASDKViewController<ProfileNode> {
         }
         node.onAvatarTapped = { [weak self] in
             self?.presentAvatarPicker()
+        }
+        node.onSearchTapped = { [weak self] in
+            self?.onSearchTapped?()
         }
     }
 

--- a/Zyna/Screens/RoomDetails/RoomDetailsNode.swift
+++ b/Zyna/Screens/RoomDetails/RoomDetailsNode.swift
@@ -1,0 +1,153 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class RoomDetailsNode: BaseNode {
+
+    var onSearchTapped: (() -> Void)?
+
+    // MARK: - Nodes
+
+    private let avatarBackgroundNode = ASDisplayNode()
+    private let avatarImageNode = ASImageNode()
+    private let avatarInitialsNode = ASTextNode()
+    private let nameNode = ASTextNode()
+    private let memberCountNode = ASTextNode()
+    private let searchButtonNode = ASButtonNode()
+
+    // MARK: - State
+
+    var topInset: CGFloat = 40
+    var bottomInset: CGFloat = 16
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        setupNodes()
+    }
+
+    // MARK: - Setup
+
+    private func setupNodes() {
+        avatarBackgroundNode.backgroundColor = .systemGray4
+        avatarImageNode.clipsToBounds = true
+        avatarImageNode.contentMode = .scaleAspectFill
+        avatarImageNode.isLayerBacked = true
+
+        let searchIcon = UIImage(
+            systemName: "magnifyingglass",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .medium)
+        )
+        searchButtonNode.setImage(searchIcon, for: .normal)
+        searchButtonNode.setAttributedTitle(NSAttributedString(
+            string: "  Search Messages",
+            attributes: [.font: UIFont.systemFont(ofSize: 17), .foregroundColor: UIColor.label]
+        ), for: .normal)
+        searchButtonNode.contentHorizontalAlignment = .middle
+        searchButtonNode.addTarget(self, action: #selector(searchTapped), forControlEvents: .touchUpInside)
+    }
+
+    // MARK: - Update
+
+    func update(name: String, memberCount: Int?, avatarMxcUrl: String?) {
+        let initials = String(name.prefix(1)).uppercased()
+        avatarInitialsNode.attributedText = NSAttributedString(
+            string: initials,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 32, weight: .semibold),
+                .foregroundColor: UIColor.white
+            ]
+        )
+
+        nameNode.attributedText = NSAttributedString(
+            string: name,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 22, weight: .bold),
+                .foregroundColor: UIColor.label
+            ]
+        )
+
+        if let count = memberCount {
+            // TODO: Replace with stringsdict plural rules when adding localization
+            memberCountNode.attributedText = NSAttributedString(
+                string: "\(count) member\(count == 1 ? "" : "s")",
+                attributes: [
+                    .font: UIFont.systemFont(ofSize: 14),
+                    .foregroundColor: UIColor.secondaryLabel
+                ]
+            )
+        }
+
+        if let mxcUrl = avatarMxcUrl {
+            loadAvatarImage(mxcUrl: mxcUrl)
+        }
+
+        setNeedsLayout()
+    }
+
+    private func loadAvatarImage(mxcUrl: String) {
+        Task { @MainActor in
+            guard let image = await MediaCache.shared.loadThumbnail(mxcUrl: mxcUrl, size: 200) else { return }
+            self.avatarImageNode.image = image
+        }
+    }
+
+    // MARK: - Layout
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let size = CGSize(width: 100, height: 100)
+        avatarBackgroundNode.style.preferredSize = size
+        avatarImageNode.style.preferredSize = size
+
+        let initialsCenter = ASCenterLayoutSpec(
+            centeringOptions: .XY, sizingOptions: .minimumXY, child: avatarInitialsNode
+        )
+        let withInitials = ASOverlayLayoutSpec(child: avatarBackgroundNode, overlay: initialsCenter)
+        let avatarSpec = ASOverlayLayoutSpec(child: withInitials, overlay: avatarImageNode)
+
+        var infoChildren: [ASLayoutElement] = [avatarSpec, nameNode]
+        if memberCountNode.attributedText != nil {
+            infoChildren.append(memberCountNode)
+        }
+
+        let profileStack = ASStackLayoutSpec(
+            direction: .vertical, spacing: 8,
+            justifyContent: .start, alignItems: .center,
+            children: infoChildren
+        )
+
+        let spacer = ASLayoutSpec()
+        spacer.style.flexGrow = 1
+
+        searchButtonNode.style.alignSelf = .stretch
+
+        let mainStack = ASStackLayoutSpec(
+            direction: .vertical, spacing: 0,
+            justifyContent: .start, alignItems: .stretch,
+            children: [profileStack, spacer, searchButtonNode]
+        )
+
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: topInset, left: 24, bottom: bottomInset, right: 24),
+            child: mainStack
+        )
+    }
+
+    // MARK: - Actions
+
+    @objc private func searchTapped() {
+        onSearchTapped?()
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        avatarBackgroundNode.cornerRadius = 50
+        avatarBackgroundNode.clipsToBounds = true
+        avatarImageNode.cornerRadius = 50
+        avatarImageNode.clipsToBounds = true
+    }
+}

--- a/Zyna/Screens/RoomDetails/RoomDetailsNode.swift
+++ b/Zyna/Screens/RoomDetails/RoomDetailsNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class RoomDetailsNode: BaseNode {
+final class RoomDetailsNode: ScreenNode {
 
     var onSearchTapped: (() -> Void)?
 

--- a/Zyna/Screens/RoomDetails/RoomDetailsViewController.swift
+++ b/Zyna/Screens/RoomDetails/RoomDetailsViewController.swift
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class RoomDetailsViewController: ASDKViewController<RoomDetailsNode> {
+
+    var onSearchTapped: (() -> Void)?
+
+    private let room: Room
+    private let memberCount: Int?
+
+    init(room: Room, memberCount: Int?) {
+        self.room = room
+        self.memberCount = memberCount
+        super.init(node: RoomDetailsNode())
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        node.onSearchTapped = { [weak self] in
+            self?.onSearchTapped?()
+        }
+
+        let name = room.displayName() ?? "Group"
+        let avatarUrl = try? room.avatarUrl()
+        node.update(name: name, memberCount: memberCount, avatarMxcUrl: avatarUrl)
+    }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        node.topInset = view.safeAreaInsets.top + 24
+        node.bottomInset = max(view.safeAreaInsets.bottom + 16, 16)
+        node.setNeedsLayout()
+    }
+}

--- a/Zyna/Screens/Rooms/RoomsController.swift
+++ b/Zyna/Screens/Rooms/RoomsController.swift
@@ -22,7 +22,7 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
     var onComposeTapped: (() -> Void)?
 
     override init() {
-        super.init(node: BaseNode())
+        super.init(node: ScreenNode())
 
         setupTableNode()
         bindViewModel()

--- a/Zyna/Screens/Settings/SettingsView.swift
+++ b/Zyna/Screens/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ final class SettingsViewController: ASDKViewController<ASDisplayNode> {
     private let textNode = ASTextNode()
 
     override init() {
-        super.init(node: BaseNode())
+        super.init(node: ScreenNode())
 
         textNode.attributedText = NSAttributedString(
             string: "Настройки",

--- a/Zyna/Screens/StartChat/StartChatNode.swift
+++ b/Zyna/Screens/StartChat/StartChatNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class StartChatNode: BaseNode {
+final class StartChatNode: ScreenNode {
 
     let tableNode = ASTableNode()
 

--- a/Zyna/Services/Database/DatabaseService.swift
+++ b/Zyna/Services/Database/DatabaseService.swift
@@ -93,6 +93,12 @@ final class DatabaseService {
             )
         }
 
+        migrator.registerMigration("v2_zynaAttributes") { db in
+            try db.alter(table: "storedMessage") { t in
+                t.add(column: "zynaAttributesJSON", .text)
+            }
+        }
+
         return migrator
     }
 }

--- a/Zyna/Services/Database/MessageWindow.swift
+++ b/Zyna/Services/Database/MessageWindow.swift
@@ -8,7 +8,9 @@ import GRDB
 
 /// Manages a cursor-based sliding window of messages for a single room.
 /// Queries GRDB on demand instead of observing all rows.
-/// All methods must be called on the main queue.
+/// Most methods mutate state and emit UI updates — call them on
+/// main. The `queryOlder()` read-only method is thread-safe and
+/// designed for use from Texture's background batch-fetch queue.
 final class MessageWindow {
 
     // MARK: - Configuration

--- a/Zyna/Services/Database/MessageWindow.swift
+++ b/Zyna/Services/Database/MessageWindow.swift
@@ -59,32 +59,56 @@ final class MessageWindow {
 
     // MARK: - Load Older (scroll up)
 
-    /// Returns true if messages were loaded from GRDB.
-    @discardableResult
-    func loadOlder(count: Int = pageSize) -> Bool {
-        guard let oldestTs = oldestTimestamp else { return false }
+    /// Result of an older-page GRDB query, ready to be applied on main.
+    struct OlderPage {
+        let merged: [StoredMessage]
+        let fetchedCount: Int
+        let trimmed: Bool
+    }
+
+    /// Pure GRDB read + merge/sort. Safe to call from any queue.
+    /// Returns nil when there's nothing to load.
+    func queryOlder(count: Int = pageSize) -> OlderPage? {
+        guard let oldestTs = oldestTimestamp else { return nil }
 
         let older = queryOlderThan(timestamp: oldestTs, limit: count)
-        guard !older.isEmpty else {
-            hasOlderInDB = false
-            return false
-        }
+        guard !older.isEmpty else { return nil }
 
-        // Build new window: existing + older
         var all = (previousStored ?? []) + older
         all.sort { $0.timestamp > $1.timestamp }
 
-        // Trim newest end if too large
         let maxSize = Self.windowSize + Self.trimThreshold
+        var trimmed = false
         if all.count > maxSize {
             all = Array(all.suffix(Self.windowSize))
-            hasNewerInDB = true
+            trimmed = true
         }
+        return OlderPage(
+            merged: all, fetchedCount: older.count, trimmed: trimmed
+        )
+    }
 
-        updateCursors(from: all)
+    /// Apply a pre-computed older page on the main thread. Mutates
+    /// cursors, flags, and fires onChange.
+    func applyOlder(_ page: OlderPage) {
+        if page.trimmed { hasNewerInDB = true }
+        updateCursors(from: page.merged)
         hasOlderInDB = checkHasOlderInDB()
-        emitChange(all)
-        log("loadOlder: +\(older.count), window=\(all.count)")
+        emitChange(page.merged)
+        log("loadOlder: +\(page.fetchedCount), window=\(page.merged.count)")
+    }
+
+    /// Legacy single-shot helper — performs both query and apply
+    /// synchronously on the caller's thread. Use for code paths
+    /// that are already on main. For bg-queue entry points, call
+    /// `queryOlder` then marshal `applyOlder` to main.
+    @discardableResult
+    func loadOlder(count: Int = pageSize) -> Bool {
+        guard let page = queryOlder(count: count) else {
+            if oldestTimestamp != nil { hasOlderInDB = false }
+            return false
+        }
+        applyOlder(page)
         return true
     }
 

--- a/Zyna/Services/Database/StoredMessage.swift
+++ b/Zyna/Services/Database/StoredMessage.swift
@@ -145,7 +145,8 @@ extension StoredMessage {
             content: content,
             reactions: Self.decodeReactions(reactionsJSON),
             replyInfo: replyInfo,
-            zynaAttributes: Self.decodeZynaAttributes(zynaAttributesJSON)
+            zynaAttributes: Self.decodeZynaAttributes(zynaAttributesJSON),
+            sendStatus: sendStatus
         )
     }
 

--- a/Zyna/Services/Database/StoredMessage.swift
+++ b/Zyna/Services/Database/StoredMessage.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import UIKit
 import GRDB
 import MatrixRustSDK
 
@@ -32,6 +33,11 @@ struct StoredMessage: Codable, FetchableRecord, PersistableRecord {
     var replySenderId: String?
     var replySenderName: String?
     var replyBody: String?
+
+    /// Serialised Zyna-specific message attributes (color, checklist,
+    /// callSignal etc.) extracted from the event's `formatted_body` HTML.
+    /// NULL when no attributes present.
+    var zynaAttributesJSON: String?
 }
 
 // MARK: - ChatMessage → StoredMessage
@@ -95,6 +101,8 @@ extension StoredMessage {
             self.replySenderName = reply.senderDisplayName
             self.replyBody = reply.body
         }
+
+        self.zynaAttributesJSON = Self.encodeZynaAttributes(msg.zynaAttributes)
     }
 }
 
@@ -136,7 +144,8 @@ extension StoredMessage {
             timestamp: Date(timeIntervalSince1970: timestamp),
             content: content,
             reactions: Self.decodeReactions(reactionsJSON),
-            replyInfo: replyInfo
+            replyInfo: replyInfo,
+            zynaAttributes: Self.decodeZynaAttributes(zynaAttributesJSON)
         )
     }
 
@@ -198,5 +207,40 @@ private extension StoredMessage {
         guard let data = json.data(using: .utf8),
               let items = try? JSONDecoder().decode([ReactionJSON].self, from: data) else { return [] }
         return items.map { MessageReaction(key: $0.key, count: $0.count, isOwn: $0.isOwn) }
+    }
+}
+
+// MARK: - Zyna attributes JSON
+
+private extension StoredMessage {
+
+    struct ZynaAttributesJSON: Codable {
+        let color: String?
+        let checklist: [ChecklistItem]?
+        let callSignal: CallSignalData?
+    }
+
+    static func encodeZynaAttributes(_ attrs: ZynaMessageAttributes) -> String? {
+        guard !attrs.isEmpty else { return nil }
+        let payload = ZynaAttributesJSON(
+            color: attrs.color?.hexString,
+            checklist: attrs.checklist,
+            callSignal: attrs.callSignal
+        )
+        guard let data = try? JSONEncoder().encode(payload),
+              let json = String(data: data, encoding: .utf8) else { return nil }
+        return json
+    }
+
+    static func decodeZynaAttributes(_ json: String?) -> ZynaMessageAttributes {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let payload = try? JSONDecoder().decode(ZynaAttributesJSON.self, from: data)
+        else { return ZynaMessageAttributes() }
+        return ZynaMessageAttributes(
+            color: payload.color.flatMap(UIColor.fromHexString),
+            checklist: payload.checklist,
+            callSignal: payload.callSignal
+        )
     }
 }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -119,6 +119,7 @@ final class TimelineService {
 
         let reactions = buildReactions(from: event)
         let replyInfo = buildReplyInfo(from: event)
+        let zynaAttributes = extractZynaAttributes(from: event)
 
         let itemIdentifier: ChatItemIdentifier? = {
             switch event.eventOrTransactionId {
@@ -137,8 +138,36 @@ final class TimelineService {
             timestamp: timestamp,
             content: content,
             reactions: reactions,
-            replyInfo: replyInfo
+            replyInfo: replyInfo,
+            zynaAttributes: zynaAttributes
         )
+    }
+
+    /// Extracts Zyna-specific attributes embedded in the event's
+    /// `formatted_body` HTML. Returns empty attributes for non-text
+    /// content or when no carrier span is present.
+    private static func extractZynaAttributes(from event: EventTimelineItem) -> ZynaMessageAttributes {
+        guard case .msgLike(let msgContent) = event.content,
+              case .message(let message) = msgContent.kind,
+              case .text = message.msgType
+        else { return ZynaMessageAttributes() }
+
+        // matrix-rust-sdk's typed path runs formatted_body through an HTML
+        // sanitiser that drops unknown attributes (including our data-zyna).
+        // Read the raw event JSON and extract formatted_body ourselves.
+        guard let rawJSON = event.lazyProvider.debugInfo().originalJson,
+              let formattedBody = Self.extractFormattedBodyFromRawEvent(rawJSON)
+        else { return ZynaMessageAttributes() }
+
+        return ZynaHTMLCodec.decode(htmlBody: formattedBody)
+    }
+
+    private static func extractFormattedBodyFromRawEvent(_ json: String) -> String? {
+        guard let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = root["content"] as? [String: Any]
+        else { return nil }
+        return content["formatted_body"] as? String
     }
 
     private static func buildReactions(from event: EventTimelineItem) -> [MessageReaction] {
@@ -274,6 +303,27 @@ final class TimelineService {
         do {
             try await timeline.send(msg: messageEventContentFromMarkdown(md: text))
             logTimeline("Message sent")
+        } catch {
+            logTimeline("Send failed: \(error)")
+        }
+    }
+
+    /// Sends a text message with a Zyna-specific HTML carrier that embeds
+    /// `ZynaMessageAttributes` (custom color, future checklist, etc.).
+    /// The plain `body` remains clean text for foreign clients.
+    func sendMessage(_ text: String, zynaAttributes: ZynaMessageAttributes) async {
+        guard let timeline else { return }
+        // Foreign clients will show `text` verbatim; Zyna reads the
+        // data-zyna span out of formatted_body on receive.
+        let htmlBody = ZynaHTMLCodec.encode(
+            userHTML: ZynaHTMLCodec.escapeForHTMLAttribute(text),
+            attributes: zynaAttributes
+        )
+        do {
+            try await timeline.send(msg: messageEventContentFromHtml(
+                body: text, htmlBody: htmlBody
+            ))
+            logTimeline("Message sent with Zyna attrs")
         } catch {
             logTimeline("Send failed: \(error)")
         }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -252,13 +252,13 @@ final class TimelineService {
 
     // MARK: - Pagination
 
-    func paginateBackwards() async {
+    func paginateBackwards(numEvents: UInt16 = 20) async {
         guard let timeline, !isPaginatingSubject.value else { return }
 
         await MainActor.run { isPaginatingSubject.send(true) }
 
         do {
-            try await timeline.paginateBackwards(numEvents: 20)
+            try await timeline.paginateBackwards(numEvents: numEvents)
             logTimeline("Paginated backwards successfully")
         } catch {
             logTimeline("Pagination failed: \(error)")

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -155,11 +155,29 @@ final class TimelineService {
         // matrix-rust-sdk's typed path runs formatted_body through an HTML
         // sanitiser that drops unknown attributes (including our data-zyna).
         // Read the raw event JSON and extract formatted_body ourselves.
-        guard let rawJSON = event.lazyProvider.debugInfo().originalJson,
-              let formattedBody = Self.extractFormattedBodyFromRawEvent(rawJSON)
+        // Primary path: parse raw event JSON (unmodified by SDK sanitiser).
+        if let rawJSON = event.lazyProvider.debugInfo().originalJson,
+           let formatted = Self.extractFormattedBodyFromRawEvent(rawJSON) {
+            return ZynaHTMLCodec.decode(htmlBody: formatted)
+        }
+
+        // Fallback for our own just-sent messages: during the brief
+        // window where the local-echo and first sync diffs arrive
+        // without the prepared rawJSON, the bubble would flash default
+        // blue. Look up the colour we just stashed in the cache.
+        guard event.isOwn,
+              case .msgLike(let c) = event.content,
+              case .message(let m) = c.kind,
+              case .text(let t) = m.msgType
         else { return ZynaMessageAttributes() }
 
-        return ZynaHTMLCodec.decode(htmlBody: formattedBody)
+        if let cached = OutgoingAttributesCache.shared.peek(
+            body: t.body,
+            senderId: event.sender
+        ) {
+            return cached
+        }
+        return ZynaMessageAttributes()
     }
 
     private static func extractFormattedBodyFromRawEvent(_ json: String) -> String? {
@@ -319,6 +337,17 @@ final class TimelineService {
             userHTML: ZynaHTMLCodec.escapeForHTMLAttribute(text),
             attributes: zynaAttributes
         )
+
+        // Optimistic cache so the local echo / pre-rawJSON timeline
+        // updates can render the bubble with the right color instead
+        // of flashing through the default blue first.
+        let senderId = (try? MatrixClientService.shared.client?.userId()) ?? ""
+        OutgoingAttributesCache.shared.remember(
+            attributes: zynaAttributes,
+            body: text,
+            senderId: senderId
+        )
+
         do {
             try await timeline.send(msg: messageEventContentFromHtml(
                 body: text, htmlBody: htmlBody

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -139,7 +139,8 @@ final class TimelineService {
             content: content,
             reactions: reactions,
             replyInfo: replyInfo,
-            zynaAttributes: zynaAttributes
+            zynaAttributes: zynaAttributes,
+            sendStatus: "synced"
         )
     }
 

--- a/Zyna/UIComponents/GradientButton.swift
+++ b/Zyna/UIComponents/GradientButton.swift
@@ -5,14 +5,15 @@
 
 import AsyncDisplayKit
 
-final class GradientButton: BaseNode {
+final class GradientButton: ASDisplayNode {
     let button: ButtonNode
     private let gradient: GradientNode
-    
+
     init(title: String, gradientStyle: GradientNodeStyle) {
         self.button = ButtonNode(title: title)
         self.gradient = GradientNode(nodeStyle: gradientStyle)
         super.init()
+        automaticallyManagesSubnodes = true
         self.cornerRadius = 16
         self.cornerRoundingType = .clipping
     }

--- a/Zyna/UIComponents/TextInputNode.swift
+++ b/Zyna/UIComponents/TextInputNode.swift
@@ -5,7 +5,7 @@
 
 import AsyncDisplayKit
 
-final class TextInputNode: BaseNode {
+final class TextInputNode: ASDisplayNode {
     
     enum FieldType {
         case regular
@@ -28,6 +28,7 @@ final class TextInputNode: BaseNode {
         self.placeholder = placeholder
         self.type = type
         super.init()
+        automaticallyManagesSubnodes = true
         setupUI()
     }
     override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {

--- a/ZynaTests/ZynaHTMLCodecTests.swift
+++ b/ZynaTests/ZynaHTMLCodecTests.swift
@@ -1,0 +1,217 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Testing
+import Foundation
+import UIKit
+@testable import Zyna
+
+@Suite("ZynaHTMLCodec")
+struct ZynaHTMLCodecTests {
+
+    // MARK: - Empty attributes
+
+    @Test("Empty attributes: HTML unchanged, no carrier span")
+    func emptyAttributes() {
+        let result = ZynaHTMLCodec.encode(
+            userHTML: "Hello",
+            attributes: ZynaMessageAttributes()
+        )
+        #expect(result == "Hello")
+        #expect(!result.contains("data-zyna"))
+    }
+
+    @Test("Empty checklist treated as empty")
+    func emptyChecklist() {
+        let attrs = ZynaMessageAttributes(checklist: [])
+        #expect(attrs.isEmpty)
+    }
+
+    // MARK: - Color
+
+    @Test("Color round-trip")
+    func colorRoundTrip() {
+        let red = UIColor(red: 1, green: 0, blue: 0, alpha: 1)
+        let html = ZynaHTMLCodec.encode(
+            userHTML: "Hi",
+            attributes: ZynaMessageAttributes(color: red)
+        )
+        #expect(html.hasPrefix("Hi"))
+        #expect(html.contains("data-zyna"))
+        #expect(html.contains("#FF0000"))
+
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.color?.hexString == "#FF0000")
+        #expect(decoded.checklist == nil)
+        #expect(decoded.callSignal == nil)
+    }
+
+    // MARK: - Checklist
+
+    @Test("Checklist round-trip")
+    func checklistRoundTrip() {
+        let items = [
+            ChecklistItem(text: "buy milk", checked: false),
+            ChecklistItem(text: "call mom", checked: true)
+        ]
+        let html = ZynaHTMLCodec.encode(
+            userHTML: "Todo",
+            attributes: ZynaMessageAttributes(checklist: items)
+        )
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.checklist == items)
+    }
+
+    // MARK: - Call signal
+
+    @Test("Call signal (ICE candidate) round-trip")
+    func callSignalRoundTrip() {
+        let signal = CallSignalData(
+            type: "ice-candidate",
+            callId: "call-123",
+            sdp: nil,
+            candidate: "candidate:foundation 1 udp 2130706431 192.168.1.1 54321 typ host"
+        )
+        let html = ZynaHTMLCodec.encode(
+            userHTML: "📞",
+            attributes: ZynaMessageAttributes(callSignal: signal)
+        )
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.callSignal == signal)
+    }
+
+    @Test("Call signal (offer with SDP) round-trip")
+    func callOfferRoundTrip() {
+        let signal = CallSignalData(
+            type: "offer",
+            callId: "call-abc",
+            sdp: "v=0\r\no=- 123 2 IN IP4 0.0.0.0\r\n",
+            candidate: nil
+        )
+        let html = ZynaHTMLCodec.encode(
+            userHTML: "📞",
+            attributes: ZynaMessageAttributes(callSignal: signal)
+        )
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.callSignal?.sdp == signal.sdp)
+        #expect(decoded.callSignal?.candidate == nil)
+    }
+
+    // MARK: - All fields
+
+    @Test("All attributes together round-trip")
+    func allFieldsRoundTrip() {
+        let attrs = ZynaMessageAttributes(
+            color: UIColor(red: 0, green: 0.5, blue: 1, alpha: 1),
+            checklist: [ChecklistItem(text: "x", checked: true)],
+            callSignal: nil
+        )
+        let html = ZynaHTMLCodec.encode(userHTML: "Hello", attributes: attrs)
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.color?.hexString == "#0080FF")
+        #expect(decoded.checklist?.count == 1)
+        #expect(decoded.checklist?.first?.text == "x")
+        #expect(decoded.checklist?.first?.checked == true)
+    }
+
+    // MARK: - HTML preservation
+
+    @Test("User HTML with formatting is preserved")
+    func userHTMLPreserved() {
+        let userHTML = "<b>Bold</b> and <i>italic</i>"
+        let html = ZynaHTMLCodec.encode(
+            userHTML: userHTML,
+            attributes: ZynaMessageAttributes(color: .red)
+        )
+        #expect(html.hasPrefix(userHTML))
+    }
+
+    @Test("User HTML with quotes doesn't break carrier extraction")
+    func userHTMLWithQuotes() {
+        let userHTML = #"<a href="https://example.com">link</a>"#
+        let attrs = ZynaMessageAttributes(color: UIColor.red)
+        let html = ZynaHTMLCodec.encode(userHTML: userHTML, attributes: attrs)
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.color?.hexString == "#FF0000")
+    }
+
+    // MARK: - Decoding edge cases
+
+    @Test("Decode empty HTML returns empty attributes")
+    func decodeEmpty() {
+        let decoded = ZynaHTMLCodec.decode(htmlBody: "")
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("Decode HTML without carrier returns empty")
+    func decodeNoCarrier() {
+        let decoded = ZynaHTMLCodec.decode(htmlBody: "<b>Just text</b>")
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("Decode malformed JSON returns empty")
+    func decodeMalformedJSON() {
+        let decoded = ZynaHTMLCodec.decode(
+            htmlBody: #"Hi<span data-zyna="not json"></span>"#
+        )
+        #expect(decoded.isEmpty)
+    }
+
+    @Test("Decode tolerates unknown keys (forward-compat)")
+    func decodeUnknownKeys() {
+        // Simulates a future Zyna version adding new keys.
+        let html = #"Hi<span data-zyna="{&quot;v&quot;:99,&quot;color&quot;:&quot;#FF0000&quot;,&quot;futureThing&quot;:&quot;ignoreMe&quot;}"></span>"#
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.color?.hexString == "#FF0000")
+    }
+
+    @Test("Decode finds carrier anywhere in the HTML")
+    func decodeCarrierAnywhere() {
+        // Attribute span could appear at any position — parser must find it.
+        let html = #"<span data-zyna="{&quot;v&quot;:1,&quot;color&quot;:&quot;#00FF00&quot;}"></span>Hello world"#
+        let decoded = ZynaHTMLCodec.decode(htmlBody: html)
+        #expect(decoded.color?.hexString == "#00FF00")
+    }
+
+    // MARK: - JSON shape stability
+
+    @Test("Encoded JSON contains version v:1")
+    func encodedIncludesVersion() {
+        let html = ZynaHTMLCodec.encode(
+            userHTML: "x",
+            attributes: ZynaMessageAttributes(color: .red)
+        )
+        #expect(html.contains("&quot;v&quot;:1"))
+    }
+
+    @Test("Encode is deterministic (sorted keys)")
+    func encodeDeterministic() {
+        let attrs = ZynaMessageAttributes(
+            color: .red,
+            checklist: [ChecklistItem(text: "a", checked: false)]
+        )
+        let a = ZynaHTMLCodec.encode(userHTML: "x", attributes: attrs)
+        let b = ZynaHTMLCodec.encode(userHTML: "x", attributes: attrs)
+        #expect(a == b)
+    }
+
+    // MARK: - HTML escaping
+
+    @Test("Escape and unescape round-trip")
+    func escapeRoundTrip() {
+        let samples = [
+            "plain",
+            "has \"quotes\"",
+            "with <tag> inside",
+            "ampersand & more",
+            "mixed \"<tag>\" & \"other\""
+        ]
+        for s in samples {
+            let escaped = ZynaHTMLCodec.escapeForHTMLAttribute(s)
+            let unescaped = ZynaHTMLCodec.unescapeFromHTMLAttribute(escaped)
+            #expect(unescaped == s, "round-trip failed for: \(s)")
+        }
+    }
+}

--- a/ZynaTests/ZynaTests.swift
+++ b/ZynaTests/ZynaTests.swift
@@ -1,0 +1,16 @@
+//
+//  ZynaTests.swift
+//  ZynaTests
+//
+//  Created by Dmitry Markovskiy on 05.04.2026.
+//
+
+import Testing
+
+struct ZynaTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}


### PR DESCRIPTION
## Summary

Stage 10 lands four independent chat features and the infrastructure behind them. Everything stays on the typed matrix-rust-sdk send path — no SDK fork, no `sendRaw` for user messages.

## Features

### Background history sync
Every room back-paginates its full history into GRDB on chat open, so scrolling up is instant once synced. DB is the UI's source of truth; Timeline diffs flow through `TimelineDiffBatcher`.

### In-chat search
GRDB-backed search with navigation between results, search bar component, and `ChatSearchState` model.

### Room details screen
Dedicated screen showing room metadata, member list, and a search button exposed from profiles.

### Custom message attributes (extensible)
Zyna-specific data rides in `formatted_body` as a hidden `<span data-zyna="{...}">` carrier. Foreign Matrix clients render only the plain body; Zyna extracts attributes from raw event JSON (bypassing the SDK's HTML sanitiser). Schema is versioned (`v:1`) and easy to extend — see `ZynaMessageAttributes` + `ZynaHTMLCodec`.

First concrete attribute: **custom bubble colour**, picked via a long-press arc palette on the Send button (drag → highlight + haptic → send). Scaffolded for future features: checklist, call-signal payloads.

### Message status indicator
Clock/check/delivered/failed icons to the right of each outgoing bubble's timestamp. Drawn via shared cached `UIImage`s (generated once, tinted per-cell via `imageModificationBlock`) and composited with `ASImageNode`s — zero per-cell CPU at scroll time. Clock hand rotates via `CABasicAnimation` on the GPU compositor. Currently stubbed as "synced"; real per-stage tracking lands when we wire `SendHandle` observation.

## Infrastructure

- **`CLAUDE.md`** — project instructions (Texture principles, main-thread discipline, SDK constraints, file organisation, pitfalls learned along the way).
- **`Atomic<T>`** utility (OSAllocatedUnfairLock-backed).
- **`NetworkReachability`** singleton wrapping NWPathMonitor, with documented VPN / captive-portal caveats.
- **`OutgoingAttributesCache`** — short-lived TTL cache so just-sent coloured bubbles don't flash default-blue while the SDK's raw event JSON is still being prepared.
- **Swift Testing** target (`ZynaTests`) with 19 unit tests for the HTML codec round-trip.
- **`BaseNode` → `ScreenNode`** rename and related decoupling.

## Perf / fixes

- Chat pagination's GRDB query now runs on the Texture-provided background queue; only the UI-mutating apply step marshals to main. Fixes a chat-open freeze and main-thread warnings when scrolling up.
- Bubble renders its custom colour from `ZynaMessageAttributes`.
- Input bar long-press gesture safely coexists with the mic-hold gesture via scoped hit regions.

## Test plan

- [x] Open chat — no visible freeze, history appears instantly
- [x] Scroll up — pagination smooth, no main-thread warnings
- [x] Long-press Send → drag over palette → release on colour → coloured bubble is sent
- [x] Release off-colour → palette sticks, tap elsewhere closes it
- [x] Sent coloured bubbles display correctly; Element shows only plain text (no data-zyna artefacts)
- [x] Status indicator (double-tick) appears on own bubbles
- [x] Search: open → type → navigate results
- [x] Room details from profile → verify data
- [x] Unit tests pass: `Cmd+U`
