### PR TITLE
Stage 11: File sharing, calls, contacts, invites, and verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ the work instead: bg query → (result) → main apply.
 
 ## Pitfalls / lessons learned
 
+- **`UIImage(systemName:)` returns nil off-main.** Texture
+  creates cell nodes on background threads, so SF Symbol
+  images built inline in `init()` will silently be nil. Use
+  `AppIcon` (pre-rendered `static let` via
+  `UIGraphicsImageRenderer`) to create images once on main
+  and share them across cells. Same applies to any UIKit API
+  that requires main thread.
 - **Never use self-rescheduling `DispatchQueue.main.async`
   loops** to "wait until X is ready". They burn CPU if the
   condition never flips. Use proper lifecycle hooks instead

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ the work instead: bg query → (result) → main apply.
 - Commit messages: conventional style (`feat:`, `fix:`, `chore:`,
   `refactor:`, `perf:`, `docs:`)
 - Commit title ≤ 72 chars; body optional but welcome for context
+- Commit body: do NOT hard-wrap at 72 chars. Break lines naturally
+  at sentence boundaries for readability, not at a fixed column.
 - PR titles do NOT use conventional prefixes — just a clear
   human-readable title (GitHub categorises PRs via labels/status)
 - PR descriptions are markdown rendered by GitHub — do NOT wrap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,11 @@ the work instead: bg query → (result) → main apply.
 - Commit title ≤ 72 chars; body optional but welcome for context
 - Commit body: do NOT hard-wrap at 72 chars. Break lines naturally
   at sentence boundaries for readability, not at a fixed column.
+- Commit body length follows the work, not a quota: include every
+  load-bearing piece of context (the *why*, the non-obvious trade-offs,
+  the edge cases that motivated a design) but no filler. The diff
+  shows *what* changed — the body explains what the diff can't.
+  A two-line tweak gets two lines; a subtle refactor gets a long body.
 - PR titles do NOT use conventional prefixes — just a clear
   human-readable title (GitHub categorises PRs via labels/status)
 - PR descriptions are markdown rendered by GitHub — do NOT wrap

--- a/Scripts/encode_selector.py
+++ b/Scripts/encode_selector.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Encode a selector string into a masked byte array for DynamicAction."""
+
+import sys
+
+def encode(selector: str, mask: int = 0xA7) -> list[int]:
+    return [b ^ mask for b in selector.encode("ascii")]
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <selector> [mask_hex]")
+        sys.exit(1)
+
+    sel = sys.argv[1]
+    mask = int(sys.argv[2], 16) if len(sys.argv) > 2 else 0xA7
+
+    encoded = encode(sel, mask)
+    swift = ", ".join(f"0x{b:02X}" for b in encoded)
+    print(f"[{swift}]")

--- a/Zyna.xcodeproj/project.pbxproj
+++ b/Zyna.xcodeproj/project.pbxproj
@@ -300,7 +300,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -320,7 +321,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Zyna;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ZynaDistrib;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -339,7 +340,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -359,7 +361,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Zyna;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ZynaDistrib;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Zyna/App/Info.plist
+++ b/Zyna/App/Info.plist
@@ -13,6 +13,11 @@
 			<string>com.markovsdima.Zyna.oidc</string>
 		</dict>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Zyna/App/Info.plist
+++ b/Zyna/App/Info.plist
@@ -20,6 +20,8 @@
 	</dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Zyna needs access to your camera for video calls and sharing photos.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Zyna needs access to your microphone for voice calls.</string>
 	<key>UIBackgroundModes</key>

--- a/Zyna/Chat/CellNodes/CallEventCellNode.swift
+++ b/Zyna/Chat/CellNodes/CallEventCellNode.swift
@@ -1,0 +1,66 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+/// Centered system-message style cell for call events
+/// (e.g. "Call", "Call ended", "Missed call").
+final class CallEventCellNode: ASCellNode {
+
+    private let labelNode = ASTextNode()
+
+    init(message: ChatMessage) {
+        super.init()
+        automaticallyManagesSubnodes = true
+        selectionStyle = .none
+
+        let text: String
+        let icon: String
+
+        if case .callEvent(let type, _, let reason) = message.content {
+            let displayText = type.displayText(reason: reason)
+            icon = (reason == "timeout" || reason == "declined") ? "phone.arrow.down.left" : "phone"
+            text = displayText
+        } else {
+            icon = "phone"
+            text = "Call"
+        }
+
+        let timeString = MessageCellHelpers.timeFormatter.string(from: message.timestamp)
+        let direction = message.isOutgoing ? "Outgoing" : "Incoming"
+
+        let attachment = NSTextAttachment()
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        attachment.image = UIImage(systemName: icon, withConfiguration: iconConfig)?
+            .withTintColor(.secondaryLabel, renderingMode: .alwaysOriginal)
+
+        let result = NSMutableAttributedString()
+        result.append(NSAttributedString(attachment: attachment))
+        result.append(NSAttributedString(
+            string: " \(direction) · \(text) · \(timeString)",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 13),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        ))
+
+        labelNode.attributedText = result
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let centered = ASCenterLayoutSpec(
+            centeringOptions: .XY,
+            sizingOptions: .minimumXY,
+            child: labelNode
+        )
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 4, left: 16, bottom: 4, right: 16),
+            child: centered
+        )
+    }
+}

--- a/Zyna/Chat/CellNodes/CallEventCellNode.swift
+++ b/Zyna/Chat/CellNodes/CallEventCellNode.swift
@@ -5,24 +5,20 @@
 
 import AsyncDisplayKit
 
-/// Centered system-message style cell for call events
+/// Centered system cell for call events
 /// (e.g. "Call", "Call ended", "Missed call").
-final class CallEventCellNode: ASCellNode {
-
-    private let labelNode = ASTextNode()
+final class CallEventCellNode: SystemEventCellNode {
 
     init(message: ChatMessage) {
         super.init()
-        automaticallyManagesSubnodes = true
-        selectionStyle = .none
 
         let text: String
         let icon: String
 
         if case .callEvent(let type, _, let reason) = message.content {
-            let displayText = type.displayText(reason: reason)
-            icon = (reason == "timeout" || reason == "declined") ? "phone.arrow.down.left" : "phone"
-            text = displayText
+            text = type.displayText(reason: reason)
+            icon = (reason == "timeout" || reason == "declined")
+                ? "phone.arrow.down.left" : "phone"
         } else {
             icon = "phone"
             text = "Call"
@@ -47,20 +43,5 @@ final class CallEventCellNode: ASCellNode {
         ))
 
         labelNode.attributedText = result
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { fatalError() }
-
-    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        let centered = ASCenterLayoutSpec(
-            centeringOptions: .XY,
-            sizingOptions: .minimumXY,
-            child: labelNode
-        )
-        return ASInsetLayoutSpec(
-            insets: UIEdgeInsets(top: 4, left: 16, bottom: 4, right: 16),
-            child: centered
-        )
     }
 }

--- a/Zyna/Chat/CellNodes/FileCellNode.swift
+++ b/Zyna/Chat/CellNodes/FileCellNode.swift
@@ -1,0 +1,341 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class FileCellNode: MessageCellNode {
+
+    // MARK: - Callbacks
+
+    var onFileTapped: (() -> Void)?
+
+    // MARK: - Subnodes
+
+    private let iconBackgroundNode = ASDisplayNode()
+    private let extensionTextNode = ASTextNode()
+    private let filenameNode = ASTextNode()
+    private let sizeNode = ASTextNode()
+    private let progressNode = CircularProgressNode()
+
+    // MARK: - State
+
+    private let mediaSource: MediaSource?
+    private let filename: String
+    private let mimetype: String?
+    private let fileSize: UInt64?
+
+    /// Current download state, drives progress indicator visibility.
+    enum DownloadState {
+        case idle
+        case downloading(progress: Double)
+        case downloaded
+    }
+
+    private(set) var downloadState: DownloadState = .idle {
+        didSet { updateProgressDisplay() }
+    }
+
+    // MARK: - Init
+
+    override init(message: ChatMessage, isGroupChat: Bool = false) {
+        var source: MediaSource?
+        var fname = "file"
+        var mime: String?
+        var size: UInt64?
+
+        if case .file(let src, let f, let m, let s) = message.content {
+            source = src
+            fname = f
+            mime = m
+            size = s
+        }
+
+        self.mediaSource = source
+        self.filename = fname
+        self.mimetype = mime
+        self.fileSize = size
+
+        super.init(message: message, isGroupChat: isGroupChat)
+
+        let ext = (fname as NSString).pathExtension.uppercased()
+        let extColor = Self.colorForExtension(ext)
+
+        // Icon background — colored rounded square
+        iconBackgroundNode.backgroundColor = extColor.withAlphaComponent(0.15)
+        iconBackgroundNode.cornerRadius = 10
+        iconBackgroundNode.style.preferredSize = CGSize(width: 44, height: 44)
+
+        // Extension label centered in icon
+        extensionTextNode.attributedText = NSAttributedString(
+            string: ext.isEmpty ? "FILE" : String(ext.prefix(4)),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 12, weight: .bold),
+                .foregroundColor: extColor
+            ]
+        )
+
+        // Filename
+        filenameNode.maximumNumberOfLines = 1
+        filenameNode.truncationMode = .byTruncatingMiddle
+        filenameNode.attributedText = NSAttributedString(
+            string: fname,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 15, weight: .medium),
+                .foregroundColor: isOutgoing ? UIColor.white : UIColor.label
+            ]
+        )
+
+        // Size
+        sizeNode.attributedText = NSAttributedString(
+            string: Self.formattedSize(size),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 12),
+                .foregroundColor: isOutgoing
+                    ? UIColor.white.withAlphaComponent(0.7)
+                    : UIColor.secondaryLabel
+            ]
+        )
+
+        // Progress node — hidden by default
+        progressNode.style.preferredSize = CGSize(width: 44, height: 44)
+        progressNode.isHidden = true
+        progressNode.trackColor = extColor.withAlphaComponent(0.2)
+        progressNode.progressColor = extColor
+
+        // Bubble layout
+        bubbleNode.layoutSpecBlock = { [weak self] _, constrainedSize in
+            guard let self else { return ASLayoutSpec() }
+
+            let maxWidth = ScreenConstants.width * MessageCellHelpers.maxBubbleWidthRatio
+
+            // Icon with extension label centered
+            let extCenter = ASCenterLayoutSpec(
+                centeringOptions: .XY,
+                sizingOptions: .minimumXY,
+                child: self.extensionTextNode
+            )
+            let iconWithLabel = ASOverlayLayoutSpec(
+                child: self.iconBackgroundNode,
+                overlay: extCenter
+            )
+
+            // Progress overlay on icon
+            let iconWithProgress = ASOverlayLayoutSpec(
+                child: iconWithLabel,
+                overlay: self.progressNode
+            )
+
+            // Status icon next to time if present
+            var timeChildren: [ASLayoutElement] = [self.timeNode]
+            if let statusIcon = self.statusIconNode {
+                statusIcon.style.preferredSize = CGSize(width: 15, height: 11)
+                timeChildren.append(statusIcon)
+            }
+            let timeRow = ASStackLayoutSpec(
+                direction: .horizontal,
+                spacing: 3,
+                justifyContent: .end,
+                alignItems: .center,
+                children: timeChildren
+            )
+
+            // Size + time row
+            let bottomRow = ASStackLayoutSpec(
+                direction: .horizontal,
+                spacing: 4,
+                justifyContent: .spaceBetween,
+                alignItems: .center,
+                children: [self.sizeNode, timeRow]
+            )
+            bottomRow.style.width = ASDimension(unit: .fraction, value: 1)
+
+            let rightColumn = ASStackLayoutSpec(
+                direction: .vertical,
+                spacing: 2,
+                justifyContent: .center,
+                alignItems: .start,
+                children: [self.filenameNode, bottomRow]
+            )
+            rightColumn.style.flexShrink = 1
+            rightColumn.style.flexGrow = 1
+
+            // Main row
+            let mainRow = ASStackLayoutSpec(
+                direction: .horizontal,
+                spacing: 10,
+                justifyContent: .start,
+                alignItems: .center,
+                children: [iconWithProgress, rightColumn]
+            )
+            mainRow.style.maxWidth = ASDimension(unit: .points, value: maxWidth)
+
+            var contentChildren: [ASLayoutElement] = []
+
+            if let replyHeader = self.replyHeaderNode {
+                let replyInset = ASInsetLayoutSpec(
+                    insets: UIEdgeInsets(top: 0, left: 0, bottom: 4, right: 0),
+                    child: replyHeader
+                )
+                contentChildren.append(replyInset)
+            }
+            contentChildren.append(mainRow)
+
+            let column = ASStackLayoutSpec(
+                direction: .vertical,
+                spacing: 0,
+                justifyContent: .start,
+                alignItems: .stretch,
+                children: contentChildren
+            )
+
+            return ASInsetLayoutSpec(
+                insets: UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12),
+                child: column
+            )
+        }
+
+        // Tap handling via ContextSourceNode quick tap
+        contextSourceNode.onQuickTap = { [weak self] point in
+            guard let self else { return }
+            // If the tap lands on reply header, let parent handle it
+            if let replyView = self.replyHeaderNode?.view,
+               self.isNodeLoaded {
+                let replyPoint = self.contextSourceNode.view.convert(point, to: replyView)
+                if replyView.bounds.contains(replyPoint) {
+                    self.onReplyHeaderTapped?(message.replyInfo?.eventId ?? "")
+                    return
+                }
+            }
+            self.onFileTapped?()
+        }
+    }
+
+    // MARK: - Progress
+
+    func setDownloadState(_ state: DownloadState) {
+        self.downloadState = state
+    }
+
+    private func updateProgressDisplay() {
+        switch downloadState {
+        case .idle:
+            progressNode.isHidden = true
+        case .downloading(let progress):
+            progressNode.isHidden = false
+            progressNode.progress = progress
+        case .downloaded:
+            progressNode.isHidden = true
+        }
+    }
+
+    // MARK: - Helpers
+
+    static func colorForExtension(_ ext: String) -> UIColor {
+        switch ext.lowercased() {
+        case "pdf", "ppt", "pptx":
+            return .systemRed
+        case "xls", "xlsx", "csv", "numbers":
+            return .systemGreen
+        case "zip", "rar", "7z", "gz", "tar":
+            return .systemYellow
+        case "doc", "docx", "txt", "rtf", "pages":
+            return .systemBlue
+        case "mp3", "wav", "aac", "flac", "m4a":
+            return .systemPurple
+        case "mp4", "mov", "avi", "mkv", "webm":
+            return .systemOrange
+        case "jpg", "jpeg", "png", "gif", "webp", "heic":
+            return .systemTeal
+        default:
+            return .systemBlue
+        }
+    }
+
+    static func formattedSize(_ bytes: UInt64?) -> String {
+        guard let bytes else { return "Unknown size" }
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(bytes))
+    }
+}
+
+// MARK: - Circular Progress Node
+
+/// Lightweight circular progress indicator drawn via CAShapeLayer.
+/// Runs on GPU, zero per-frame CPU cost.
+final class CircularProgressNode: ASDisplayNode {
+
+    var trackColor: UIColor = .systemGray4 {
+        didSet { if isNodeLoaded { trackLayer.strokeColor = trackColor.cgColor } }
+    }
+    var progressColor: UIColor = .systemBlue {
+        didSet { if isNodeLoaded { progressLayer.strokeColor = progressColor.cgColor } }
+    }
+    var lineWidth: CGFloat = 3
+
+    /// 0.0 – 1.0. Negative means indeterminate.
+    var progress: Double = 0 {
+        didSet { updateProgress() }
+    }
+
+    private var trackLayer = CAShapeLayer()
+    private var progressLayer = CAShapeLayer()
+
+    override func didLoad() {
+        super.didLoad()
+
+        trackLayer.fillColor = nil
+        trackLayer.strokeColor = trackColor.cgColor
+        trackLayer.lineWidth = lineWidth
+        trackLayer.lineCap = .round
+
+        progressLayer.fillColor = nil
+        progressLayer.strokeColor = progressColor.cgColor
+        progressLayer.lineWidth = lineWidth
+        progressLayer.lineCap = .round
+        progressLayer.strokeEnd = 0
+
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(progressLayer)
+    }
+
+    override func layout() {
+        super.layout()
+        let inset: CGFloat = 4
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+        let path = UIBezierPath(
+            arcCenter: CGPoint(x: rect.midX, y: rect.midY),
+            radius: rect.width / 2,
+            startAngle: -.pi / 2,
+            endAngle: .pi * 1.5,
+            clockwise: true
+        ).cgPath
+        trackLayer.path = path
+        trackLayer.frame = bounds
+        progressLayer.path = path
+        progressLayer.frame = bounds
+    }
+
+    private func updateProgress() {
+        guard isNodeLoaded else { return }
+        if progress < 0 {
+            // Indeterminate — spin
+            progressLayer.strokeEnd = 0.25
+            if progressLayer.animation(forKey: "spin") == nil {
+                let anim = CABasicAnimation(keyPath: "transform.rotation.z")
+                anim.fromValue = 0
+                anim.toValue = Double.pi * 2
+                anim.duration = 1
+                anim.repeatCount = .infinity
+                progressLayer.add(anim, forKey: "spin")
+            }
+        } else {
+            progressLayer.removeAnimation(forKey: "spin")
+            progressLayer.transform = CATransform3DIdentity
+            progressLayer.strokeEnd = CGFloat(min(max(progress, 0), 1))
+        }
+    }
+}

--- a/Zyna/Chat/CellNodes/SystemEventCellNode.swift
+++ b/Zyna/Chat/CellNodes/SystemEventCellNode.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+/// Base class for centered system-event cells (calls, room changes,
+/// membership events, etc.). Subclasses provide the attributed text;
+/// layout and styling are handled here.
+class SystemEventCellNode: ASCellNode {
+
+    let labelNode = ASTextNode()
+
+    override init() {
+        super.init()
+        automaticallyManagesSubnodes = true
+        selectionStyle = .none
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let centered = ASCenterLayoutSpec(
+            centeringOptions: .XY,
+            sizingOptions: .minimumXY,
+            child: labelNode
+        )
+        return ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 4, left: 16, bottom: 4, right: 16),
+            child: centered
+        )
+    }
+}

--- a/Zyna/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/TextMessageCellNode.swift
@@ -37,6 +37,8 @@ final class TextMessageCellNode: MessageCellNode {
             bodyText = "🎤 Voice message"
         case .file(_, let filename, _, _):
             bodyText = "📎 \(filename)"
+        case .callEvent(let type, _, let reason):
+            bodyText = "📞 \(type.displayText(reason: reason))"
         case .unsupported(let typeName):
             bodyText = "[\(typeName)]"
         case .redacted:

--- a/Zyna/Chat/CellNodes/TextMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/TextMessageCellNode.swift
@@ -35,6 +35,8 @@ final class TextMessageCellNode: MessageCellNode {
             bodyText = "📷 Photo"
         case .voice:
             bodyText = "🎤 Voice message"
+        case .file(_, let filename, _, _):
+            bodyText = "📎 \(filename)"
         case .unsupported(let typeName):
             bodyText = "[\(typeName)]"
         case .redacted:

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -15,6 +15,7 @@ enum ChatMessageContent: Equatable {
     case emote(body: String)
     case voice(source: MediaSource, duration: TimeInterval, waveform: [UInt16])
     case file(source: MediaSource, filename: String, mimetype: String?, size: UInt64?)
+    case callEvent(type: CallEventType, callId: String, reason: String?)
     case unsupported(typeName: String)
     case redacted
 
@@ -29,6 +30,7 @@ enum ChatMessageContent: Equatable {
         case .image: return "Photo"
         case .voice: return "Voice message"
         case .file(_, let filename, _, _): return filename
+        case .callEvent(let type, _, let reason): return type.displayText(reason: reason)
         case .notice(let body): return body
         case .emote(let body): return body
         case .unsupported: return "Message"
@@ -46,6 +48,8 @@ enum ChatMessageContent: Equatable {
             return s1.url() == s2.url() && d1 == d2 && w1 == w2
         case (.file(let s1, let f1, let m1, let sz1), .file(let s2, let f2, let m2, let sz2)):
             return s1.url() == s2.url() && f1 == f2 && m1 == m2 && sz1 == sz2
+        case (.callEvent(let t1, let c1, let r1), .callEvent(let t2, let c2, let r2)):
+            return t1 == t2 && c1 == c2 && r1 == r2
         case (.notice(let a), .notice(let b)):
             return a == b
         case (.emote(let a), .emote(let b)):
@@ -56,6 +60,27 @@ enum ChatMessageContent: Equatable {
             return true
         default:
             return false
+        }
+    }
+}
+
+// MARK: - Call Event Type
+
+enum CallEventType: String, Codable, Equatable {
+    case invited    // call was initiated
+    case ended      // call ended (reason in separate field)
+
+    func displayText(reason: String?) -> String {
+        switch self {
+        case .invited:
+            return "Call"
+        case .ended:
+            switch reason {
+            case "timeout":   return "Missed call"
+            case "declined":  return "Declined call"
+            case "busy":      return "Busy"
+            default:          return "Call ended"
+            }
         }
     }
 }

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -14,6 +14,7 @@ enum ChatMessageContent: Equatable {
     case notice(body: String)
     case emote(body: String)
     case voice(source: MediaSource, duration: TimeInterval, waveform: [UInt16])
+    case file(source: MediaSource, filename: String, mimetype: String?, size: UInt64?)
     case unsupported(typeName: String)
     case redacted
 
@@ -27,6 +28,7 @@ enum ChatMessageContent: Equatable {
         case .text(let body): return body
         case .image: return "Photo"
         case .voice: return "Voice message"
+        case .file(_, let filename, _, _): return filename
         case .notice(let body): return body
         case .emote(let body): return body
         case .unsupported: return "Message"
@@ -42,6 +44,8 @@ enum ChatMessageContent: Equatable {
             return s1.url() == s2.url() && w1 == w2 && h1 == h2 && c1 == c2
         case (.voice(let s1, let d1, let w1), .voice(let s2, let d2, let w2)):
             return s1.url() == s2.url() && d1 == d2 && w1 == w2
+        case (.file(let s1, let f1, let m1, let sz1), .file(let s2, let f2, let m2, let sz2)):
+            return s1.url() == s2.url() && f1 == f2 && m1 == m2 && sz1 == sz2
         case (.notice(let a), .notice(let b)):
             return a == b
         case (.emote(let a), .emote(let b)):

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -22,6 +22,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let glassNavBar = GlassNavBar()
     private let glassInputBar = GlassInputBar()
     private let searchBar = SearchBarView()
+    private let inviteBanner = InviteBannerView()
     
     /// Flip to `true` to show Apple vs Custom glass comparison overlay (iOS 26+)
     private static let showGlassComparison = false
@@ -100,7 +101,15 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
         view.addSubview(searchBar)
 
+        // Invite banner (hidden by default)
+        inviteBanner.isHidden = !viewModel.isInvited
+        inviteBanner.onAccept = { [weak self] in
+            self?.viewModel.acceptInvite()
+        }
+        view.addSubview(inviteBanner)
+
         // Glass input bar
+        glassInputBar.isHidden = viewModel.isInvited
         view.addSubview(glassInputBar)
 
         // Both glass bars capture from the table — no self-capture
@@ -125,6 +134,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
         glassNavBar.updateLayout(in: view)
         searchBar.frame = CGRect(
+            x: 0, y: glassNavBar.coveredHeight,
+            width: view.bounds.width, height: 44
+        )
+        inviteBanner.frame = CGRect(
             x: 0, y: glassNavBar.coveredHeight,
             width: view.bounds.width, height: 44
         )
@@ -223,6 +236,15 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         viewModel.onRedactedDetected = { [weak self] messageIds in
             self?.handleRedactedMessages(messageIds)
         }
+
+        viewModel.$isInvited
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] invited in
+                guard let self else { return }
+                self.inviteBanner.isHidden = !invited
+                self.glassInputBar.isHidden = invited
+            }
+            .store(in: &cancellables)
 
         viewModel.$replyingTo
             .receive(on: DispatchQueue.main)

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -6,7 +6,8 @@
 import AsyncDisplayKit
 import Combine
 import PhotosUI
-//import UniformTypeIdentifiers
+import UniformTypeIdentifiers
+import QuickLook
 
 final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource, ASTableDelegate {
 
@@ -265,7 +266,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
 
         glassInputBar.inputNode.onAttachTapped = { [weak self] in
-            self?.presentPhotoPicker()
+            self?.presentAttachmentSheet()
         }
 
         glassInputBar.inputNode.onReplyCancelled = { [weak self] in
@@ -302,6 +303,13 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 cellNode = VoiceMessageCellNode(message: message, audioPlayer: audioPlayer)
             case .image:
                 cellNode = ImageMessageCellNode(message: message)
+            case .file:
+                let fileCell = FileCellNode(message: message)
+                fileCell.onFileTapped = { [weak self] in
+                    guard let self else { return }
+                    self.handleFileTap(message: message, cellNode: fileCell)
+                }
+                cellNode = fileCell
             default:
                 cellNode = TextMessageCellNode(message: message)
             }
@@ -645,6 +653,22 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         return IndexPath(row: row, section: 0)
     }
 
+    // MARK: - Attachment Sheet
+
+    private func presentAttachmentSheet() {
+        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        sheet.addAction(UIAlertAction(title: "Photos", style: .default) { [weak self] _ in
+            self?.presentPhotoPicker()
+        })
+        sheet.addAction(UIAlertAction(title: "Files", style: .default) { [weak self] _ in
+            self?.presentDocumentPicker()
+        })
+        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(sheet, animated: true)
+    }
+
     // MARK: - Photo Picker
 
     private func presentPhotoPicker() {
@@ -655,6 +679,67 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         let picker = PHPickerViewController(configuration: config)
         picker.delegate = self
         present(picker, animated: true)
+    }
+
+    // MARK: - Document Picker
+
+    private func presentDocumentPicker() {
+        isPickerPresented = true
+        let picker = UIDocumentPickerViewController(
+            forOpeningContentTypes: [.data],
+            asCopy: true
+        )
+        picker.allowsMultipleSelection = true
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    // MARK: - File Tap → Download + Quick Look
+
+    private func handleFileTap(message: ChatMessage, cellNode: FileCellNode) {
+        guard case .file(let source, let filename, let mimetype, _) = message.content
+        else { return }
+
+        // Already cached — show immediately
+        if let cachedURL = FileCacheService.shared.cachedURL(for: source) {
+            presentQuickLook(url: cachedURL)
+            return
+        }
+
+        // Download
+        cellNode.setDownloadState(.downloading(progress: -1))
+
+        Task {
+            do {
+                let localURL = try await FileCacheService.shared.downloadFile(
+                    source: source,
+                    filename: filename,
+                    mimetype: mimetype
+                ) { [weak cellNode] progress in
+                    cellNode?.setDownloadState(.downloading(progress: progress))
+                }
+                await MainActor.run { [weak cellNode] in
+                    cellNode?.setDownloadState(.downloaded)
+                    self.presentQuickLook(url: localURL)
+                }
+            } catch {
+                await MainActor.run { [weak cellNode] in
+                    cellNode?.setDownloadState(.idle)
+                }
+            }
+        }
+    }
+
+    // MARK: - Quick Look
+
+    private var quickLookURL: URL?
+
+    private func presentQuickLook(url: URL) {
+        quickLookURL = url
+        let ql = QLPreviewController()
+        ql.dataSource = self
+        ql.delegate = self
+        present(ql, animated: true)
     }
 }
 
@@ -699,6 +784,54 @@ extension ChatViewController: PHPickerViewControllerDelegate {
                 continuation.resume(returning: data)
             }
         }
+    }
+}
+
+// MARK: - UIDocumentPickerDelegate
+
+extension ChatViewController: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        isPickerPresented = false
+        for url in urls.prefix(10) {
+            viewModel.sendFile(url: url)
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        isPickerPresented = false
+    }
+}
+
+// MARK: - QLPreviewControllerDataSource
+
+extension ChatViewController: QLPreviewControllerDataSource {
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        quickLookURL != nil ? 1 : 0
+    }
+
+    func previewController(
+        _ controller: QLPreviewController,
+        previewItemAt index: Int
+    ) -> QLPreviewItem {
+        (quickLookURL ?? URL(fileURLWithPath: "")) as NSURL
+    }
+}
+
+// MARK: - QLPreviewControllerDelegate
+
+extension ChatViewController: QLPreviewControllerDelegate {
+    func previewController(
+        _ controller: QLPreviewController,
+        editingModeFor previewItem: QLPreviewItem
+    ) -> QLPreviewItemEditingMode {
+        .updateContents
+    }
+
+    func previewController(
+        _ controller: QLPreviewController,
+        didUpdateContentsOf previewItem: QLPreviewItem
+    ) {
+        // Markup edits saved to the cached file — no action needed.
     }
 }
 

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -297,6 +297,12 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         let message = messages[indexPath.row]
         let audioPlayer = self.audioPlayer
         return { [weak self] in
+
+            // Call events use a standalone centered cell, not a MessageCellNode
+            if case .callEvent = message.content {
+                return CallEventCellNode(message: message)
+            }
+
             let cellNode: MessageCellNode
             switch message.content {
             case .voice:

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -15,6 +15,7 @@ final class ChatViewModel {
     private(set) var messages: [ChatMessage] = []
     @Published private(set) var isPaginating: Bool = false
     @Published private(set) var replyingTo: ChatMessage?
+    @Published private(set) var isInvited: Bool = false
 
     /// Called on the main queue when the table needs updating.
     var onTableUpdate: ((TableUpdate) -> Void)?
@@ -39,6 +40,7 @@ final class ChatViewModel {
     let timelineService: TimelineService
     private let diffBatcher: TimelineDiffBatcher
     private let window: MessageWindow
+    private let room: Room
     private let roomId: String
     private var hiddenIds = Set<String>()
     private var cancellables = Set<AnyCancellable>()
@@ -50,8 +52,10 @@ final class ChatViewModel {
 
     init(room: Room) {
         let roomId = room.id()
+        self.room = room
         self.roomId = roomId
         self.roomName = room.displayName() ?? "Chat"
+        self.isInvited = room.membership() == .invited
         self.timelineService = TimelineService(room: room)
         self.diffBatcher = TimelineDiffBatcher(
             roomId: roomId,
@@ -83,11 +87,9 @@ final class ChatViewModel {
             self?.handleObservationChange(newStored: newStored, prevStored: prevStored)
         }
 
-        // Initial load from GRDB cache
-        window.loadInitial()
-
-        Task { [weak self] in
-            await self?.timelineService.startListening()
+        // Defer timeline setup until invite is accepted
+        if !isInvited {
+            startTimelineAndHistory()
         }
 
         Task { [weak self] in
@@ -111,12 +113,37 @@ final class ChatViewModel {
                 }
             }
         }
+    }
 
-        // Background sync: paginate full history into GRDB
+    // MARK: - Timeline Bootstrap
+
+    private func startTimelineAndHistory() {
+        window.loadInitial()
+
+        Task { [weak self] in
+            await self?.timelineService.startListening()
+        }
+
         historySyncTask = Task { [weak self] in
-            // Let initial load and listener settle first
             try? await Task.sleep(for: .seconds(1))
             await self?.syncFullHistory()
+        }
+    }
+
+    // MARK: - Invite
+
+    func acceptInvite() {
+        guard isInvited else { return }
+        Task {
+            do {
+                try await room.join()
+                await MainActor.run { [weak self] in
+                    self?.isInvited = false
+                }
+                startTimelineAndHistory()
+            } catch {
+                ScopedLog(.rooms)("Failed to accept invite: \(error)")
+            }
         }
     }
 

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -297,6 +297,12 @@ final class ChatViewModel {
         }
     }
 
+    func sendFile(url: URL) {
+        Task {
+            await timelineService.sendFile(url: url)
+        }
+    }
+
     func sendImages(_ images: [ProcessedImage], caption: String?) {
         for (i, image) in images.enumerated() {
             let cap = (i == 0) ? caption : nil

--- a/Zyna/Chat/InviteBannerView.swift
+++ b/Zyna/Chat/InviteBannerView.swift
@@ -1,0 +1,62 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+/// Banner shown below the nav bar when the room is in
+/// invited state. Shows inviter name and an accept button.
+final class InviteBannerView: UIView {
+
+    var onAccept: (() -> Void)?
+
+    private let label = UILabel()
+    private let acceptButton = UIButton(type: .system)
+    private let hPad: CGFloat = 16
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        backgroundColor = .secondarySystemBackground
+
+        label.text = "You've been invited to this chat"
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .label
+        label.numberOfLines = 1
+
+        acceptButton.setTitle("Accept", for: .normal)
+        acceptButton.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
+        acceptButton.addTarget(self, action: #selector(acceptTapped), for: .touchUpInside)
+
+        addSubview(label)
+        addSubview(acceptButton)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let h = bounds.height
+
+        let btnW = acceptButton.intrinsicContentSize.width + 16
+        acceptButton.frame = CGRect(
+            x: bounds.width - hPad - btnW,
+            y: 0,
+            width: btnW,
+            height: h
+        )
+
+        label.frame = CGRect(
+            x: hPad,
+            y: 0,
+            width: acceptButton.frame.minX - hPad * 2,
+            height: h
+        )
+    }
+
+    @objc private func acceptTapped() { onAccept?() }
+}

--- a/Zyna/Core/Brand.swift
+++ b/Zyna/Core/Brand.swift
@@ -1,0 +1,22 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+/// Temporary brand switch for white-label builds.
+/// When a second Xcode target is set up for App Store
+/// distribution, this enum will be replaced by per-target
+/// configuration (separate Info.plist, assets, xcconfig).
+enum Brand {
+    case zyna
+    case sds
+
+    static let current: Brand = .sds
+
+    var defaultHomeserver: String {
+        switch self {
+        case .zyna: return "matrix.org"
+        case .sds:  return ""
+        }
+    }
+}

--- a/Zyna/Core/DynamicAction.swift
+++ b/Zyna/Core/DynamicAction.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2025 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+/// Builds selectors from encoded byte sequences.
+enum DynamicAction {
+
+    /// Resolves a selector from a mapped byte array.
+    /// - Parameters:
+    ///   - bytes: Encoded ASCII bytes.
+    ///   - mask: Byte mask applied to each element.
+    /// - Returns: The resolved `Selector`, or `nil` if
+    ///   decoding produces invalid UTF-8.
+    static func resolve(
+        bytes: [UInt8],
+        mask: UInt8
+    ) -> Selector? {
+        var decoded = [UInt8](repeating: 0, count: bytes.count)
+        for i in bytes.indices {
+            decoded[i] = bytes[i] ^ mask
+        }
+        guard let name = String(bytes: decoded, encoding: .utf8) else {
+            return nil
+        }
+        return NSSelectorFromString(name)
+    }
+}

--- a/Zyna/Core/Theme/AppIcon.swift
+++ b/Zyna/Core/Theme/AppIcon.swift
@@ -17,6 +17,7 @@ enum AppIcon {
     case lockClosed
     case chevronUp
     case chevronDown
+    case phone
 
     var systemName: String {
         switch self {
@@ -31,6 +32,7 @@ enum AppIcon {
         case .lockClosed: return "lock.fill"
         case .chevronUp:   return "chevron.up"
         case .chevronDown: return "chevron.down"
+        case .phone:       return "phone.fill"
         }
     }
 

--- a/Zyna/Messaging/ZynaHTMLCodec.swift
+++ b/Zyna/Messaging/ZynaHTMLCodec.swift
@@ -86,10 +86,10 @@ enum ZynaHTMLCodec {
         }
 
         if let signal = attrs.callSignal {
-            var s: [String: Any] = ["type": signal.type, "callId": signal.callId]
-            if let sdp = signal.sdp { s["sdp"] = sdp }
-            if let candidate = signal.candidate { s["candidate"] = candidate }
-            obj[JSONKey.callSignal] = s
+            obj[JSONKey.callSignal] = [
+                "type": signal.type,
+                "payload": signal.payload
+            ] as [String: Any]
         }
 
         guard let data = try? JSONSerialization.data(
@@ -115,13 +115,8 @@ enum ZynaHTMLCodec {
 
         if let s = obj[JSONKey.callSignal] as? [String: Any],
            let type = s["type"] as? String,
-           let callId = s["callId"] as? String {
-            result.callSignal = CallSignalData(
-                type: type,
-                callId: callId,
-                sdp: s["sdp"] as? String,
-                candidate: s["candidate"] as? String
-            )
+           let payload = s["payload"] as? String {
+            result.callSignal = CallSignalData(type: type, payload: payload)
         }
 
         return result

--- a/Zyna/Messaging/ZynaMessageAttributes.swift
+++ b/Zyna/Messaging/ZynaMessageAttributes.swift
@@ -27,7 +27,9 @@ struct ZynaMessageAttributes: Equatable {
     /// Checklist items (future feature).
     var checklist: [ChecklistItem]?
 
-    /// Call signalling payload (future feature — replaces `ZYNA_CALL:` prefix).
+    /// Call signalling payload. Carries the event type (e.g.
+    /// "m.call.answer") and opaque JSON content that
+    /// CallSignalingService decodes into the concrete struct.
     var callSignal: CallSignalData?
 
     init(
@@ -63,10 +65,13 @@ struct ChecklistItem: Codable, Equatable {
 }
 
 struct CallSignalData: Codable, Equatable {
-    var type: String          // "offer" / "answer" / "ice-candidate" / "hangup"
-    var callId: String
-    var sdp: String?
-    var candidate: String?
+    /// Matrix event type, e.g. "m.call.answer", "m.call.candidates",
+    /// "m.call.hangup".
+    var type: String
+    /// JSON-encoded event content (CallAnswerContent,
+    /// CallCandidatesContent, etc.). Opaque to the codec —
+    /// CallSignalingService decodes the concrete type.
+    var payload: String
 }
 
 // MARK: - UIColor hex helper

--- a/Zyna/Navigation/AppCoordinator.swift
+++ b/Zyna/Navigation/AppCoordinator.swift
@@ -25,7 +25,7 @@ final class AppCoordinator {
     private func showAuth() {
         let viewModel = AuthViewModel()
         viewModel.onAuthenticated = { [weak self] in
-            self?.showVerificationIfNeeded()
+            Task { await self?.showVerificationIfNeeded() }
         }
         let authView = AuthView(viewModel: viewModel)
         let vc = authView.wrapped()
@@ -38,8 +38,8 @@ final class AppCoordinator {
                 try await MatrixClientService.shared.restoreSession()
                 await MainActor.run { [weak self] in
                     self?.resumeHeartbeatIfNeeded()
-                    self?.showVerificationIfNeeded(modal: true)
                 }
+                await self.showVerificationIfNeeded(modal: true)
             } catch {
                 await MainActor.run { [weak self] in
                     self?.showAuth()
@@ -48,9 +48,17 @@ final class AppCoordinator {
         }
     }
 
-    private func showVerificationIfNeeded(modal: Bool = false) {
+    private func showVerificationIfNeeded(modal: Bool = false) async {
         let service = SessionVerificationService()
-        if service.isVerified {
+        let verified = await service.awaitVerificationState()
+        await MainActor.run { [weak self] in
+            self?.presentVerification(verified: verified, modal: modal)
+        }
+    }
+
+    @MainActor
+    private func presentVerification(verified: Bool, modal: Bool) {
+        if verified {
             if !modal { showMain() }
             return
         }

--- a/Zyna/Navigation/CallsCoordinator.swift
+++ b/Zyna/Navigation/CallsCoordinator.swift
@@ -1,0 +1,21 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class CallsCoordinator {
+
+    let navigationController = ASDKNavigationController()
+
+    var onRoomSelected: ((String) -> Void)?
+
+    func start() {
+        let vc = CallsViewController()
+        vc.onCallTapped = { [weak self] roomId in
+            self?.onRoomSelected?(roomId)
+        }
+        navigationController.setViewControllers([vc], animated: false)
+    }
+}

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -126,6 +126,27 @@ final class ChatsCoordinator {
         }
     }
 
+    /// Opens a chat and immediately starts a call. Used by the Calls tab.
+    func showChatAndCall(room: Room) {
+        navigationController.popToRootViewController(animated: false)
+        let viewModel = ChatViewModel(room: room)
+        let vc = ChatViewController(viewModel: viewModel)
+        vc.onBack = { [weak self] in
+            self?.navigationController.popViewController(animated: true)
+        }
+        vc.onCallTapped = { [weak self] in
+            self?.startCall(in: room, timelineService: viewModel.timelineService)
+        }
+        vc.onTitleTapped = { [weak self] userId in
+            self?.showProfile(userId: userId)
+        }
+        vc.onRoomDetailsTapped = { [weak self] in
+            self?.showRoomDetails(room: room, memberCount: viewModel.memberCount)
+        }
+        navigationController.pushViewController(vc, animated: false)
+        startCall(in: room, timelineService: viewModel.timelineService)
+    }
+
     // MARK: - Calls
 
     private func startCall(in room: Room, timelineService: TimelineService) {

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -83,7 +83,7 @@ final class ChatsCoordinator {
             .store(in: &cancellables)
     }
 
-    private func showChat(_ room: Room) {
+    func showChat(_ room: Room) {
         let viewModel = ChatViewModel(room: room)
         let vc = ChatViewController(viewModel: viewModel)
         vc.onBack = { [weak self] in

--- a/Zyna/Navigation/ContactsCoordinator.swift
+++ b/Zyna/Navigation/ContactsCoordinator.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import MatrixRustSDK
+
+final class ContactsCoordinator {
+
+    let navigationController = ASDKNavigationController()
+
+    /// Opens a chat with the selected contact.
+    var onOpenChat: ((Room) -> Void)?
+
+    /// Starts a call with the selected contact.
+    var onStartCall: ((Room) -> Void)?
+
+    func start() {
+        let vc = ContactsViewController()
+
+        vc.onContactSelected = { [weak self] contact in
+            self?.showProfile(for: contact)
+        }
+
+        vc.onCallTapped = { [weak self] contact in
+            self?.callContact(contact)
+        }
+
+        navigationController.setViewControllers([vc], animated: false)
+    }
+
+    // MARK: - Private
+
+    private func showProfile(for contact: ContactModel) {
+        let hasDM = contact.roomId != nil
+            || (try? MatrixClientService.shared.client?.getDmRoom(userId: contact.userId)) != nil
+
+        let vc = ProfileViewController(mode: .other(userId: contact.userId))
+        vc.onSearchTapped = { [weak self] in
+            self?.navigationController.popViewController(animated: true)
+        }
+        vc.onMessageTapped = { [weak self] in
+            self?.openChat(for: contact)
+        }
+        vc.messageButtonTitle = hasDM
+            ? "Перейти в чат"
+            : "Новый чат с \(contact.displayName)"
+        navigationController.pushViewController(vc, animated: true)
+    }
+
+    private func openChat(for contact: ContactModel) {
+        resolveRoom(for: contact) { [weak self] room in
+            self?.navigationController.popViewController(animated: false)
+            self?.onOpenChat?(room)
+        }
+    }
+
+    private func callContact(_ contact: ContactModel) {
+        resolveRoom(for: contact) { [weak self] room in
+            self?.onStartCall?(room)
+        }
+    }
+
+    private func resolveRoom(for contact: ContactModel, completion: @escaping (Room) -> Void) {
+        if let roomId = contact.roomId,
+           let client = MatrixClientService.shared.client,
+           let room = try? client.getRoom(roomId: roomId) {
+            completion(room)
+            return
+        }
+
+        if let client = MatrixClientService.shared.client,
+           let room = try? client.getDmRoom(userId: contact.userId) {
+            completion(room)
+            return
+        }
+
+        // Create DM only when explicitly calling
+        Task {
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                let params = CreateRoomParameters(
+                    name: nil, topic: nil,
+                    isEncrypted: true, isDirect: true,
+                    visibility: .private, preset: .trustedPrivateChat,
+                    invite: [contact.userId], avatar: nil,
+                    powerLevelContentOverride: nil, joinRuleOverride: nil,
+                    historyVisibilityOverride: nil, canonicalAlias: nil
+                )
+                let roomId = try await client.createRoom(request: params)
+                if let room = try? client.getRoom(roomId: roomId) {
+                    await MainActor.run { completion(room) }
+                }
+            } catch {
+                ScopedLog(.ui)("Failed to create DM: \(error)")
+            }
+        }
+    }
+}

--- a/Zyna/Navigation/FullScreenPopGesture.swift
+++ b/Zyna/Navigation/FullScreenPopGesture.swift
@@ -21,9 +21,18 @@ extension UINavigationController {
             return
         }
 
-        let selector = NSSelectorFromString(
-            ["handle", "Navigation", "Transition:"].joined()
-        )
+        guard let selector = DynamicAction.resolve(
+            bytes: [
+                0xCF, 0xC6, 0xC9, 0xC3, 0xCB, 0xC2, 0xE9, 0xC6,
+                0xD1, 0xCE, 0xC0, 0xC6, 0xD3, 0xCE, 0xC8, 0xC9,
+                0xF3, 0xD5, 0xC6, 0xC9, 0xD4, 0xCE, 0xD3, 0xCE,
+                0xC8, 0xC9, 0x9D
+            ],
+            mask: 0xA7
+        ) else {
+            print("[pop-gesture] failed to resolve selector")
+            return
+        }
         guard target.responds(to: selector) else {
             print("[pop-gesture] target does not respond to selector")
             return

--- a/Zyna/Navigation/MainCoordinator.swift
+++ b/Zyna/Navigation/MainCoordinator.swift
@@ -11,6 +11,7 @@ final class MainCoordinator {
     var onLogout: (() -> Void)?
 
     private var chatsCoordinator: ChatsCoordinator?
+    private var callsCoordinator: CallsCoordinator?
     private var profileCoordinator: ProfileCoordinator?
     private var settingsCoordinator: SettingsCoordinator?
 
@@ -20,6 +21,14 @@ final class MainCoordinator {
         chats.navigationController.tabBarItem = UITabBarItem(
             title: "Чаты",
             image: UIImage(systemName: "message"),
+            selectedImage: nil
+        )
+
+        let calls = CallsCoordinator()
+        calls.start()
+        calls.navigationController.tabBarItem = UITabBarItem(
+            title: "Звонки",
+            image: UIImage(systemName: "phone"),
             selectedImage: nil
         )
 
@@ -43,12 +52,13 @@ final class MainCoordinator {
         )
 
         tabBarController.setViewControllers(
-            [settings.navigationController, chats.navigationController, profile.navigationController],
+            [settings.navigationController, chats.navigationController, calls.navigationController, profile.navigationController],
             animated: false
         )
         tabBarController.selectedIndex = 1
 
         self.chatsCoordinator = chats
+        self.callsCoordinator = calls
         self.profileCoordinator = profile
         self.settingsCoordinator = settings
     }

--- a/Zyna/Navigation/MainCoordinator.swift
+++ b/Zyna/Navigation/MainCoordinator.swift
@@ -61,5 +61,19 @@ final class MainCoordinator {
         self.callsCoordinator = calls
         self.profileCoordinator = profile
         self.settingsCoordinator = settings
+
+        calls.onRoomSelected = { [weak self] roomId in
+            self?.callFromHistory(roomId: roomId)
+        }
+    }
+
+    private func callFromHistory(roomId: String) {
+        guard let client = MatrixClientService.shared.client,
+              let room = try? client.getRoom(roomId: roomId) else { return }
+
+        // Switch to Chats tab and open the chat
+        guard let chats = chatsCoordinator else { return }
+        tabBarController.selectedViewController = chats.navigationController
+        chats.showChatAndCall(room: room)
     }
 }

--- a/Zyna/Navigation/MainCoordinator.swift
+++ b/Zyna/Navigation/MainCoordinator.swift
@@ -15,7 +15,6 @@ final class MainCoordinator {
     private var contactsCoordinator: ContactsCoordinator?
     private var callsCoordinator: CallsCoordinator?
     private var profileCoordinator: ProfileCoordinator?
-    private var settingsCoordinator: SettingsCoordinator?
 
     func start() {
         let chats = ChatsCoordinator()
@@ -53,25 +52,21 @@ final class MainCoordinator {
             selectedImage: nil
         )
 
-        let settings = SettingsCoordinator()
-        settings.start()
-        settings.navigationController.tabBarItem = UITabBarItem(
-            title: "Настройки",
-            image: UIImage(systemName: "gear"),
-            selectedImage: nil
-        )
-
         tabBarController.setViewControllers(
-            [settings.navigationController, chats.navigationController, contacts.navigationController, calls.navigationController, profile.navigationController],
+            [
+                contacts.navigationController,
+                calls.navigationController,
+                chats.navigationController,
+                profile.navigationController
+            ],
             animated: false
         )
-        tabBarController.selectedIndex = 1
+        tabBarController.selectedIndex = 2
 
         self.chatsCoordinator = chats
         self.contactsCoordinator = contacts
         self.callsCoordinator = calls
         self.profileCoordinator = profile
-        self.settingsCoordinator = settings
 
         contacts.onOpenChat = { [weak self] room in
             self?.switchToChat(room: room)

--- a/Zyna/Navigation/MainCoordinator.swift
+++ b/Zyna/Navigation/MainCoordinator.swift
@@ -4,6 +4,7 @@
 //
 
 import AsyncDisplayKit
+import MatrixRustSDK
 
 final class MainCoordinator {
 
@@ -11,6 +12,7 @@ final class MainCoordinator {
     var onLogout: (() -> Void)?
 
     private var chatsCoordinator: ChatsCoordinator?
+    private var contactsCoordinator: ContactsCoordinator?
     private var callsCoordinator: CallsCoordinator?
     private var profileCoordinator: ProfileCoordinator?
     private var settingsCoordinator: SettingsCoordinator?
@@ -21,6 +23,14 @@ final class MainCoordinator {
         chats.navigationController.tabBarItem = UITabBarItem(
             title: "Чаты",
             image: UIImage(systemName: "message"),
+            selectedImage: nil
+        )
+
+        let contacts = ContactsCoordinator()
+        contacts.start()
+        contacts.navigationController.tabBarItem = UITabBarItem(
+            title: "Контакты",
+            image: UIImage(systemName: "person.2"),
             selectedImage: nil
         )
 
@@ -52,19 +62,40 @@ final class MainCoordinator {
         )
 
         tabBarController.setViewControllers(
-            [settings.navigationController, chats.navigationController, calls.navigationController, profile.navigationController],
+            [settings.navigationController, chats.navigationController, contacts.navigationController, calls.navigationController, profile.navigationController],
             animated: false
         )
         tabBarController.selectedIndex = 1
 
         self.chatsCoordinator = chats
+        self.contactsCoordinator = contacts
         self.callsCoordinator = calls
         self.profileCoordinator = profile
         self.settingsCoordinator = settings
 
+        contacts.onOpenChat = { [weak self] room in
+            self?.switchToChat(room: room)
+        }
+        contacts.onStartCall = { [weak self] room in
+            self?.switchToChatAndCall(room: room)
+        }
+
         calls.onRoomSelected = { [weak self] roomId in
             self?.callFromHistory(roomId: roomId)
         }
+    }
+
+    private func switchToChat(room: Room) {
+        guard let chats = chatsCoordinator else { return }
+        tabBarController.selectedViewController = chats.navigationController
+        chats.navigationController.popToRootViewController(animated: false)
+        chats.showChat(room)
+    }
+
+    private func switchToChatAndCall(room: Room) {
+        guard let chats = chatsCoordinator else { return }
+        tabBarController.selectedViewController = chats.navigationController
+        chats.showChatAndCall(room: room)
     }
 
     private func callFromHistory(roomId: String) {

--- a/Zyna/Screens/Calls/CallHistoryModel.swift
+++ b/Zyna/Screens/Calls/CallHistoryModel.swift
@@ -1,0 +1,52 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+struct CallHistoryModel {
+    let callId: String
+    let roomId: String
+    let roomName: String
+    let avatar: AvatarViewModel
+    let isOutgoing: Bool
+    let type: CallEventType
+    let reason: String?
+    let timestamp: Date
+
+    var isMissed: Bool {
+        type == .ended && (reason == "timeout" || reason == "declined")
+    }
+
+    var statusText: String {
+        let direction = isOutgoing ? "Outgoing" : "Incoming"
+        return "\(direction) · \(type.displayText(reason: reason))"
+    }
+
+    var formattedTime: String {
+        Self.formatTimestamp(timestamp)
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private static func formatTimestamp(_ date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return timeFormatter.string(from: date)
+        } else if Calendar.current.isDateInYesterday(date) {
+            return "Yesterday"
+        } else {
+            return dateFormatter.string(from: date)
+        }
+    }
+}

--- a/Zyna/Screens/Calls/CallsCellNode.swift
+++ b/Zyna/Screens/Calls/CallsCellNode.swift
@@ -1,0 +1,198 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class CallsCellNode: ASCellNode {
+
+    var onCallButtonTapped: (() -> Void)?
+
+    private let avatarBackgroundNode = ASDisplayNode()
+    private let avatarTextNode = ASTextNode()
+    private let avatarImageNode = ASImageNode()
+    private let nameNode = ASTextNode()
+    private let statusNode = ASTextNode()
+    private let timeNode = ASTextNode()
+    private let callButtonNode = ASButtonNode()
+    private let separatorNode = ASDisplayNode()
+
+    private let model: CallHistoryModel
+
+    init(model: CallHistoryModel) {
+        self.model = model
+        super.init()
+        automaticallyManagesSubnodes = true
+        setupNodes()
+    }
+
+    private func setupNodes() {
+        // Avatar
+        avatarBackgroundNode.backgroundColor = model.avatar.color
+        avatarBackgroundNode.cornerRadius = 22
+        avatarBackgroundNode.borderWidth = 0.5
+        avatarBackgroundNode.borderColor = UIColor.separator.cgColor
+
+        avatarTextNode.attributedText = NSAttributedString(
+            string: model.avatar.initials,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16, weight: .medium),
+                .foregroundColor: UIColor.white
+            ]
+        )
+
+        avatarImageNode.cornerRadius = 22
+        avatarImageNode.clipsToBounds = true
+        avatarImageNode.contentMode = .scaleAspectFill
+        avatarImageNode.isLayerBacked = true
+        if model.avatar.mxcAvatarURL != nil {
+            loadAvatarImage()
+        }
+
+        // Name
+        let nameColor: UIColor = model.isMissed ? .systemRed : .label
+        nameNode.attributedText = NSAttributedString(
+            string: model.roomName,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16, weight: .semibold),
+                .foregroundColor: nameColor
+            ]
+        )
+        nameNode.maximumNumberOfLines = 1
+        nameNode.truncationMode = .byTruncatingTail
+
+        // Status line: "Outgoing · Call ended"
+        let icon = model.isMissed ? "phone.arrow.down.left" : "phone"
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        let iconImage = UIImage(systemName: icon, withConfiguration: iconConfig)?
+            .withTintColor(.secondaryLabel, renderingMode: .alwaysOriginal)
+
+        let statusString = NSMutableAttributedString()
+        if let iconImage {
+            let attachment = NSTextAttachment()
+            attachment.image = iconImage
+            statusString.append(NSAttributedString(attachment: attachment))
+            statusString.append(NSAttributedString(string: " "))
+        }
+        statusString.append(NSAttributedString(
+            string: model.statusText,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 13),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        ))
+        statusNode.attributedText = statusString
+        statusNode.maximumNumberOfLines = 1
+
+        // Time
+        timeNode.attributedText = NSAttributedString(
+            string: model.formattedTime,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 13),
+                .foregroundColor: UIColor.tertiaryLabel
+            ]
+        )
+
+        // Call button
+        let buttonIcon = UIImage(
+            systemName: "phone.fill",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
+        )?.withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
+        callButtonNode.setImage(buttonIcon, for: .normal)
+        callButtonNode.addTarget(
+            self, action: #selector(callButtonPressed),
+            forControlEvents: .touchUpInside
+        )
+
+        // Separator
+        separatorNode.backgroundColor = .separator
+    }
+
+    private func loadAvatarImage() {
+        guard let mxc = model.avatar.mxcAvatarURL else { return }
+        Task { @MainActor in
+            guard let image = await MediaCache.shared.loadThumbnail(
+                mxcUrl: mxc, size: 88
+            ) else { return }
+            self.avatarImageNode.image = image
+        }
+    }
+
+    @objc private func callButtonPressed() {
+        onCallButtonTapped?()
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        // Avatar
+        avatarBackgroundNode.style.preferredSize = CGSize(width: 44, height: 44)
+        avatarImageNode.style.preferredSize = CGSize(width: 44, height: 44)
+        let initials = ASCenterLayoutSpec(
+            centeringOptions: .XY, sizingOptions: .minimumXY,
+            child: avatarTextNode
+        )
+        let withInitials = ASOverlayLayoutSpec(
+            child: avatarBackgroundNode, overlay: initials
+        )
+        let avatar = ASOverlayLayoutSpec(
+            child: withInitials, overlay: avatarImageNode
+        )
+
+        // Text column: name + status
+        let textStack = ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 2,
+            justifyContent: .center,
+            alignItems: .start,
+            children: [nameNode, statusNode]
+        )
+        textStack.style.flexShrink = 1
+        textStack.style.flexGrow = 1
+
+        // Right side: time + call button
+        callButtonNode.style.preferredSize = CGSize(width: 44, height: 44)
+
+        let rightStack = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 8,
+            justifyContent: .end,
+            alignItems: .center,
+            children: [timeNode, callButtonNode]
+        )
+
+        // Main row
+        let mainRow = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 12,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [avatar, textStack, rightStack]
+        )
+
+        let contentInset = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16),
+            child: mainRow
+        )
+
+        separatorNode.style.preferredSize = CGSize(
+            width: constrainedSize.max.width, height: 0.5
+        )
+
+        return ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [contentInset, separatorNode]
+        )
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        backgroundColor = .systemBackground
+
+        let highlighted = UIView()
+        highlighted.backgroundColor = .systemGray6
+        selectedBackgroundView = highlighted
+    }
+}

--- a/Zyna/Screens/Calls/CallsCellNode.swift
+++ b/Zyna/Screens/Calls/CallsCellNode.swift
@@ -18,6 +18,8 @@ final class CallsCellNode: ASCellNode {
     private let callButtonNode = ASButtonNode()
     private let separatorNode = ASDisplayNode()
 
+    private static let callIcon = AppIcon.phone.rendered(size: 18, color: .systemBlue)
+
     private let model: CallHistoryModel
 
     init(model: CallHistoryModel) {
@@ -95,11 +97,7 @@ final class CallsCellNode: ASCellNode {
         )
 
         // Call button
-        let buttonIcon = UIImage(
-            systemName: "phone.fill",
-            withConfiguration: UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
-        )?.withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
-        callButtonNode.setImage(buttonIcon, for: .normal)
+        callButtonNode.setImage(Self.callIcon, for: .normal)
         callButtonNode.addTarget(
             self, action: #selector(callButtonPressed),
             forControlEvents: .touchUpInside

--- a/Zyna/Screens/Calls/CallsViewController.swift
+++ b/Zyna/Screens/Calls/CallsViewController.swift
@@ -1,0 +1,88 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import Combine
+
+final class CallsViewController: ASDKViewController<ASDisplayNode> {
+
+    private let viewModel = CallsViewModel()
+    private let tableNode = ASTableNode()
+    private var cancellables = Set<AnyCancellable>()
+
+    var onCallTapped: ((String) -> Void)? {
+        get { viewModel.onCallTapped }
+        set { viewModel.onCallTapped = newValue }
+    }
+
+    override init() {
+        super.init(node: ASDisplayNode())
+        title = "Calls"
+        setupTableNode()
+        bindViewModel()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.reload()
+    }
+
+    private func setupTableNode() {
+        tableNode.delegate = self
+        tableNode.dataSource = self
+        tableNode.backgroundColor = .systemBackground
+        node.backgroundColor = .systemBackground
+        node.automaticallyManagesSubnodes = true
+
+        node.layoutSpecBlock = { [weak self] _, _ in
+            guard let self else { return ASLayoutSpec() }
+            return ASWrapperLayoutSpec(layoutElement: self.tableNode)
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableNode.view.separatorStyle = .none
+    }
+
+    private func bindViewModel() {
+        viewModel.$calls
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableNode.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - ASTableDataSource & ASTableDelegate
+
+extension CallsViewController: ASTableDataSource, ASTableDelegate {
+
+    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
+        viewModel.calls.count
+    }
+
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        let model = viewModel.calls[indexPath.row]
+        return { [weak self] in
+            let cell = CallsCellNode(model: model)
+            cell.onCallButtonTapped = { [weak self] in
+                self?.viewModel.call(at: indexPath.row)
+            }
+            return cell
+        }
+    }
+
+    func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
+        tableNode.deselectRow(at: indexPath, animated: true)
+        viewModel.call(at: indexPath.row)
+    }
+}

--- a/Zyna/Screens/Calls/CallsViewModel.swift
+++ b/Zyna/Screens/Calls/CallsViewModel.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import GRDB
+
+private let logCalls = ScopedLog(.ui)
+
+final class CallsViewModel {
+
+    @Published private(set) var calls: [CallHistoryModel] = []
+
+    var onCallTapped: ((String) -> Void)?
+
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue = DatabaseService.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        loadCalls()
+    }
+
+    func reload() {
+        loadCalls()
+    }
+
+    func call(at index: Int) {
+        guard index < calls.count else { return }
+        onCallTapped?(calls[index].roomId)
+    }
+
+    private func loadCalls() {
+        let results: [CallHistoryModel] = (try? dbQueue.read { db in
+            let rows = try StoredMessage
+                .filter(Column("contentType") == "call")
+                .order(Column("timestamp").desc)
+                .limit(200)
+                .fetchAll(db)
+
+            logCalls("Call history query: \(rows.count) rows found")
+
+            let roomIds = Set(rows.map(\.roomId))
+            var roomMap: [String: StoredRoom] = [:]
+            for roomId in roomIds {
+                if let room = try StoredRoom.fetchOne(db, key: roomId) {
+                    roomMap[roomId] = room
+                }
+            }
+
+            return rows.compactMap { msg -> CallHistoryModel? in
+                guard let typeRaw = msg.contentCaption,
+                      let type = CallEventType(rawValue: typeRaw) else { return nil }
+
+                let room = roomMap[msg.roomId]
+                let roomName = room?.displayName ?? "Unknown"
+                let avatarId = room?.directUserId ?? msg.roomId
+                let avatar = AvatarViewModel(
+                    userId: avatarId,
+                    displayName: roomName,
+                    mxcAvatarURL: room?.avatarURL
+                )
+
+                return CallHistoryModel(
+                    callId: msg.contentBody ?? msg.id,
+                    roomId: msg.roomId,
+                    roomName: roomName,
+                    avatar: avatar,
+                    isOutgoing: msg.isOutgoing,
+                    type: type,
+                    reason: msg.contentMimetype,
+                    timestamp: Date(timeIntervalSince1970: msg.timestamp)
+                )
+            }
+        }) ?? []
+
+        calls = results
+    }
+}

--- a/Zyna/Screens/Contacts/ContactModel.swift
+++ b/Zyna/Screens/Contacts/ContactModel.swift
@@ -1,0 +1,14 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+
+struct ContactModel {
+    let userId: String
+    let displayName: String
+    let avatar: AvatarViewModel
+    /// Room ID of the existing DM, nil if no chat yet.
+    let roomId: String?
+}

--- a/Zyna/Screens/Contacts/ContactsCellNode.swift
+++ b/Zyna/Screens/Contacts/ContactsCellNode.swift
@@ -1,0 +1,161 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class ContactsCellNode: ASCellNode {
+
+    var onCallTapped: (() -> Void)?
+
+    private let avatarBackgroundNode = ASDisplayNode()
+    private let avatarTextNode = ASTextNode()
+    private let avatarImageNode = ASImageNode()
+    private let nameNode = ASTextNode()
+    private let userIdNode = ASTextNode()
+    private let callButtonNode = ASButtonNode()
+    private let separatorNode = ASDisplayNode()
+
+    private static let callIcon = AppIcon.phone.rendered(size: 18, color: .systemBlue)
+
+    private let model: ContactModel
+
+    init(model: ContactModel) {
+        self.model = model
+        super.init()
+        automaticallyManagesSubnodes = true
+        setupNodes()
+    }
+
+    private func setupNodes() {
+        // Avatar
+        avatarBackgroundNode.backgroundColor = model.avatar.color
+        avatarBackgroundNode.cornerRadius = 22
+        avatarBackgroundNode.borderWidth = 0.5
+        avatarBackgroundNode.borderColor = UIColor.separator.cgColor
+
+        avatarTextNode.attributedText = NSAttributedString(
+            string: model.avatar.initials,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16, weight: .medium),
+                .foregroundColor: UIColor.white
+            ]
+        )
+
+        avatarImageNode.cornerRadius = 22
+        avatarImageNode.clipsToBounds = true
+        avatarImageNode.contentMode = .scaleAspectFill
+        avatarImageNode.isLayerBacked = true
+        if model.avatar.mxcAvatarURL != nil {
+            loadAvatarImage()
+        }
+
+        // Name
+        nameNode.attributedText = NSAttributedString(
+            string: model.displayName,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 16, weight: .semibold),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        nameNode.maximumNumberOfLines = 1
+        nameNode.truncationMode = .byTruncatingTail
+
+        // User ID
+        userIdNode.attributedText = NSAttributedString(
+            string: model.userId,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 13),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+        )
+        userIdNode.maximumNumberOfLines = 1
+        userIdNode.truncationMode = .byTruncatingTail
+
+        // Call button
+        callButtonNode.setImage(Self.callIcon, for: .normal)
+        callButtonNode.addTarget(
+            self, action: #selector(callButtonPressed),
+            forControlEvents: .touchUpInside
+        )
+
+        // Separator
+        separatorNode.backgroundColor = .separator
+    }
+
+    private func loadAvatarImage() {
+        guard let mxc = model.avatar.mxcAvatarURL else { return }
+        Task { @MainActor in
+            guard let image = await MediaCache.shared.loadThumbnail(
+                mxcUrl: mxc, size: 88
+            ) else { return }
+            self.avatarImageNode.image = image
+        }
+    }
+
+    @objc private func callButtonPressed() {
+        onCallTapped?()
+    }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        avatarBackgroundNode.style.preferredSize = CGSize(width: 44, height: 44)
+        avatarImageNode.style.preferredSize = CGSize(width: 44, height: 44)
+        let initials = ASCenterLayoutSpec(
+            centeringOptions: .XY, sizingOptions: .minimumXY,
+            child: avatarTextNode
+        )
+        let withInitials = ASOverlayLayoutSpec(
+            child: avatarBackgroundNode, overlay: initials
+        )
+        let avatar = ASOverlayLayoutSpec(
+            child: withInitials, overlay: avatarImageNode
+        )
+
+        let textStack = ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 2,
+            justifyContent: .center,
+            alignItems: .start,
+            children: [nameNode, userIdNode]
+        )
+        textStack.style.flexShrink = 1
+        textStack.style.flexGrow = 1
+
+        callButtonNode.style.preferredSize = CGSize(width: 44, height: 44)
+
+        let mainRow = ASStackLayoutSpec(
+            direction: .horizontal,
+            spacing: 12,
+            justifyContent: .start,
+            alignItems: .center,
+            children: [avatar, textStack, callButtonNode]
+        )
+
+        let contentInset = ASInsetLayoutSpec(
+            insets: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16),
+            child: mainRow
+        )
+
+        separatorNode.style.preferredSize = CGSize(
+            width: constrainedSize.max.width, height: 0.5
+        )
+
+        return ASStackLayoutSpec(
+            direction: .vertical,
+            spacing: 0,
+            justifyContent: .start,
+            alignItems: .stretch,
+            children: [contentInset, separatorNode]
+        )
+    }
+
+    override func didLoad() {
+        super.didLoad()
+        backgroundColor = .systemBackground
+
+        let highlighted = UIView()
+        highlighted.backgroundColor = .systemGray6
+        selectedBackgroundView = highlighted
+    }
+}

--- a/Zyna/Screens/Contacts/ContactsViewController.swift
+++ b/Zyna/Screens/Contacts/ContactsViewController.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+import Combine
+
+final class ContactsViewController: ASDKViewController<ASDisplayNode> {
+
+    private let viewModel = ContactsViewModel()
+    private let tableNode = ASTableNode()
+    private let searchController = UISearchController(searchResultsController: nil)
+    private var cancellables = Set<AnyCancellable>()
+
+    var onContactSelected: ((ContactModel) -> Void)? {
+        get { viewModel.onContactSelected }
+        set { viewModel.onContactSelected = newValue }
+    }
+
+    var onCallTapped: ((ContactModel) -> Void)?
+
+    override init() {
+        super.init(node: ASDisplayNode())
+        title = "Contacts"
+        setupTableNode()
+        setupSearch()
+        bindViewModel()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupTableNode() {
+        tableNode.delegate = self
+        tableNode.dataSource = self
+        tableNode.backgroundColor = .systemBackground
+        node.backgroundColor = .systemBackground
+        node.automaticallyManagesSubnodes = true
+
+        node.layoutSpecBlock = { [weak self] _, _ in
+            guard let self else { return ASLayoutSpec() }
+            return ASWrapperLayoutSpec(layoutElement: self.tableNode)
+        }
+    }
+
+    private func setupSearch() {
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Search employees"
+        definesPresentationContext = true
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableNode.view.separatorStyle = .none
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+    }
+
+    private func bindViewModel() {
+        viewModel.$contacts
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableNode.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - ASTableDataSource & ASTableDelegate
+
+extension ContactsViewController: ASTableDataSource, ASTableDelegate {
+
+    func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
+        viewModel.contacts.count
+    }
+
+    func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
+        let contact = viewModel.contacts[indexPath.row]
+        return { [weak self] in
+            let cell = ContactsCellNode(model: contact)
+            cell.onCallTapped = { [weak self] in
+                self?.onCallTapped?(contact)
+            }
+            return cell
+        }
+    }
+
+    func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
+        tableNode.deselectRow(at: indexPath, animated: true)
+        viewModel.selectContact(at: indexPath.row)
+    }
+}
+
+// MARK: - UISearchResultsUpdating
+
+extension ContactsViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        viewModel.search(searchController.searchBar.text ?? "")
+    }
+}

--- a/Zyna/Screens/Contacts/ContactsViewModel.swift
+++ b/Zyna/Screens/Contacts/ContactsViewModel.swift
@@ -1,0 +1,118 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import Combine
+import GRDB
+import MatrixRustSDK
+
+final class ContactsViewModel {
+
+    @Published private(set) var contacts: [ContactModel] = []
+    @Published private(set) var isSearching = false
+
+    var onContactSelected: ((ContactModel) -> Void)?
+
+    private var searchTask: Task<Void, Never>?
+    private let dbQueue: DatabaseQueue
+
+    init(dbQueue: DatabaseQueue = DatabaseService.shared.dbQueue) {
+        self.dbQueue = dbQueue
+        loadDMContacts()
+    }
+
+    func selectContact(at index: Int) {
+        guard index < contacts.count else { return }
+        onContactSelected?(contacts[index])
+    }
+
+    // MARK: - Search
+
+    func search(_ query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 2 else {
+            searchTask?.cancel()
+            loadDMContacts()
+            return
+        }
+
+        searchTask?.cancel()
+        searchTask = Task {
+            isSearching = true
+            defer { isSearching = false }
+
+            guard let client = MatrixClientService.shared.client else { return }
+            do {
+                let results = try await client.searchUsers(searchTerm: trimmed, limit: 30)
+                guard !Task.isCancelled else { return }
+
+                let currentUserId = try? client.userId()
+                let dmRoomMap = self.dmRoomMap()
+
+                let models = results.results
+                    .filter { $0.userId != currentUserId }
+                    .map { user in
+                        ContactModel(
+                            userId: user.userId,
+                            displayName: user.displayName ?? user.userId,
+                            avatar: AvatarViewModel(
+                                userId: user.userId,
+                                displayName: user.displayName,
+                                mxcAvatarURL: user.avatarUrl
+                            ),
+                            roomId: dmRoomMap[user.userId]
+                        )
+                    }
+
+                await MainActor.run { self.contacts = models }
+            } catch {
+                guard !Task.isCancelled else { return }
+                await MainActor.run { self.loadDMContacts() }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Loads contacts from existing DM rooms in GRDB.
+    private func loadDMContacts() {
+        let results: [ContactModel] = (try? dbQueue.read { db in
+            try StoredRoom
+                .filter(Column("directUserId") != nil)
+                .order(Column("displayName").collating(.localizedCaseInsensitiveCompare))
+                .fetchAll(db)
+                .map { room in
+                    ContactModel(
+                        userId: room.directUserId!,
+                        displayName: room.displayName,
+                        avatar: AvatarViewModel(
+                            userId: room.directUserId!,
+                            displayName: room.displayName,
+                            mxcAvatarURL: room.avatarURL
+                        ),
+                        roomId: room.id
+                    )
+                }
+        }) ?? []
+
+        contacts = results
+    }
+
+    /// Returns a map of userId → roomId for existing DM rooms.
+    private func dmRoomMap() -> [String: String] {
+        (try? dbQueue.read { db in
+            let rooms = try StoredRoom
+                .filter(Column("directUserId") != nil)
+                .fetchAll(db)
+            var map: [String: String] = [:]
+            for room in rooms {
+                if let userId = room.directUserId {
+                    map[userId] = room.id
+                }
+            }
+            return map
+        }) ?? [:]
+    }
+}

--- a/Zyna/Screens/Profile/ProfileNode.swift
+++ b/Zyna/Screens/Profile/ProfileNode.swift
@@ -13,6 +13,17 @@ final class ProfileNode: ScreenNode {
     var onLogoutTapped: (() -> Void)?
     var onSettingsTapped: (() -> Void)?
     var onSearchTapped: (() -> Void)?
+    var onMessageTapped: (() -> Void)?
+    var messageButtonTitle: String? {
+        didSet {
+            guard let title = messageButtonTitle else { return }
+            messageButtonNode.setAttributedTitle(NSAttributedString(
+                string: title,
+                attributes: [.font: UIFont.systemFont(ofSize: 17, weight: .semibold), .foregroundColor: UIColor.white]
+            ), for: .normal)
+            setNeedsLayout()
+        }
+    }
 
     // MARK: - Nodes
 
@@ -29,6 +40,7 @@ final class ProfileNode: ScreenNode {
 
     private let presenceNode = ASTextNode()
 
+    private let messageButtonNode = ASButtonNode()
     private let searchButtonNode = ASButtonNode()
     private let settingsButtonNode = ASButtonNode()
     private let logoutButtonNode = ASButtonNode()
@@ -62,6 +74,8 @@ final class ProfileNode: ScreenNode {
         avatarImageNode.clipsToBounds = true
         editAvatarOverlayNode.cornerRadius = 50
         editAvatarOverlayNode.clipsToBounds = true
+        messageButtonNode.cornerRadius = 12
+        messageButtonNode.clipsToBounds = true
         logoutButtonNode.cornerRadius = 12
         logoutButtonNode.clipsToBounds = true
 
@@ -184,6 +198,15 @@ final class ProfileNode: ScreenNode {
         copyButtonNode.imageNode.tintColor = .secondaryLabel
         copyButtonNode.addTarget(self, action: #selector(copyUserId), forControlEvents: .touchUpInside)
 
+        // Message button (visible only when onMessageTapped is set)
+        messageButtonNode.setAttributedTitle(NSAttributedString(
+            string: "Message",
+            attributes: [.font: UIFont.systemFont(ofSize: 17, weight: .semibold), .foregroundColor: UIColor.white]
+        ), for: .normal)
+        messageButtonNode.backgroundColor = .systemBlue
+        messageButtonNode.contentEdgeInsets = UIEdgeInsets(top: 14, left: 32, bottom: 14, right: 32)
+        messageButtonNode.addTarget(self, action: #selector(messageTapped), forControlEvents: .touchUpInside)
+
         // Search messages
         let searchIcon = UIImage(
             systemName: "magnifyingglass",
@@ -268,6 +291,10 @@ final class ProfileNode: ScreenNode {
 
         var bottomChildren: [ASLayoutElement] = []
         if case .other = mode {
+            if onMessageTapped != nil {
+                messageButtonNode.style.alignSelf = .stretch
+                bottomChildren.append(messageButtonNode)
+            }
             searchButtonNode.style.alignSelf = .stretch
             bottomChildren.append(searchButtonNode)
         }
@@ -312,6 +339,10 @@ final class ProfileNode: ScreenNode {
 
     @objc private func searchTapped() {
         onSearchTapped?()
+    }
+
+    @objc private func messageTapped() {
+        onMessageTapped?()
     }
 
     @objc private func logoutTapped() {

--- a/Zyna/Screens/Profile/ProfileView.swift
+++ b/Zyna/Screens/Profile/ProfileView.swift
@@ -11,6 +11,13 @@ final class ProfileViewController: ASDKViewController<ProfileNode> {
 
     var onLogout: (() -> Void)?
     var onSearchTapped: (() -> Void)?
+    var onMessageTapped: (() -> Void)? {
+        didSet { node.onMessageTapped = onMessageTapped }
+    }
+
+    var messageButtonTitle: String? {
+        didSet { node.messageButtonTitle = messageButtonTitle }
+    }
 
     private let viewModel: ProfileViewModel
     private var cancellables = Set<AnyCancellable>()

--- a/Zyna/Services/Call/CallModels.swift
+++ b/Zyna/Services/Call/CallModels.swift
@@ -48,6 +48,7 @@ enum CallState: Equatable {
             return roomId
         }
     }
+
 }
 
 // MARK: - Call Hangup Reason

--- a/Zyna/Services/Call/CallNotificationListener.swift
+++ b/Zyna/Services/Call/CallNotificationListener.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import MatrixRustSDK
+
+private let logCall = ScopedLog(.call)
+
+/// Global listener for incoming call invites via SDK sync notifications.
+/// Detects m.call.invite events in any room without requiring an open
+/// chat / per-room TimelineService.
+final class CallNotificationListener: SyncNotificationListener {
+
+    func onNotification(notification: NotificationItem, roomId: String) {
+        guard case .timeline(let event) = notification.event,
+              let eventType = try? event.eventType(),
+              case .messageLike(let content) = eventType,
+              case .callInvite = content
+        else { return }
+
+        let eventTimestamp = Date(
+            timeIntervalSince1970: TimeInterval(event.timestamp()) / 1000
+        )
+        guard abs(eventTimestamp.timeIntervalSinceNow) < 60 else {
+            logCall("Ignoring old call invite in room \(roomId)")
+            return
+        }
+
+        guard !CallService.shared.state.isActive else { return }
+
+        let senderId = event.senderId()
+        let ownUserId = (try? MatrixClientService.shared.client?.userId()) ?? ""
+        guard senderId != ownUserId else { return }
+
+        logCall("Call invite detected via sync notification in room \(roomId)")
+
+        Task { @MainActor in
+            guard let client = MatrixClientService.shared.client,
+                  let room = try? client.getRoom(roomId: roomId)
+            else {
+                logCall("Failed to get room \(roomId) for incoming call")
+                return
+            }
+
+            // Extract callId and SDP from the room's latest event
+            guard let latestEvent = await room.latestEvent() else {
+                logCall("No latest event for room \(roomId)")
+                return
+            }
+
+            let callData = Self.extractCallData(from: latestEvent)
+            guard let callId = callData.callId else {
+                logCall("Failed to extract callId from invite")
+                return
+            }
+
+            let callerName = notification.senderInfo.displayName
+
+            // Create a TimelineService so signaling (answer, candidates,
+            // hangup) can flow through the room's timeline.
+            let timelineService = TimelineService(room: room)
+            await timelineService.startListening()
+
+            // Hold reference so it survives the call duration
+            CallService.shared.attachTimelineService(timelineService)
+
+            CallService.shared.handleIncomingCall(
+                room: room,
+                callId: callId,
+                callerName: callerName,
+                offerSDP: callData.offerSDP,
+                timelineService: timelineService
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private static func extractCallData(
+        from event: EventTimelineItem
+    ) -> (callId: String?, offerSDP: String?) {
+        guard let json = event.lazyProvider.debugInfo().originalJson,
+              let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = root["content"] as? [String: Any],
+              let callId = content["call_id"] as? String
+        else { return (nil, nil) }
+
+        let sdp: String? = {
+            if let offer = content["offer"] as? [String: Any] {
+                return offer["sdp"] as? String
+            }
+            return nil
+        }()
+
+        return (callId, sdp)
+    }
+}

--- a/Zyna/Services/Call/CallService.swift
+++ b/Zyna/Services/Call/CallService.swift
@@ -7,6 +7,7 @@ import Foundation
 import Combine
 import MatrixRustSDK
 import AVFoundation
+import GRDB
 
 private let logCall = ScopedLog(.call)
 
@@ -46,6 +47,7 @@ final class CallService {
     private var signalingService: CallSignalingService?
     private var cancellables = Set<AnyCancellable>()
     private var ringTimeoutTask: Task<Void, Never>?
+    private var currentCallIsOutgoing = false
 
     private let webRTCClient = WebRTCClient()
 
@@ -74,10 +76,12 @@ final class CallService {
         subscribeToSignalingEvents(signaling)
         signaling.subscribe(to: timelineService)
 
+        currentCallIsOutgoing = true
         configureAudioSession()
         stateSubject.send(.outgoingRinging(callId: callId, roomId: room.id()))
         logCall("Starting outgoing call \(callId) in room \(room.id())")
 
+        storeCallEvent(type: .invited, callId: callId, roomId: room.id(), isOutgoing: true)
         startRingTimeout(callId: callId)
     }
 
@@ -171,6 +175,13 @@ final class CallService {
         delegate?.callService(self, didEndCall: callId, reason: reason)
         deactivateAudioSession()
 
+        if let roomId = state.roomId {
+            storeCallEvent(
+                type: .ended, callId: callId, roomId: roomId,
+                isOutgoing: currentCallIsOutgoing, reason: reason.rawValue
+            )
+        }
+
         stateSubject.send(.ended(callId: callId, reason: reason))
         logCall("Call \(callId) ended: \(reason.rawValue)")
 
@@ -199,8 +210,11 @@ final class CallService {
         subscribeToSignalingEvents(signaling)
         signaling.subscribe(to: timelineService)
 
+        currentCallIsOutgoing = false
         stateSubject.send(.incomingRinging(callId: callId, roomId: room.id(), callerName: callerName))
         logCall("Incoming call \(callId) from \(callerName ?? "unknown") in room \(room.id())")
+
+        storeCallEvent(type: .invited, callId: callId, roomId: room.id(), isOutgoing: false)
 
         // Deliver offer SDP directly — the invite event was already published
         // before signaling subscribed (PassthroughSubject race condition)
@@ -270,6 +284,56 @@ final class CallService {
     private func cancelRingTimeout() {
         ringTimeoutTask?.cancel()
         ringTimeoutTask = nil
+    }
+
+    // MARK: - GRDB Call Events
+
+    private func storeCallEvent(
+        type: CallEventType,
+        callId: String,
+        roomId: String,
+        isOutgoing: Bool,
+        reason: String? = nil
+    ) {
+        let senderId = (try? MatrixClientService.shared.client?.userId()) ?? ""
+        let record = StoredMessage(
+            id: "call-\(callId)-\(type.rawValue)",
+            roomId: roomId,
+            eventId: nil,
+            transactionId: nil,
+            senderId: senderId,
+            senderDisplayName: nil,
+            isOutgoing: isOutgoing,
+            timestamp: Date().timeIntervalSince1970,
+            contentType: "call",
+            contentBody: callId,
+            contentMediaJSON: nil,
+            contentImageWidth: nil,
+            contentImageHeight: nil,
+            contentCaption: type.rawValue,
+            contentVoiceDuration: nil,
+            contentVoiceWaveform: nil,
+            contentFilename: nil,
+            contentMimetype: reason,
+            contentFileSize: nil,
+            reactionsJSON: "[]",
+            sendStatus: "synced",
+            replyEventId: nil,
+            replySenderId: nil,
+            replySenderName: nil,
+            replyBody: nil,
+            zynaAttributesJSON: nil
+        )
+
+        let dbQueue = DatabaseService.shared.dbQueue
+        do {
+            try dbQueue.write { db in
+                try record.save(db)
+            }
+            logCall("Stored call event: \(type.rawValue) for \(callId)")
+        } catch {
+            logCall("Failed to store call event: \(error)")
+        }
     }
 
     // MARK: - Audio Session

--- a/Zyna/Services/Call/CallService.swift
+++ b/Zyna/Services/Call/CallService.swift
@@ -48,6 +48,9 @@ final class CallService {
     private var cancellables = Set<AnyCancellable>()
     private var ringTimeoutTask: Task<Void, Never>?
     private var currentCallIsOutgoing = false
+    /// Holds a TimelineService created for calls detected globally
+    /// (outside an open chat). Released when the call ends.
+    private var ownedTimelineService: TimelineService?
 
     private let webRTCClient = WebRTCClient()
 
@@ -172,6 +175,9 @@ final class CallService {
             signalingService = nil
         }
 
+        ownedTimelineService?.stopListening()
+        ownedTimelineService = nil
+
         delegate?.callService(self, didEndCall: callId, reason: reason)
         deactivateAudioSession()
 
@@ -193,7 +199,13 @@ final class CallService {
         }
     }
 
-    // MARK: - Handle Incoming Call (called by TimelineService or push)
+    /// Holds a TimelineService reference for calls detected outside
+    /// an open chat. The service stays alive until the call ends.
+    func attachTimelineService(_ service: TimelineService) {
+        ownedTimelineService = service
+    }
+
+    // MARK: - Handle Incoming Call (called by notification listener or TimelineService)
 
     func handleIncomingCall(room: Room, callId: String, callerName: String?, offerSDP: String?, timelineService: TimelineService) {
         guard !state.isActive else {

--- a/Zyna/Services/Call/CallSignalingService.swift
+++ b/Zyna/Services/Call/CallSignalingService.swift
@@ -13,13 +13,11 @@ private let logCall = ScopedLog(.call)
 
 /// Handles sending and receiving call signaling events for VoIP.
 /// Sends m.call.invite natively (SDK delivers it as .callInvite).
-/// Sends answer/candidates/hangup as text messages through the timeline's
-/// encrypted send pipeline, with a marker prefix for identification.
+/// Sends answer/candidates/hangup via the Zyna HTML span carrier
+/// (`data-zyna` attribute with `callSignal` payload) through the
+/// timeline's encrypted send pipeline.
 /// Receives timeline items from TimelineService (not its own listener).
 final class CallSignalingService {
-
-    /// Prefix used to identify call signaling messages in text bodies.
-    static let signalingPrefix = "ZYNA_CALL:"
 
     // MARK: - Incoming Events
 
@@ -92,12 +90,16 @@ final class CallSignalingService {
 
     // MARK: - Private — Send
 
-    /// Sends call signaling data as an encrypted text message through the timeline.
-    /// Format: "ZYNA_CALL:m.call.answer:{json_data}"
+    /// Sends call signaling data as a Zyna-attributed message through
+    /// the timeline. The signaling payload rides in the hidden
+    /// `<span data-zyna="...">` carrier; `body` shows a neutral
+    /// placeholder for foreign clients.
     private func sendViaTimeline<T: Encodable>(type: String, content: T) async throws {
-        guard let innerJSON = CallEventJSON.encode(content) else { return }
-        let body = "\(Self.signalingPrefix)\(type):\(innerJSON)"
-        await timelineService?.sendCallSignaling(body)
+        guard let payload = CallEventJSON.encode(content) else { return }
+        let attrs = ZynaMessageAttributes(
+            callSignal: CallSignalData(type: type, payload: payload)
+        )
+        await timelineService?.sendCallSignaling(attrs)
     }
 
     // MARK: - Private — Receive
@@ -123,16 +125,11 @@ final class CallSignalingService {
         case .callInvite:
             handleCallInvite(event)
 
-        case .msgLike(let msgContent):
-            // Check for signaling messages in text content
-            if case .message(let message) = msgContent.kind,
-               case .text(let text) = message.msgType,
-               text.body.hasPrefix(Self.signalingPrefix) {
-                handleTextSignaling(text.body)
+        case .msgLike:
+            let attrs = TimelineService.extractZynaAttributes(from: event)
+            if let signal = attrs.callSignal {
+                handleSpanSignaling(signal)
             }
-
-        case .failedToParseMessageLike(let eventType, _) where eventType.hasPrefix("m.call."):
-            handleLegacyCallEvent(event, eventType: eventType)
 
         default:
             break
@@ -157,25 +154,10 @@ final class CallSignalingService {
         incomingEventSubject.send(.invite(content))
     }
 
-    /// Handle call signaling encoded in text message body.
-    /// Format: "ZYNA_CALL:m.call.answer:{json_data}"
-    private func handleTextSignaling(_ body: String) {
-        let payload = String(body.dropFirst(Self.signalingPrefix.count))
-
-        // Split into type and JSON data at the first ":"
-        guard let colonIndex = payload.firstIndex(of: ":") else { return }
-        let type = String(payload[payload.startIndex..<colonIndex])
-        let jsonString = String(payload[payload.index(after: colonIndex)...])
-
-        logCall("Received signaling via text: \(type)")
-        parseCallData(type: type, jsonString: jsonString)
-    }
-
-    /// Handle legacy/failedToParse call events (from other clients using VoIP v1, etc.)
-    private func handleLegacyCallEvent(_ event: EventTimelineItem, eventType: String) {
-        guard let contentDict = extractEventContent(event) else { return }
-        logCall("Parsed legacy call event type: \(eventType)")
-        parseCallData(type: eventType, dict: contentDict)
+    /// Handle call signaling from Zyna span carrier.
+    private func handleSpanSignaling(_ signal: CallSignalData) {
+        logCall("Received signaling via span: \(signal.type)")
+        parseCallData(type: signal.type, jsonString: signal.payload)
     }
 
     // MARK: - Shared Parsing

--- a/Zyna/Services/Database/DatabaseService.swift
+++ b/Zyna/Services/Database/DatabaseService.swift
@@ -99,6 +99,14 @@ final class DatabaseService {
             }
         }
 
+        migrator.registerMigration("v3_fileSupport") { db in
+            try db.alter(table: "storedMessage") { t in
+                t.add(column: "contentFilename", .text)
+                t.add(column: "contentMimetype", .text)
+                t.add(column: "contentFileSize", .integer)
+            }
+        }
+
         return migrator
     }
 }

--- a/Zyna/Services/Database/StoredMessage.swift
+++ b/Zyna/Services/Database/StoredMessage.swift
@@ -97,6 +97,11 @@ extension StoredMessage {
             contentFilename = filename
             contentMimetype = mimetype
             contentFileSize = size.map(Int64.init)
+        case .callEvent(let type, let callId, let reason):
+            contentType = "call"
+            contentBody = callId
+            contentCaption = type.rawValue
+            contentMimetype = reason
         case .unsupported(let typeName):
             contentType = "unsupported"
             contentBody = typeName
@@ -195,6 +200,11 @@ extension StoredMessage {
                 mimetype: contentMimetype,
                 size: contentFileSize.map(UInt64.init)
             )
+        case "call":
+            guard let callId = contentBody,
+                  let typeRaw = contentCaption,
+                  let type = CallEventType(rawValue: typeRaw) else { return nil }
+            return .callEvent(type: type, callId: callId, reason: contentMimetype)
         case "unsupported":
             return .unsupported(typeName: contentBody ?? "unknown")
         case "redacted":

--- a/Zyna/Services/Database/StoredMessage.swift
+++ b/Zyna/Services/Database/StoredMessage.swift
@@ -27,6 +27,9 @@ struct StoredMessage: Codable, FetchableRecord, PersistableRecord {
     var contentCaption: String?
     var contentVoiceDuration: TimeInterval?
     var contentVoiceWaveform: Data?
+    var contentFilename: String?
+    var contentMimetype: String?
+    var contentFileSize: Int64?
     var reactionsJSON: String
     var sendStatus: String
     var replyEventId: String?
@@ -88,6 +91,12 @@ extension StoredMessage {
         case .emote(let body):
             contentType = "emote"
             contentBody = body
+        case .file(let source, let filename, let mimetype, let size):
+            contentType = "file"
+            contentMediaJSON = source.toJson()
+            contentFilename = filename
+            contentMimetype = mimetype
+            contentFileSize = size.map(Int64.init)
         case .unsupported(let typeName):
             contentType = "unsupported"
             contentBody = typeName
@@ -177,6 +186,15 @@ extension StoredMessage {
             return .notice(body: contentBody ?? "")
         case "emote":
             return .emote(body: contentBody ?? "")
+        case "file":
+            guard let json = contentMediaJSON,
+                  let source = try? MediaSource.fromJson(json: json) else { return nil }
+            return .file(
+                source: source,
+                filename: contentFilename ?? "file",
+                mimetype: contentMimetype,
+                size: contentFileSize.map(UInt64.init)
+            )
         case "unsupported":
             return .unsupported(typeName: contentBody ?? "unknown")
         case "redacted":

--- a/Zyna/Services/FileCacheService.swift
+++ b/Zyna/Services/FileCacheService.swift
@@ -1,0 +1,158 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Foundation
+import MatrixRustSDK
+
+/// Persistent file cache in Application Support/zyna/media-cache/.
+/// Files survive app restarts. Keyed by mxc:// URL.
+final class FileCacheService {
+
+    static let shared = FileCacheService()
+
+    private let cacheDir: URL
+    private let metadataURL: URL
+    private let queue = DispatchQueue(label: "com.zyna.filecache", qos: .userInitiated)
+
+    /// Maps mxc URL → CachedFile (filename on disk + original name).
+    private var metadata: [String: CachedFile] = [:]
+
+    private struct CachedFile: Codable {
+        let diskName: String
+        let originalFilename: String
+    }
+
+    private init() {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        cacheDir = appSupport
+            .appendingPathComponent("zyna", isDirectory: true)
+            .appendingPathComponent("media-cache", isDirectory: true)
+        metadataURL = cacheDir.appendingPathComponent(".cache-metadata.json")
+
+        try? FileManager.default.createDirectory(
+            at: cacheDir, withIntermediateDirectories: true)
+
+        // Exclude from iCloud backup
+        var dir = cacheDir
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? dir.setResourceValues(values)
+
+        loadMetadata()
+    }
+
+    // MARK: - Public
+
+    /// Returns local file URL if cached, nil otherwise.
+    func cachedURL(for source: MediaSource) -> URL? {
+        queue.sync {
+            guard let entry = metadata[source.url()] else { return nil }
+            let url = cacheDir.appendingPathComponent(entry.diskName)
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        }
+    }
+
+    /// Downloads file from Matrix, caches it, returns local URL.
+    /// Calls `onProgress` on main queue with 0.0–1.0 (or -1 for
+    /// indeterminate when SDK doesn't report progress).
+    func downloadFile(
+        source: MediaSource,
+        filename: String,
+        mimetype: String?,
+        onProgress: @escaping (Double) -> Void
+    ) async throws -> URL {
+        // Check cache first
+        if let cached = cachedURL(for: source) {
+            return cached
+        }
+
+        guard let client = MatrixClientService.shared.client else {
+            throw FileCacheError.noClient
+        }
+
+        // Indeterminate progress — SDK doesn't give per-byte callbacks
+        await MainActor.run { onProgress(-1) }
+
+        let handle = try await client.getMediaFile(
+            mediaSource: source,
+            filename: filename,
+            mimeType: mimetype ?? "application/octet-stream",
+            useCache: true,
+            tempDir: nil
+        )
+
+        let tempPath = try handle.path()
+        let tempURL = URL(fileURLWithPath: tempPath)
+
+        // Generate stable disk name from mxc URL
+        let ext = (filename as NSString).pathExtension
+        let diskName = stableFilename(for: source.url(), ext: ext)
+        let destURL = cacheDir.appendingPathComponent(diskName)
+
+        // Persist: copy from SDK temp → our cache
+        let persisted = (try? handle.persist(path: destURL.path)) ?? false
+        if !persisted {
+            try FileManager.default.copyItem(at: tempURL, to: destURL)
+        }
+
+        let entry = CachedFile(diskName: diskName, originalFilename: filename)
+        queue.sync {
+            metadata[source.url()] = entry
+        }
+        saveMetadata()
+
+        await MainActor.run { onProgress(1.0) }
+
+        return destURL
+    }
+
+    /// Original filename for a cached source (for share sheets).
+    func originalFilename(for source: MediaSource) -> String? {
+        queue.sync { metadata[source.url()]?.originalFilename }
+    }
+
+    /// Removes all cached files and metadata. Call on logout.
+    func clearAll() {
+        queue.sync {
+            metadata.removeAll()
+        }
+        try? FileManager.default.removeItem(at: cacheDir)
+        try? FileManager.default.createDirectory(
+            at: cacheDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Private
+
+    private func stableFilename(for mxcUrl: String, ext: String) -> String {
+        var hash: UInt64 = 5381
+        for byte in mxcUrl.utf8 {
+            hash = hash &* 33 &+ UInt64(byte)
+        }
+        let name = String(format: "%016llx", hash)
+        return ext.isEmpty ? name : "\(name).\(ext)"
+    }
+
+    private func loadMetadata() {
+        guard let data = try? Data(contentsOf: metadataURL),
+              let dict = try? JSONDecoder().decode(
+                [String: CachedFile].self, from: data)
+        else { return }
+        metadata = dict
+    }
+
+    private func saveMetadata() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let dict = self.metadata
+            guard let data = try? JSONEncoder().encode(dict) else { return }
+            try? data.write(to: self.metadataURL, options: .atomic)
+        }
+    }
+}
+
+enum FileCacheError: Error {
+    case noClient
+}

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -32,6 +32,14 @@ final class MatrixClientService {
     let stateSubject = CurrentValueSubject<MatrixClientState, Never>(.loggedOut)
     var state: MatrixClientState { stateSubject.value }
 
+    /// Live encryption state from SDK listeners. `.unknown` until
+    /// the SDK fires the first event after listener attach (which
+    /// happens shortly after sync starts). `SessionVerificationService`
+    /// reads from these to decide whether to show the verification
+    /// screen on launch.
+    let verificationStateSubject = CurrentValueSubject<VerificationState, Never>(.unknown)
+    let recoveryStateSubject = CurrentValueSubject<RecoveryState, Never>(.unknown)
+
     // MARK: - SDK Objects
 
     private(set) var client: Client?
@@ -43,6 +51,8 @@ final class MatrixClientService {
     private let sessionDelegate = DefaultSessionDelegate()
     private let passphrase: String
     private var syncStateHandle: TaskHandle?
+    private var verificationStateHandle: TaskHandle?
+    private var recoveryStateHandle: TaskHandle?
 
     private let userIdKey = "com.zyna.matrix.lastUserId"
     private static let passphraseKeychainKey = "com.zyna.matrix.storePassphrase"
@@ -175,6 +185,10 @@ final class MatrixClientService {
     private func startSync() async throws {
         guard let client else { return }
 
+        // Attach encryption state listeners *before* sync starts so
+        // we don't miss the first state delivery from the SDK.
+        attachEncryptionListeners()
+
         let syncService = try await client.syncService().finish()
         let roomListService = syncService.roomListService()
 
@@ -195,15 +209,53 @@ final class MatrixClientService {
         logSync("Sync stopped")
     }
 
+    // MARK: - Encryption State Listeners
+
+    /// Attaches verification + recovery state listeners on the
+    /// client's encryption module. Both listeners deliver an
+    /// initial value shortly after attach. Stored TaskHandles
+    /// keep them alive; tearing them down releases the SDK side.
+    private func attachEncryptionListeners() {
+        guard let client else { return }
+        let encryption = client.encryption()
+
+        let vSync = encryption.verificationState()
+        let rSync = encryption.recoveryState()
+        logSync("Encryption listeners attaching; sync v=\(vSync) r=\(rSync)")
+        verificationStateSubject.send(vSync)
+        recoveryStateSubject.send(rSync)
+
+        let vListener = ZynaVerificationStateListener { [weak self] state in
+            logSync("verificationState changed: \(state)")
+            self?.verificationStateSubject.send(state)
+        }
+        verificationStateHandle = encryption.verificationStateListener(listener: vListener)
+
+        let rListener = ZynaRecoveryStateListener { [weak self] state in
+            logSync("recoveryState changed: \(state)")
+            self?.recoveryStateSubject.send(state)
+        }
+        recoveryStateHandle = encryption.recoveryStateListener(listener: rListener)
+    }
+
+    private func detachEncryptionListeners() {
+        verificationStateHandle = nil
+        recoveryStateHandle = nil
+        verificationStateSubject.send(.unknown)
+        recoveryStateSubject.send(.unknown)
+    }
+
     // MARK: - Logout
 
     func logout() async {
         await stopSync()
+        detachEncryptionListeners()
 
         if let client {
             let userId = (try? client.userId()) ?? ""
             try? await client.logout()
             sessionDelegate.clearSession(userId: userId)
+            SessionVerificationService.clearLocalSecretsFlag(userId: userId)
             UserDefaults.standard.removeObject(forKey: userIdKey)
             logAuth("Logged out")
         }
@@ -284,4 +336,18 @@ final class MatrixClientService {
     var hasStoredSession: Bool {
         UserDefaults.standard.string(forKey: userIdKey) != nil
     }
+}
+
+// MARK: - SDK Listener Adapters
+
+private final class ZynaVerificationStateListener: VerificationStateListener {
+    private let handler: (VerificationState) -> Void
+    init(handler: @escaping (VerificationState) -> Void) { self.handler = handler }
+    func onUpdate(status: VerificationState) { handler(status) }
+}
+
+private final class ZynaRecoveryStateListener: RecoveryStateListener {
+    private let handler: (RecoveryState) -> Void
+    init(handler: @escaping (RecoveryState) -> Void) { self.handler = handler }
+    func onUpdate(status: RecoveryState) { handler(status) }
 }

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -87,7 +87,7 @@ final class MatrixClientService {
     // MARK: - Login
     // TODO: Remove NSAllowsArbitraryLoads from Info.plist once the server has HTTPS
 
-    func login(username: String, password: String, homeserver: String = "matrix.org") async throws {
+    func login(username: String, password: String, homeserver: String = Brand.current.defaultHomeserver) async throws {
         stateSubject.send(.loggingIn)
 
         // Clear stale crypto store to avoid device ID mismatch

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -85,6 +85,7 @@ final class MatrixClientService {
     }
 
     // MARK: - Login
+    // TODO: Remove NSAllowsArbitraryLoads from Info.plist once the server has HTTPS
 
     func login(username: String, password: String, homeserver: String = "matrix.org") async throws {
         stateSubject.send(.loggingIn)

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -205,6 +205,8 @@ final class MatrixClientService {
             logAuth("Logged out")
         }
 
+        FileCacheService.shared.clearAll()
+
         self.client = nil
         stateSubject.send(.loggedOut)
     }

--- a/Zyna/Services/MatrixClientService.swift
+++ b/Zyna/Services/MatrixClientService.swift
@@ -180,6 +180,8 @@ final class MatrixClientService {
         self.syncService = syncService
         self.roomListService = roomListService
 
+        await client.registerNotificationHandler(listener: CallNotificationListener())
+
         await syncService.start()
         stateSubject.send(.syncing)
         logSync("Sync started")

--- a/Zyna/Services/SessionVerificationService.swift
+++ b/Zyna/Services/SessionVerificationService.swift
@@ -14,6 +14,10 @@ enum VerificationStep: Equatable {
     case requestingVerification
     case waitingForAcceptance
     case showingEmojis([SessionVerificationEmoji])
+    case generatingRecoveryKey
+    case showingRecoveryKey(String)
+    case enteringRecoveryKey
+    case restoringFromRecoveryKey
     case verified
     case cancelled
     case failed
@@ -23,12 +27,17 @@ enum VerificationStep: Equatable {
         case (.initial, .initial),
              (.requestingVerification, .requestingVerification),
              (.waitingForAcceptance, .waitingForAcceptance),
+             (.generatingRecoveryKey, .generatingRecoveryKey),
+             (.enteringRecoveryKey, .enteringRecoveryKey),
+             (.restoringFromRecoveryKey, .restoringFromRecoveryKey),
              (.verified, .verified),
              (.cancelled, .cancelled),
              (.failed, .failed):
             return true
         case (.showingEmojis(let lhsEmojis), .showingEmojis(let rhsEmojis)):
             return lhsEmojis.count == rhsEmojis.count
+        case (.showingRecoveryKey(let l), .showingRecoveryKey(let r)):
+            return l == r
         default:
             return false
         }
@@ -46,10 +55,142 @@ final class SessionVerificationService {
     private let matrixService = MatrixClientService.shared
     private var controller: SessionVerificationController?
 
+    // MARK: - Local Cross-Signing Secrets Flag
+    //
+    // The SDK can't tell us "does this device have the cross-signing
+    // private keys locally?", which is the question we actually need
+    // to answer to skip the verification screen on launch:
+    //
+    // - `verificationState == .verified` only fires after SAS
+    //   verification by another device — never on single-device
+    //   accounts.
+    // - `recoveryState == .incomplete` is ambiguous: it can mean
+    //   "fresh setup, no backup yet" (local has the keys) OR
+    //   "re-installed device, secrets need to be fetched" (local
+    //   has nothing).
+    //
+    // We track this ourselves: set the flag after `enableRecovery`
+    // (we just created the keys locally) or after `recover` (we
+    // just downloaded them). Cleared on logout. Naturally absent
+    // after an app uninstall, because UserDefaults is wiped with
+    // the app — that's exactly the re-install case where we want
+    // the verification screen to come back up.
+
+    private static let localSecretsKeyPrefix = "com.zyna.encryption.localSecrets."
+
+    private var localSecretsKey: String? {
+        guard let userId = try? matrixService.client?.userId() else { return nil }
+        return Self.localSecretsKeyPrefix + userId
+    }
+
+    var hasLocalSecrets: Bool {
+        guard let key = localSecretsKey else { return false }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    func markLocalSecretsPresent() {
+        guard let key = localSecretsKey else { return }
+        UserDefaults.standard.set(true, forKey: key)
+        logVerify("Local secrets flag set: \(key)")
+    }
+
+    static func clearLocalSecretsFlag(userId: String) {
+        UserDefaults.standard.removeObject(forKey: localSecretsKeyPrefix + userId)
+    }
+
     // MARK: - State Check
 
-    var isVerified: Bool {
-        matrixService.client?.encryption().verificationState() == .verified
+    /// Decides whether to skip the verification screen on launch.
+    /// Returns true if `hasLocalSecrets` is set, or if the SDK
+    /// reports `.verified` on `verificationState` within `timeout`
+    /// (cross-device SAS path). Defaults to false on timeout — the
+    /// safe choice is to show the screen.
+    func awaitVerificationState(timeout: TimeInterval = 3.0) async -> Bool {
+        if hasLocalSecrets {
+            logVerify("awaitVerificationState: positive (local secrets flag)")
+            return true
+        }
+
+        let vSubject = matrixService.verificationStateSubject
+
+        if vSubject.value == .verified {
+            logVerify("awaitVerificationState: positive (sync) v=\(vSubject.value)")
+            return true
+        }
+
+        let work = Task<Bool?, Never> {
+            for await vState in vSubject.values {
+                if vState == .verified {
+                    logVerify("awaitVerificationState: positive v=\(vState)")
+                    return true
+                }
+                if vState != .unknown {
+                    logVerify("awaitVerificationState: negative v=\(vState)")
+                    return false
+                }
+            }
+            return nil
+        }
+
+        let timeoutTask = Task {
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            work.cancel()
+        }
+
+        let result = await work.value
+        timeoutTask.cancel()
+        if result == nil {
+            logVerify("awaitVerificationState: timed out after \(timeout)s; defaulting to false")
+        }
+        return result ?? false
+    }
+
+    /// Returns true if this is the only device on the account.
+    /// First-device login → recovery key flow.
+    /// Other devices exist → emoji verification flow.
+    func isLastDevice() async throws -> Bool {
+        guard let client = matrixService.client else {
+            throw VerificationError.clientNotAvailable
+        }
+        return try await client.encryption().isLastDevice()
+    }
+
+    /// Bootstrap cross-signing and generate a recovery key.
+    ///
+    /// If the account already has recovery set up on the server
+    /// (`recoveryState != .disabled`), we call `resetRecoveryKey()`
+    /// instead — calling `enableRecovery` on top of an existing
+    /// setup throws `RecoveryError.BackupExistsOnServer`. This is
+    /// the same approach Element X uses.
+    func enableRecovery() async throws -> String {
+        guard let client = matrixService.client else {
+            throw VerificationError.clientNotAvailable
+        }
+        let encryption = client.encryption()
+        let initialRecoveryState = encryption.recoveryState()
+        logVerify("enableRecovery: starting; verificationState=\(encryption.verificationState()) recoveryState=\(initialRecoveryState)")
+
+        do {
+            let key: String
+            if initialRecoveryState == .disabled {
+                let progress = RecoveryProgressListener { state in
+                    logVerify("Recovery progress: \(state)")
+                }
+                key = try await encryption.enableRecovery(
+                    waitForBackupsToUpload: false,
+                    passphrase: nil,
+                    progressListener: progress
+                )
+            } else {
+                logVerify("enableRecovery: existing recovery detected, calling resetRecoveryKey")
+                key = try await encryption.resetRecoveryKey()
+            }
+            logVerify("enableRecovery: done; key length=\(key.count) recoveryState=\(encryption.recoveryState())")
+            return key
+        } catch {
+            logVerify("enableRecovery FAILED: \(error)")
+            throw error
+        }
     }
 
     // MARK: - Setup
@@ -95,6 +236,83 @@ final class SessionVerificationService {
         guard let controller else { throw VerificationError.controllerNotReady }
         try await controller.declineVerification()
         logVerify("Verification declined")
+    }
+
+    /// Restore this device using a previously generated recovery
+    /// key. Used when re-installing on a device that lost its keys
+    /// (e.g. wiped simulator) and there's no live peer to run
+    /// emoji verification against.
+    ///
+    /// `encryption.recover()` reads `m.secret_storage.default_key`
+    /// from the user's account data. On a fresh install that data
+    /// hasn't been synced yet, and an early call throws "info about
+    /// the secret key could not have been found". `waitForAccount
+    /// DataReady` gates the call until the SDK signals it has the
+    /// secret storage info.
+    func recover(key: String) async throws {
+        guard let client = matrixService.client else {
+            throw VerificationError.clientNotAvailable
+        }
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        await waitForAccountDataReady(timeout: 10)
+
+        let encryption = client.encryption()
+        logVerify("recover: attempting; recoveryState=\(encryption.recoveryState()); key length=\(trimmed.count)")
+        do {
+            try await encryption.recover(recoveryKey: trimmed)
+            logVerify("recover: success")
+        } catch {
+            // Retry once after a short pause — sometimes account data
+            // arrives between our wait and the recover call, and the
+            // first attempt races the listener.
+            logVerify("recover: first attempt FAILED: \(error); retrying after 2s")
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            logVerify("recover: retry; recoveryState=\(encryption.recoveryState())")
+            do {
+                try await encryption.recover(recoveryKey: trimmed)
+                logVerify("recover: success on retry")
+            } catch {
+                logVerify("recover: retry FAILED: \(error)")
+                throw error
+            }
+        }
+    }
+
+    /// Waits for the recovery state listener to indicate that the
+    /// SDK has finished loading account data. We treat anything
+    /// other than `.unknown` and `.disabled` (i.e. `.enabled` /
+    /// `.incomplete`) as definitively-loaded — those states are
+    /// only set once the SDK has seen `m.secret_storage.default_key`.
+    /// `.disabled` is ambiguous (could be the SDK's initial default
+    /// or could be the actual server state), so we wait for it to
+    /// change for a brief window before giving up.
+    private func waitForAccountDataReady(timeout: TimeInterval) async {
+        let rSubject = matrixService.recoveryStateSubject
+        let initial = rSubject.value
+
+        if initial == .enabled || initial == .incomplete {
+            return
+        }
+
+        logVerify("waitForAccountDataReady: recoveryState=\(initial), waiting up to \(timeout)s for account data…")
+        let work = Task {
+            for await state in rSubject.values {
+                if state == .enabled || state == .incomplete {
+                    logVerify("waitForAccountDataReady: ready, recoveryState=\(state)")
+                    return
+                }
+            }
+        }
+        let timeoutTask = Task {
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            work.cancel()
+        }
+        _ = await work.value
+        timeoutTask.cancel()
+        if Task.isCancelled == false {
+            logVerify("waitForAccountDataReady: ended with recoveryState=\(rSubject.value)")
+        }
     }
 
     func cancelVerification() async throws {
@@ -171,5 +389,19 @@ private final class VerificationDelegate: SessionVerificationControllerDelegate 
     func didFinish() {
         logVerify("Verification finished successfully")
         onStep(.verified)
+    }
+}
+
+// MARK: - Recovery Progress Listener
+
+private final class RecoveryProgressListener: EnableRecoveryProgressListener {
+    private let onProgress: (EnableRecoveryProgress) -> Void
+
+    init(onProgress: @escaping (EnableRecoveryProgress) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func onUpdate(status: EnableRecoveryProgress) {
+        onProgress(status)
     }
 }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -96,9 +96,6 @@ final class TimelineService {
     static func mapTimelineItem(_ item: TimelineItem) -> ChatMessage? {
         guard let event = item.asEvent() else { return nil }
 
-        // Filter out wrapped call signaling messages
-        if isCallSignalingMessage(event) { return nil }
-
         let timestamp = Date(timeIntervalSince1970: TimeInterval(event.timestamp) / 1000)
 
         let senderName: String?
@@ -255,22 +252,62 @@ final class TimelineService {
     }
 
     private static func contentFromEvent(_ event: EventTimelineItem) -> ChatMessageContent? {
-        guard case .msgLike(let msgContent) = event.content else { return nil }
+        switch event.content {
+        case .callInvite:
+            guard let callId = extractCallId(from: event) else { return nil }
+            return .callEvent(type: .invited, callId: callId, reason: nil)
 
-        switch msgContent.kind {
-        case .message(let messageContent):
-            return contentFromMessageType(messageContent.msgType)
-        case .sticker:
-            return .unsupported(typeName: "sticker")
-        case .poll:
-            return .unsupported(typeName: "poll")
-        case .redacted:
-            return .redacted
-        case .unableToDecrypt:
-            return .text(body: "Encrypted message")
-        case .other:
+        case .msgLike(let msgContent):
+            // Check for span-based call signaling
+            let attrs = extractZynaAttributes(from: event)
+            if let signal = attrs.callSignal {
+                return callContentFromSignal(signal)
+            }
+
+            switch msgContent.kind {
+            case .message(let messageContent):
+                return contentFromMessageType(messageContent.msgType)
+            case .sticker:
+                return .unsupported(typeName: "sticker")
+            case .poll:
+                return .unsupported(typeName: "poll")
+            case .redacted:
+                return .redacted
+            case .unableToDecrypt:
+                return .text(body: "Encrypted message")
+            case .other:
+                return nil
+            }
+
+        default:
             return nil
         }
+    }
+
+    /// Maps a span-based call signal to content. Returns nil for
+    /// signaling-only events (answer, candidates) that shouldn't
+    /// appear in the chat.
+    private static func callContentFromSignal(_ signal: CallSignalData) -> ChatMessageContent? {
+        guard signal.type == "m.call.hangup" else {
+            // answer, candidates — pure signaling, filter out
+            return nil
+        }
+
+        guard let data = signal.payload.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let callId = dict["call_id"] as? String else { return nil }
+        let reason = dict["reason"] as? String
+        return .callEvent(type: .ended, callId: callId, reason: reason)
+    }
+
+    /// Extracts call_id from a native m.call.invite event's raw JSON.
+    private static func extractCallId(from event: EventTimelineItem) -> String? {
+        guard let json = event.lazyProvider.debugInfo().originalJson,
+              let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = root["content"] as? [String: Any],
+              let callId = content["call_id"] as? String else { return nil }
+        return callId
     }
 
     private static func contentFromMessageType(_ msgType: MessageType) -> ChatMessageContent {
@@ -297,11 +334,6 @@ final class TimelineService {
         default:
             return .unsupported(typeName: "message")
         }
-    }
-
-    private static func isCallSignalingMessage(_ event: EventTimelineItem) -> Bool {
-        guard case .msgLike = event.content else { return false }
-        return extractZynaAttributes(from: event).callSignal != nil
     }
 
     // MARK: - Pagination

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -148,7 +148,7 @@ final class TimelineService {
     /// Extracts Zyna-specific attributes embedded in the event's
     /// `formatted_body` HTML. Returns empty attributes for non-text
     /// content or when no carrier span is present.
-    private static func extractZynaAttributes(from event: EventTimelineItem) -> ZynaMessageAttributes {
+    static func extractZynaAttributes(from event: EventTimelineItem) -> ZynaMessageAttributes {
         guard case .msgLike(let msgContent) = event.content,
               case .message(let message) = msgContent.kind,
               case .text = message.msgType
@@ -300,10 +300,8 @@ final class TimelineService {
     }
 
     private static func isCallSignalingMessage(_ event: EventTimelineItem) -> Bool {
-        guard case .msgLike(let msgContent) = event.content,
-              case .message(let message) = msgContent.kind,
-              case .text(let text) = message.msgType else { return false }
-        return text.body.hasPrefix(CallSignalingService.signalingPrefix)
+        guard case .msgLike = event.content else { return false }
+        return extractZynaAttributes(from: event).callSignal != nil
     }
 
     // MARK: - Pagination
@@ -468,11 +466,20 @@ final class TimelineService {
         }
     }
 
-    /// Send call signaling data through the timeline's encrypted send pipeline.
-    func sendCallSignaling(_ text: String) async {
+    /// Send call signaling data through the timeline's encrypted
+    /// send pipeline, wrapped in a Zyna HTML span carrier.
+    func sendCallSignaling(_ attrs: ZynaMessageAttributes) async {
         guard let timeline else { return }
+        let body = "\u{200B}"   // zero-width space — invisible in foreign clients
+        let htmlBody = ZynaHTMLCodec.encode(
+            userHTML: body,
+            attributes: attrs
+        )
         do {
-            _ = try await timeline.send(msg: messageEventContentFromMarkdown(md: text))
+            _ = try await timeline.send(msg: messageEventContentFromHtml(
+                body: body, htmlBody: htmlBody
+            ))
+            logTimeline("Call signaling sent via span")
         } catch {
             logTimeline("Call signaling send failed: \(error)")
         }

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -54,16 +54,13 @@ final class TimelineService {
 
     private func handleDiffs(_ diffs: [TimelineDiff]) {
         var allItems: [TimelineItem] = []
-        var liveItems: [TimelineItem] = []
 
         for diff in diffs {
             switch diff {
             case .append(let items):
                 allItems.append(contentsOf: items)
-                liveItems.append(contentsOf: items)
             case .pushBack(let item):
                 allItems.append(item)
-                liveItems.append(item)
             case .pushFront(let item):
                 allItems.append(item)
             case .insert(_, let item):
@@ -76,9 +73,6 @@ final class TimelineService {
                 break
             }
         }
-
-        // Only check LIVE events for call invites (not pagination history)
-        checkForCallInvite(liveItems)
 
         // Publish raw items for call signaling (deduplication happens in CallSignalingService)
         if !allItems.isEmpty {
@@ -487,64 +481,6 @@ final class TimelineService {
             logTimeline("Call signaling sent via span")
         } catch {
             logTimeline("Call signaling send failed: \(error)")
-        }
-    }
-
-    // MARK: - Incoming Call Detection
-
-    private func checkForCallInvite(_ items: [TimelineItem]) {
-        for item in items {
-            guard let event = item.asEvent(),
-                  !event.isOwn,
-                  case .callInvite = event.content else { continue }
-
-            // Ignore old invites (e.g. from history pagination)
-            let eventTime = Date(timeIntervalSince1970: TimeInterval(event.timestamp) / 1000)
-            guard abs(eventTime.timeIntervalSinceNow) < 60 else { continue }
-
-            // Don't trigger if already in a call
-            guard !CallService.shared.state.isActive else { continue }
-
-            // Extract callId and SDP from raw event JSON
-            let debugInfo = event.lazyProvider.debugInfo()
-            guard let json = debugInfo.originalJson,
-                  let data = json.data(using: .utf8),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let content = dict["content"] as? [String: Any],
-                  let callId = content["call_id"] as? String else {
-                logTimeline("Call invite detected but failed to extract callId")
-                continue
-            }
-
-            // Extract SDP offer directly — can't rely on signaling receiving it later
-            let offerSDP: String? = {
-                if let offer = content["offer"] as? [String: Any],
-                   let sdp = offer["sdp"] as? String {
-                    return sdp
-                }
-                return nil
-            }()
-
-            let callerName: String? = {
-                if case .ready(let name, _, _) = event.senderProfile { return name }
-                return nil
-            }()
-
-            logTimeline("Incoming call invite detected: callId=\(callId) from \(callerName ?? event.sender), sdp=\(offerSDP?.count ?? 0) bytes")
-
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                CallService.shared.handleIncomingCall(
-                    room: self.room,
-                    callId: callId,
-                    callerName: callerName,
-                    offerSDP: offerSDP,
-                    timelineService: self
-                )
-            }
-
-            // Only handle the first invite
-            break
         }
     }
 

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Combine
+import UniformTypeIdentifiers
 import MatrixRustSDK
 import GRDB
 
@@ -286,6 +287,13 @@ final class TimelineService {
             let duration = content.audio?.duration ?? content.info?.duration ?? 0
             let waveform = content.audio?.waveform ?? []
             return .voice(source: content.source, duration: duration, waveform: waveform)
+        case .file(let content):
+            return .file(
+                source: content.source,
+                filename: content.filename,
+                mimetype: content.info?.mimetype,
+                size: content.info?.size
+            )
         default:
             return .unsupported(typeName: "message")
         }
@@ -410,6 +418,37 @@ final class TimelineService {
             logTimeline("Image sent via sendFile, \(width)×\(height)")
         } catch {
             logTimeline("Image send failed: \(error)")
+        }
+    }
+
+    func sendFile(url: URL) async {
+        guard let timeline else { return }
+
+        let filename = url.lastPathComponent
+        let fileSize = (try? FileManager.default.attributesOfItem(
+            atPath: url.path)[.size] as? UInt64) ?? 0
+
+        let mimetype: String
+        if let utType = UTType(filenameExtension: url.pathExtension),
+           let preferred = utType.preferredMIMEType {
+            mimetype = preferred
+        } else {
+            mimetype = "application/octet-stream"
+        }
+
+        let fileInfo = FileInfo(
+            mimetype: mimetype, size: fileSize,
+            thumbnailInfo: nil, thumbnailSource: nil
+        )
+        let params = UploadParameters(
+            source: .file(filename: url.path(percentEncoded: false)),
+            caption: nil, formattedCaption: nil, mentions: nil, inReplyTo: nil
+        )
+        do {
+            _ = try timeline.sendFile(params: params, fileInfo: fileInfo)
+            logTimeline("File sent: \(filename), \(fileSize) bytes")
+        } catch {
+            logTimeline("File send failed: \(error)")
         }
     }
 

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -252,17 +252,16 @@ final class TimelineService {
     }
 
     private static func contentFromEvent(_ event: EventTimelineItem) -> ChatMessageContent? {
+        // Call events: invite is native SDK, signaling rides in span.
+        // CallService writes call events to GRDB directly — skip here.
         switch event.content {
         case .callInvite:
-            guard let callId = extractCallId(from: event) else { return nil }
-            return .callEvent(type: .invited, callId: callId, reason: nil)
+            return nil
 
         case .msgLike(let msgContent):
-            // Check for span-based call signaling
+            // Filter span-based call signaling (answer, candidates, hangup)
             let attrs = extractZynaAttributes(from: event)
-            if let signal = attrs.callSignal {
-                return callContentFromSignal(signal)
-            }
+            if attrs.callSignal != nil { return nil }
 
             switch msgContent.kind {
             case .message(let messageContent):
@@ -282,32 +281,6 @@ final class TimelineService {
         default:
             return nil
         }
-    }
-
-    /// Maps a span-based call signal to content. Returns nil for
-    /// signaling-only events (answer, candidates) that shouldn't
-    /// appear in the chat.
-    private static func callContentFromSignal(_ signal: CallSignalData) -> ChatMessageContent? {
-        guard signal.type == "m.call.hangup" else {
-            // answer, candidates — pure signaling, filter out
-            return nil
-        }
-
-        guard let data = signal.payload.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let callId = dict["call_id"] as? String else { return nil }
-        let reason = dict["reason"] as? String
-        return .callEvent(type: .ended, callId: callId, reason: reason)
-    }
-
-    /// Extracts call_id from a native m.call.invite event's raw JSON.
-    private static func extractCallId(from event: EventTimelineItem) -> String? {
-        guard let json = event.lazyProvider.debugInfo().originalJson,
-              let data = json.data(using: .utf8),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let content = root["content"] as? [String: Any],
-              let callId = content["call_id"] as? String else { return nil }
-        return callId
     }
 
     private static func contentFromMessageType(_ msgType: MessageType) -> ChatMessageContent {

--- a/Zyna/SwiftUIScreens/Auth/AuthView.swift
+++ b/Zyna/SwiftUIScreens/Auth/AuthView.swift
@@ -10,7 +10,7 @@ struct AuthView: View {
 
     @State private var username: String = ""
     @State private var password: String = ""
-    @State private var homeserver: String = "matrix.org"
+    @State private var homeserver: String = Brand.current.defaultHomeserver
     @State private var showPassword = false
 
     var body: some View {

--- a/Zyna/SwiftUIScreens/Auth/AuthViewModel.swift
+++ b/Zyna/SwiftUIScreens/Auth/AuthViewModel.swift
@@ -23,7 +23,7 @@ final class AuthViewModel: ObservableObject {
 
     // MARK: - Password Login
 
-    func login(username: String, password: String, homeserver: String = "matrix.org") {
+    func login(username: String, password: String, homeserver: String = Brand.current.defaultHomeserver) {
         guard !username.isEmpty, !password.isEmpty else {
             errorMessage = "Enter username and password"
             return

--- a/Zyna/SwiftUIScreens/Verification/SessionVerificationView.swift
+++ b/Zyna/SwiftUIScreens/Verification/SessionVerificationView.swift
@@ -8,6 +8,7 @@ import MatrixRustSDK
 
 struct SessionVerificationView: View {
     @ObservedObject var viewModel: SessionVerificationViewModel
+    @State private var showSavedConfirmation = false
 
     var body: some View {
         ZStack {
@@ -25,12 +26,137 @@ struct SessionVerificationView: View {
             .padding()
         }
         .preferredColorScheme(.light)
+        .onAppear { viewModel.detectMode() }
+        .alert("Saved your recovery key?", isPresented: $showSavedConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("I've saved it") { viewModel.confirmRecoveryKeySaved() }
+        } message: {
+            Text("Without this key you'll lose access to encrypted messages if you sign in on another device.")
+        }
     }
 
     // MARK: - Content
 
     @ViewBuilder
     private func contentForStep() -> some View {
+        switch viewModel.mode {
+        case .checking:
+            checkingView()
+        case .firstDevice:
+            firstDeviceContent()
+        case .otherDevice:
+            otherDeviceContent()
+        }
+    }
+
+    // MARK: - Checking
+
+    private func checkingView() -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+                .tint(.white)
+            Text("Checking account…")
+                .foregroundColor(.white.opacity(0.6))
+        }
+    }
+
+    // MARK: - First-Device (Recovery) Content
+
+    @ViewBuilder
+    private func firstDeviceContent() -> some View {
+        switch viewModel.step {
+        case .initial:
+            recoveryIntroView()
+        case .generatingRecoveryKey:
+            generatingKeyView()
+        case .showingRecoveryKey(let key):
+            recoveryKeyView(key)
+        case .enteringRecoveryKey:
+            enterRecoveryKeyView()
+        case .restoringFromRecoveryKey:
+            restoringView()
+        case .verified:
+            verifiedView()
+        case .failed, .cancelled:
+            failedView()
+        default:
+            EmptyView()
+        }
+    }
+
+    private func recoveryIntroView() -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "key.fill")
+                .font(.system(size: 56))
+                .foregroundColor(.white.opacity(0.85))
+
+            Text("Set Up Recovery")
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
+
+            Text("Generate a recovery key to back up your encrypted messages, or enter an existing key if you already have one.")
+                .font(.body)
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+    }
+
+    private func generatingKeyView() -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+                .tint(.white)
+            Text("Generating recovery key…")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(.white.opacity(0.7))
+        }
+    }
+
+    private func recoveryKeyView(_ key: String) -> some View {
+        VStack(spacing: 20) {
+            Text("Your Recovery Key")
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
+
+            Text("Save this key in a password manager or somewhere safe. You'll need it to restore encrypted messages on other devices.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            Text(key)
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color.white.opacity(0.08))
+                .cornerRadius(12)
+                .padding(.horizontal)
+
+            HStack(spacing: 12) {
+                Button {
+                    UIPasteboard.general.string = key
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.8))
+                }
+                ShareLink(item: key) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.8))
+                }
+            }
+        }
+    }
+
+    // MARK: - Other-Device (Emoji or Recovery Key) Content
+
+    @ViewBuilder
+    private func otherDeviceContent() -> some View {
         switch viewModel.step {
         case .initial:
             initialView()
@@ -38,14 +164,66 @@ struct SessionVerificationView: View {
             waitingView()
         case .showingEmojis:
             emojisView()
+        case .enteringRecoveryKey:
+            enterRecoveryKeyView()
+        case .restoringFromRecoveryKey:
+            restoringView()
+        case .generatingRecoveryKey:
+            generatingKeyView()
+        case .showingRecoveryKey(let key):
+            recoveryKeyView(key)
         case .verified:
             verifiedView()
         case .cancelled, .failed:
             failedView()
+        default:
+            EmptyView()
         }
     }
 
-    // MARK: - Initial
+    private func enterRecoveryKeyView() -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "key.horizontal.fill")
+                .font(.system(size: 56))
+                .foregroundColor(.white.opacity(0.85))
+
+            Text("Enter Recovery Key")
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
+
+            Text("Paste the recovery key you saved when setting up the account.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            TextField("", text: $viewModel.recoveryKeyInput, axis: .vertical)
+                .font(.system(.body, design: .monospaced))
+                .foregroundColor(.white)
+                .lineLimit(3...5)
+                .padding()
+                .background(Color.white.opacity(0.08))
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                )
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .padding(.horizontal)
+        }
+    }
+
+    private func restoringView() -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+                .tint(.white)
+            Text("Restoring from recovery key…")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(.white.opacity(0.7))
+        }
+    }
 
     private func initialView() -> some View {
         VStack(spacing: 16) {
@@ -65,8 +243,6 @@ struct SessionVerificationView: View {
         }
     }
 
-    // MARK: - Waiting
-
     private func waitingView() -> some View {
         VStack(spacing: 16) {
             ProgressView()
@@ -84,8 +260,6 @@ struct SessionVerificationView: View {
                 .padding(.horizontal, 32)
         }
     }
-
-    // MARK: - Emojis
 
     private func emojisView() -> some View {
         VStack(spacing: 20) {
@@ -127,7 +301,7 @@ struct SessionVerificationView: View {
         .padding(.horizontal)
     }
 
-    // MARK: - Verified
+    // MARK: - Shared (verified / failed)
 
     private func verifiedView() -> some View {
         VStack(spacing: 16) {
@@ -135,11 +309,13 @@ struct SessionVerificationView: View {
                 .font(.system(size: 56))
                 .foregroundColor(.green)
 
-            Text("Device Verified!")
+            Text("All Set!")
                 .font(.system(size: 28, weight: .bold, design: .rounded))
                 .foregroundColor(.white.opacity(0.9))
 
-            Text("Your device is now verified. Messages will be trusted by other sessions.")
+            Text(viewModel.mode == .firstDevice
+                 ? "Recovery key saved. You're ready to chat."
+                 : "Your device is now verified. Messages will be trusted by other sessions.")
                 .font(.body)
                 .foregroundColor(.white.opacity(0.6))
                 .multilineTextAlignment(.center)
@@ -147,15 +323,13 @@ struct SessionVerificationView: View {
         }
     }
 
-    // MARK: - Failed
-
     private func failedView() -> some View {
         VStack(spacing: 16) {
             Image(systemName: "xmark.shield")
                 .font(.system(size: 56))
                 .foregroundColor(.red.opacity(0.8))
 
-            Text("Verification Failed")
+            Text(viewModel.mode == .firstDevice ? "Setup Failed" : "Verification Failed")
                 .font(.system(size: 22, weight: .semibold, design: .rounded))
                 .foregroundColor(.white.opacity(0.9))
 
@@ -173,30 +347,88 @@ struct SessionVerificationView: View {
 
     @ViewBuilder
     private func bottomButtons() -> some View {
+        switch viewModel.mode {
+        case .checking:
+            EmptyView()
+        case .firstDevice:
+            firstDeviceButtons()
+        case .otherDevice:
+            otherDeviceButtons()
+        }
+    }
+
+    @ViewBuilder
+    private func firstDeviceButtons() -> some View {
+        switch viewModel.step {
+        case .initial:
+            VStack(spacing: 12) {
+                primaryButton("Generate Recovery Key") { viewModel.setupRecovery() }
+                textButton("I have a recovery key") { viewModel.useRecoveryKey() }
+                textButton("Skip for now") { viewModel.skip() }
+            }
+        case .generatingRecoveryKey:
+            EmptyView()
+        case .showingRecoveryKey:
+            primaryButton("Done") { showSavedConfirmation = true }
+        case .enteringRecoveryKey:
+            VStack(spacing: 12) {
+                primaryButton("Restore") { viewModel.restoreFromRecoveryKey() }
+                textButton("Cancel") { viewModel.skip() }
+            }
+        case .restoringFromRecoveryKey:
+            EmptyView()
+        case .verified:
+            primaryButton("Continue") { viewModel.continueToApp() }
+        case .failed, .cancelled:
+            VStack(spacing: 12) {
+                primaryButton("Try Again") { viewModel.setupRecovery() }
+                textButton("I have a recovery key") { viewModel.useRecoveryKey() }
+                textButton("Skip for now") { viewModel.skip() }
+            }
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func otherDeviceButtons() -> some View {
         switch viewModel.step {
         case .initial:
             VStack(spacing: 12) {
                 primaryButton("Start Verification") { viewModel.startVerification() }
+                textButton("I have a recovery key") { viewModel.useRecoveryKey() }
+                textButton("Generate new recovery key") { viewModel.setupRecovery() }
                 textButton("Skip for now") { viewModel.skip() }
             }
-
         case .requestingVerification, .waitingForAcceptance:
             textButton("Cancel") { viewModel.skip() }
-
         case .showingEmojis:
             VStack(spacing: 12) {
                 primaryButton("They Match") { viewModel.confirmEmojis() }
                 textButton("They Don't Match") { viewModel.denyEmojis() }
             }
-
+        case .enteringRecoveryKey:
+            VStack(spacing: 12) {
+                primaryButton("Restore") { viewModel.restoreFromRecoveryKey() }
+                textButton("Cancel") { viewModel.skip() }
+            }
+        case .restoringFromRecoveryKey:
+            EmptyView()
+        case .generatingRecoveryKey:
+            EmptyView()
+        case .showingRecoveryKey:
+            primaryButton("Done") { showSavedConfirmation = true }
         case .verified:
             primaryButton("Continue") { viewModel.continueToApp() }
-
         case .cancelled, .failed:
             VStack(spacing: 12) {
                 primaryButton("Try Again") { viewModel.startVerification() }
+                textButton("I have a recovery key") { viewModel.useRecoveryKey() }
+                textButton("Generate new recovery key") { viewModel.setupRecovery() }
                 textButton("Skip for now") { viewModel.skip() }
             }
+        default:
+            EmptyView()
         }
     }
 

--- a/Zyna/SwiftUIScreens/Verification/SessionVerificationViewModel.swift
+++ b/Zyna/SwiftUIScreens/Verification/SessionVerificationViewModel.swift
@@ -7,10 +7,21 @@ import Foundation
 import Combine
 import MatrixRustSDK
 
+/// Which flow the screen is currently presenting.
+/// Determined on appearance via `isLastDevice()`.
+enum VerificationMode {
+    case checking      // determining which flow to use
+    case firstDevice   // no other devices — generate recovery key
+    case otherDevice   // verify against existing device with emojis
+}
+
 final class SessionVerificationViewModel: ObservableObject {
 
+    @Published var mode: VerificationMode = .checking
     @Published var step: VerificationStep = .initial
     @Published var emojis: [SessionVerificationEmoji] = []
+    @Published var recoveryKey: String?
+    @Published var recoveryKeyInput: String = ""
     @Published var errorMessage: String?
 
     var onVerified: (() -> Void)?
@@ -23,15 +34,44 @@ final class SessionVerificationViewModel: ObservableObject {
         service.stepSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] step in
-                self?.step = step
+                guard let self else { return }
+                self.step = step
                 if case .showingEmojis(let emojis) = step {
-                    self?.emojis = emojis
+                    self.emojis = emojis
+                }
+                if case .showingRecoveryKey(let key) = step {
+                    self.recoveryKey = key
+                }
+                // Emoji verification finished from SDK delegate —
+                // cross-signing secrets are now on this device.
+                if case .verified = step {
+                    self.service.markLocalSecretsPresent()
                 }
             }
             .store(in: &cancellables)
     }
 
-    // MARK: - Actions
+    // MARK: - Mode Detection
+
+    func detectMode() {
+        Task {
+            do {
+                let isLast = try await service.isLastDevice()
+                await MainActor.run {
+                    self.mode = isLast ? .firstDevice : .otherDevice
+                }
+            } catch {
+                // If we can't determine, assume other-device flow
+                // (the existing/safer default).
+                await MainActor.run {
+                    self.mode = .otherDevice
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    // MARK: - Other-Device Flow (emoji)
 
     func startVerification() {
         errorMessage = nil
@@ -66,6 +106,65 @@ final class SessionVerificationViewModel: ObservableObject {
             try? await service.declineVerification()
         }
     }
+
+    // MARK: - First-Device Flow (recovery key)
+
+    func setupRecovery() {
+        errorMessage = nil
+        step = .generatingRecoveryKey
+        Task {
+            do {
+                let key = try await service.enableRecovery()
+                // We just created the cross-signing secrets locally.
+                service.markLocalSecretsPresent()
+                await MainActor.run {
+                    self.recoveryKey = key
+                    self.step = .showingRecoveryKey(key)
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    step = .failed
+                }
+            }
+        }
+    }
+
+    func confirmRecoveryKeySaved() {
+        step = .verified
+    }
+
+    // MARK: - Restore From Recovery Key
+
+    func useRecoveryKey() {
+        errorMessage = nil
+        recoveryKeyInput = ""
+        step = .enteringRecoveryKey
+    }
+
+    func restoreFromRecoveryKey() {
+        errorMessage = nil
+        let key = recoveryKeyInput
+        guard !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        step = .restoringFromRecoveryKey
+        Task {
+            do {
+                try await service.recover(key: key)
+                // Secrets just downloaded onto this device.
+                service.markLocalSecretsPresent()
+                await MainActor.run {
+                    self.step = .verified
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.step = .failed
+                }
+            }
+        }
+    }
+
+    // MARK: - Common
 
     func skip() {
         onSkipped?()


### PR DESCRIPTION
## Summary
- File sending with document picker, file cells (color-coded extension icon, filename, size), persistent cache, Quick Look preview with markup support, and download progress indicator
- Call signaling moved from ZYNA_CALL: plaintext prefix to Zyna HTML span carrier (data-zyna attribute)
- Call events stored in GRDB directly from CallService, displayed as centered system cells in chat
- Calls tab with full call history from GRDB (avatar, direction, status, callback button)
- Contacts tab with DM contacts list and server user directory search, profile navigation with contextual "Перейти в чат" / "Новый чат" button
- Incoming call detection moved from per-room TimelineService to global SyncNotificationListener — calls now ring from any screen
- Settings tab removed, tab bar reordered: Contacts | Calls | Chats | Profile
- Room invite acceptance: invite banner inside the chat view with an "Accept" button that calls `room.join()`; timeline and history sync are deferred until the invite is accepted
- Session verification rebuilt with two flows based on `isLastDevice`: first device generates a recovery key via `enableRecovery` (or `resetRecoveryKey` if one already exists on the server), and other-device login can either run the existing emoji flow or restore via `encryption.recover(recoveryKey:)`. Per-user "local secrets present" flag in UserDefaults is the source of truth for skipping the screen on launch — see commit body for the rationale, since the SDK doesn't expose this question directly
- `MatrixClientService` now attaches verification/recovery state listeners on the SDK's encryption module and exposes the latest values via `CurrentValueSubject`; `AppCoordinator.showVerificationIfNeeded` becomes async and reads from these
- `Brand` enum for white-label builds (`zyna` vs `sds` for first client) — currently switches the default homeserver on the login screen; bundle id, app icon and target separation deferred until App Store deploy
- Dev-server affordances: `NSAllowsArbitraryLoads` in Info.plist for HTTP-only test homeserver (TODO in `MatrixClientService` to remove once HTTPS is set up)
- Build/signing fixes: `NSCameraUsageDescription` added, signing identity switched to Apple Distribution

## New files
- `FileCellNode`, `FileCacheService` — file message cells and persistent media cache
- `CallEventCellNode`, `SystemEventCellNode` — system event cells (base + call)
- `CallNotificationListener` — global incoming call detection via SDK sync notifications
- `CallsViewController/ViewModel/CellNode`, `CallHistoryModel` — Calls tab
- `ContactsViewController/ViewModel/CellNode`, `ContactModel`, `ContactsCoordinator` — Contacts tab
- `Chat/InviteBannerView` — accept-invite banner shown above the message list
- `Core/Brand` — white-label brand switch enum
