### PR TITLE
Stage 14: Chat peek previews, sticky dates, and chat themes

### DIFF
--- a/Zyna.xcodeproj/project.pbxproj
+++ b/Zyna.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UM3QPHF8E3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -322,7 +322,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -349,7 +349,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = UM3QPHF8E3;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -366,7 +366,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.app.zyna.Zyna;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Zyna/Chat/CellNodes/FileCellNode.swift
+++ b/Zyna/Chat/CellNodes/FileCellNode.swift
@@ -13,6 +13,7 @@ final class FileCellNode: MessageCellNode {
     var onFileTapped: (() -> Void)?
 
     override func accessibilityActivate() -> Bool {
+        guard allowsInteractiveActions else { return false }
         onFileTapped?()
         return true
     }

--- a/Zyna/Chat/CellNodes/ImageMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/ImageMessageCellNode.swift
@@ -13,6 +13,7 @@ final class ImageMessageCellNode: MessageCellNode {
     var onImageTapped: (() -> Void)?
 
     override func accessibilityActivate() -> Bool {
+        guard allowsInteractiveActions else { return false }
         onImageTapped?()
         return true
     }

--- a/Zyna/Chat/CellNodes/MessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/MessageCellNode.swift
@@ -520,6 +520,7 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
               old.replyInfo == new.replyInfo,
               old.senderDisplayName == new.senderDisplayName,
               old.senderAvatarUrl == new.senderAvatarUrl,
+              old.isFirstInCluster == new.isFirstInCluster,
               mediaGroupPresentationIsVisuallyEquivalent(old: old.mediaGroupPresentation, new: new.mediaGroupPresentation)
         else {
             return false

--- a/Zyna/Chat/CellNodes/MessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/MessageCellNode.swift
@@ -92,6 +92,11 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
     let mediaGroupPosition: MediaGroupPosition?
     private let rendersCompositeMediaBubble: Bool
     let usesAccentBubbleStyle: Bool
+    var allowsInteractiveActions = true {
+        didSet {
+            applyInteractiveActionsState()
+        }
+    }
     private var showsBubbleChrome = true
     private var usesBareBubbleContent = false
 
@@ -197,6 +202,10 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
                 ]
             )
             senderNameNode.onDidLoad { [weak self] node in
+                guard let self, self.allowsInteractiveActions else {
+                    node.view.isUserInteractionEnabled = false
+                    return
+                }
                 node.view.isUserInteractionEnabled = true
                 let tap = UITapGestureRecognizer(
                     target: self,
@@ -252,6 +261,10 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
             }
 
             avatarBackgroundNode.onDidLoad { [weak self] node in
+                guard let self, self.allowsInteractiveActions else {
+                    node.view.isUserInteractionEnabled = false
+                    return
+                }
                 node.view.isUserInteractionEnabled = true
                 let tap = UITapGestureRecognizer(
                     target: self,
@@ -324,6 +337,7 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
     }
 
     @objc private func handleSenderTap() {
+        guard allowsInteractiveActions else { return }
         onSenderTapped?(senderId)
     }
 
@@ -332,11 +346,19 @@ class MessageCellNode: ZynaCellNode, ContextMenuCellNode {
         node.onReactionTapped = { [weak self] key in
             self?.onReactionTapped?(key)
         }
+        node.isUserInteractionEnabled = allowsInteractiveActions
         node.style.maxWidth = ASDimension(
             unit: .points,
             value: ScreenConstants.width * MessageCellHelpers.maxBubbleWidthRatio
         )
         return node
+    }
+
+    private func applyInteractiveActionsState() {
+        contextSourceNode.isGestureEnabled = allowsInteractiveActions
+        senderNameNode.isUserInteractionEnabled = allowsInteractiveActions
+        avatarBackgroundNode.isUserInteractionEnabled = allowsInteractiveActions
+        reactionsNode?.isUserInteractionEnabled = allowsInteractiveActions
     }
 
     private var usesFallbackBubbleBackground: Bool {

--- a/Zyna/Chat/CellNodes/SystemEventCellNode.swift
+++ b/Zyna/Chat/CellNodes/SystemEventCellNode.swift
@@ -45,3 +45,33 @@ class SystemEventCellNode: ASCellNode {
         )
     }
 }
+
+final class DateDividerCellNode: ASCellNode {
+    static let height: CGFloat = 34
+
+    private let spacerNode = ASDisplayNode()
+
+    init(model: DateDividerModel) {
+        super.init()
+        automaticallyManagesSubnodes = true
+        selectionStyle = .none
+        backgroundColor = .clear
+        spacerNode.isLayerBacked = true
+        spacerNode.backgroundColor = .clear
+        isAccessibilityElement = true
+        accessibilityLabel = model.title
+        accessibilityTraits = .staticText
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        let width = constrainedSize.max.width.isFinite ? max(1, constrainedSize.max.width) : 1
+        spacerNode.style.preferredSize = CGSize(
+            width: width,
+            height: Self.height
+        )
+        return ASWrapperLayoutSpec(layoutElement: spacerNode)
+    }
+}

--- a/Zyna/Chat/CellNodes/SystemEventCellNode.swift
+++ b/Zyna/Chat/CellNodes/SystemEventCellNode.swift
@@ -46,7 +46,7 @@ class SystemEventCellNode: ASCellNode {
     }
 }
 
-final class DateDividerCellNode: ASCellNode {
+final class DateDividerCellNode: ZynaCellNode {
     static let height: CGFloat = 34
 
     private let spacerNode = ASDisplayNode()

--- a/Zyna/Chat/CellNodes/VoiceMessageCellNode.swift
+++ b/Zyna/Chat/CellNodes/VoiceMessageCellNode.swift
@@ -207,6 +207,7 @@ final class VoiceMessageCellNode: MessageCellNode {
     }
 
     override func accessibilityActivate() -> Bool {
+        guard allowsInteractiveActions else { return false }
         playTapped()
         return true
     }

--- a/Zyna/Chat/ChatBubbleTheme.swift
+++ b/Zyna/Chat/ChatBubbleTheme.swift
@@ -1,0 +1,194 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+struct ChatBubbleTheme: Equatable {
+    let id: String
+    let title: String
+    let outgoingGradientColors: [UIColor]
+    let startPoint: CGPoint
+    let endPoint: CGPoint
+
+    init(
+        id: String,
+        title: String,
+        outgoingGradientColors: [UIColor],
+        startPoint: CGPoint = CGPoint(x: 0.5, y: 0.0),
+        endPoint: CGPoint = CGPoint(x: 0.5, y: 1.0)
+    ) {
+        self.id = id
+        self.title = title
+        self.outgoingGradientColors = outgoingGradientColors
+        self.startPoint = startPoint
+        self.endPoint = endPoint
+    }
+
+    static let zynaBlue = ChatBubbleTheme(
+        id: "zynaBlue",
+        title: String(localized: "Zyna Blue"),
+        outgoingGradientColors: [
+            UIColor(hex: 0x8AB8FF),
+            UIColor(hex: 0x5C8EFA),
+            UIColor(hex: 0x3954D6)
+        ]
+    )
+
+    static let auroraLime = ChatBubbleTheme(
+        id: "auroraLime",
+        title: String(localized: "Aurora Lime"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xB6D94A),
+            UIColor(hex: 0x2DBA70),
+            UIColor(hex: 0x057A67)
+        ]
+    )
+
+    static let forest = ChatBubbleTheme(
+        id: "forest",
+        title: String(localized: "Forest"),
+        outgoingGradientColors: [
+            UIColor(hex: 0x72B878),
+            UIColor(hex: 0x2FA66A),
+            UIColor(hex: 0x075C4A)
+        ]
+    )
+
+    static let violetBlue = ChatBubbleTheme(
+        id: "violetBlue",
+        title: String(localized: "Violet Blue"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xB05CFF),
+            UIColor(hex: 0x6B4DFF),
+            UIColor(hex: 0x1268FF)
+        ]
+    )
+
+    static let emberRose = ChatBubbleTheme(
+        id: "emberRose",
+        title: String(localized: "Ember Rose"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xFF9AAE),
+            UIColor(hex: 0xE6507A),
+            UIColor(hex: 0x7B3FF2)
+        ]
+    )
+
+    static let lagoonTeal = ChatBubbleTheme(
+        id: "lagoonTeal",
+        title: String(localized: "Lagoon Teal"),
+        outgoingGradientColors: [
+            UIColor(hex: 0x5DE2E7),
+            UIColor(hex: 0x20B7BC),
+            UIColor(hex: 0x1768D8)
+        ]
+    )
+
+    static let solarCoral = ChatBubbleTheme(
+        id: "solarCoral",
+        title: String(localized: "Solar Coral"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xFFB15C),
+            UIColor(hex: 0xFF6B61),
+            UIColor(hex: 0xC43BE8)
+        ]
+    )
+
+    static let mango = ChatBubbleTheme(
+        id: "mango",
+        title: String(localized: "Mango"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xFFD36E),
+            UIColor(hex: 0xFF9D3D),
+            UIColor(hex: 0xEF4E5D)
+        ]
+    )
+
+    static let graphiteCyan = ChatBubbleTheme(
+        id: "graphiteCyan",
+        title: String(localized: "Graphite Cyan"),
+        outgoingGradientColors: [
+            UIColor(hex: 0x556070),
+            UIColor(hex: 0x2563EB),
+            UIColor(hex: 0x06B6D4)
+        ]
+    )
+
+    static let rubyPlum = ChatBubbleTheme(
+        id: "rubyPlum",
+        title: String(localized: "Ruby Plum"),
+        outgoingGradientColors: [
+            UIColor(hex: 0xFF5A7D),
+            UIColor(hex: 0xC72E7E),
+            UIColor(hex: 0x5B32D6)
+        ]
+    )
+
+    static let all: [ChatBubbleTheme] = [
+        .zynaBlue,
+        .auroraLime,
+        .forest,
+        .violetBlue,
+        .emberRose,
+        .lagoonTeal,
+        .solarCoral,
+        .mango,
+        .graphiteCyan,
+        .rubyPlum
+    ]
+
+    static let fallback = zynaBlue
+
+    static func theme(id: String) -> ChatBubbleTheme? {
+        return all.first { $0.id == id }
+    }
+
+    static func == (lhs: ChatBubbleTheme, rhs: ChatBubbleTheme) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+final class ChatBubbleThemeStore {
+    static let shared = ChatBubbleThemeStore()
+
+    private enum DefaultsKey {
+        static let selectedThemeId = "chatBubbleTheme.selectedThemeId"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var selectedTheme: ChatBubbleTheme {
+        selectedThemeId.flatMap(ChatBubbleTheme.theme(id:)) ?? .fallback
+    }
+
+    var selectedThemeId: String? {
+        defaults.string(forKey: DefaultsKey.selectedThemeId)
+    }
+
+    func setSelectedTheme(id: String) {
+        guard ChatBubbleTheme.theme(id: id) != nil else { return }
+        defaults.set(id, forKey: DefaultsKey.selectedThemeId)
+    }
+}
+
+enum BubbleGradientStops {
+    static func layerLocations(for colorCount: Int) -> [NSNumber]? {
+        cgLocations(for: colorCount)?.map { NSNumber(value: Double($0)) }
+    }
+
+    static func cgLocations(for colorCount: Int) -> [CGFloat]? {
+        guard colorCount > 1 else { return nil }
+        if colorCount == 3 {
+            return [0.0, 0.48, 1.0]
+        }
+        return (0 ..< colorCount).map { index in
+            CGFloat(index) / CGFloat(colorCount - 1)
+        }
+    }
+}

--- a/Zyna/Chat/ChatMessage.swift
+++ b/Zyna/Chat/ChatMessage.swift
@@ -253,6 +253,63 @@ struct ClusterNeighbor {
     let mediaGroupId: String?
 }
 
+// MARK: - Timeline Rows
+
+struct DateDividerModel: Equatable, Hashable {
+    let id: String
+    let date: Date
+    let title: String
+
+    static func make(for date: Date, calendar: Calendar = .current, now: Date = Date()) -> DateDividerModel {
+        let dayStart = calendar.startOfDay(for: date)
+        let title: String
+        if calendar.isDate(dayStart, inSameDayAs: now) {
+            title = String(localized: "Today")
+        } else if let yesterday = calendar.date(byAdding: .day, value: -1, to: calendar.startOfDay(for: now)),
+                  calendar.isDate(dayStart, inSameDayAs: yesterday) {
+            title = String(localized: "Yesterday")
+        } else if calendar.component(.year, from: dayStart) == calendar.component(.year, from: now) {
+            title = Self.currentYearDateFormatter.string(from: dayStart)
+        } else {
+            title = Self.dateFormatter.string(from: dayStart)
+        }
+
+        return DateDividerModel(
+            id: "date-divider:\(Int(dayStart.timeIntervalSince1970))",
+            date: dayStart,
+            title: title
+        )
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    private static let currentYearDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("dMMMM")
+        return formatter
+    }()
+}
+
+enum ChatTimelineRow: Equatable {
+    case message(ChatMessage)
+    case dateDivider(DateDividerModel)
+
+    var message: ChatMessage? {
+        if case .message(let message) = self { return message }
+        return nil
+    }
+
+    var dateDivider: DateDividerModel? {
+        if case .dateDivider(let model) = self { return model }
+        return nil
+    }
+}
+
 enum MediaGroupPosition: String, Equatable {
     case top
     case middle
@@ -371,6 +428,7 @@ struct ChatMessage: Identifiable, Equatable, Hashable {
             && lhs.replyInfo == rhs.replyInfo
             && lhs.zynaAttributes == rhs.zynaAttributes
             && lhs.sendStatus == rhs.sendStatus
+            && lhs.isFirstInCluster == rhs.isFirstInCluster
             && lhs.isLastInCluster == rhs.isLastInCluster
             && lhs.mediaGroupPresentation == rhs.mediaGroupPresentation
             && lhs.outgoingEnvelopeId == rhs.outgoingEnvelopeId

--- a/Zyna/Chat/ChatPeekOverlayController.swift
+++ b/Zyna/Chat/ChatPeekOverlayController.swift
@@ -1,0 +1,188 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+final class ChatPeekOverlayController: UIViewController {
+
+    private let chatController: ChatViewController
+    private let sourceFrameInScreen: CGRect?
+    private let dimmingView = UIView()
+    private let shadowView = UIView()
+    private let clippingView = UIView()
+    private var didApplyInitialState = false
+    private var didAnimateIn = false
+    private var isDismissingOverlay = false
+    private var currentTargetFrame: CGRect = .zero
+
+    init(chatController: ChatViewController, sourceFrameInScreen: CGRect?) {
+        self.chatController = chatController
+        self.sourceFrameInScreen = sourceFrameInScreen
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+
+        dimmingView.backgroundColor = UIColor.black.withAlphaComponent(0.28)
+        dimmingView.alpha = 0
+        view.addSubview(dimmingView)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
+        dimmingView.addGestureRecognizer(tap)
+
+        shadowView.backgroundColor = .clear
+        shadowView.layer.shadowColor = UIColor.black.cgColor
+        shadowView.layer.shadowOpacity = 0.24
+        shadowView.layer.shadowRadius = 26
+        shadowView.layer.shadowOffset = CGSize(width: 0, height: 18)
+        view.addSubview(shadowView)
+
+        clippingView.clipsToBounds = true
+        clippingView.backgroundColor = AppColor.chatBackground
+        clippingView.layer.cornerCurve = .continuous
+        clippingView.layer.cornerRadius = 24
+        shadowView.addSubview(clippingView)
+
+        addChild(chatController)
+        clippingView.addSubview(chatController.view)
+        chatController.didMove(toParent: self)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        dimmingView.frame = view.bounds
+        guard !isDismissingOverlay else { return }
+
+        let frame = targetFrame()
+        currentTargetFrame = frame
+        shadowView.frame = frame
+        clippingView.frame = shadowView.bounds
+        chatController.view.frame = clippingView.bounds
+        shadowView.layer.shadowPath = UIBezierPath(
+            roundedRect: shadowView.bounds,
+            cornerRadius: clippingView.layer.cornerRadius
+        ).cgPath
+
+        if !didApplyInitialState {
+            applyInitialState(targetFrame: frame)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        animateInIfNeeded()
+    }
+
+    @objc private func backgroundTapped() {
+        dismissAnimated()
+    }
+
+    private func targetFrame() -> CGRect {
+        let bounds = view.bounds
+        let safeArea = view.safeAreaInsets
+        let side = max(
+            180,
+            min(
+                420,
+                bounds.width - 32,
+                bounds.height - safeArea.top - safeArea.bottom - 80
+            )
+        )
+
+        let x = floor((bounds.width - side) / 2)
+        let minY = safeArea.top + 24
+        let maxY = max(minY, bounds.height - safeArea.bottom - side - 24)
+        let centeredY = floor((bounds.height - side) / 2) - 24
+        let y = min(max(centeredY, minY), maxY)
+
+        return CGRect(x: x, y: y, width: side, height: side)
+    }
+
+    private func applyInitialState(targetFrame: CGRect) {
+        didApplyInitialState = true
+
+        guard let sourceState = sourceState(targetFrame: targetFrame) else {
+            shadowView.alpha = 0
+            shadowView.transform = CGAffineTransform(scaleX: 0.94, y: 0.94)
+            return
+        }
+
+        shadowView.alpha = 0.9
+        shadowView.center = sourceState.center
+        shadowView.transform = sourceState.transform
+    }
+
+    private func sourceState(targetFrame: CGRect) -> (center: CGPoint, transform: CGAffineTransform)? {
+        guard let sourceFrameInScreen,
+              sourceFrameInScreen.width > 0,
+              sourceFrameInScreen.height > 0
+        else { return nil }
+
+        let sourceFrame = view.convert(sourceFrameInScreen, from: nil)
+        let scale = max(
+            0.18,
+            min(
+                sourceFrame.width / max(targetFrame.width, 1),
+                sourceFrame.height / max(targetFrame.height, 1)
+            )
+        )
+        return (
+            center: CGPoint(x: sourceFrame.midX, y: sourceFrame.midY),
+            transform: CGAffineTransform(scaleX: scale, y: scale)
+        )
+    }
+
+    private func animateInIfNeeded() {
+        guard !didAnimateIn else { return }
+        didAnimateIn = true
+
+        UIView.animate(
+            withDuration: 0.24,
+            delay: 0,
+            usingSpringWithDamping: 0.86,
+            initialSpringVelocity: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction]
+        ) {
+            self.dimmingView.alpha = 1
+            self.shadowView.alpha = 1
+            self.shadowView.center = CGPoint(x: self.currentTargetFrame.midX, y: self.currentTargetFrame.midY)
+            self.shadowView.transform = .identity
+        }
+    }
+
+    private func dismissAnimated() {
+        guard !isDismissingOverlay else { return }
+        isDismissingOverlay = true
+
+        let sourceState = sourceState(targetFrame: currentTargetFrame)
+
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: [.beginFromCurrentState, .curveEaseIn]
+        ) {
+            self.dimmingView.alpha = 0
+            self.shadowView.alpha = 0
+            if let sourceState {
+                self.shadowView.center = sourceState.center
+                self.shadowView.transform = sourceState.transform
+            } else {
+                self.shadowView.transform = CGAffineTransform(scaleX: 0.94, y: 0.94)
+            }
+        } completion: { _ in
+            self.dismiss(animated: false)
+        }
+    }
+}

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -145,17 +145,26 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private var pendingPostSendPinToLive = false
     private var redactionAnimationsArmed = false
     private var redactionAnimationArmWork: DispatchWorkItem?
+    private var didCleanupViewModel = false
+
+    private var isPreviewMode: Bool {
+        viewModel.mode.isPreview
+    }
 
     // MARK: - Init
 
     init(viewModel: ChatViewModel) {
         self.viewModel = viewModel
         super.init(node: ChatNode())
-        hidesBottomBarWhenPushed = true
+        hidesBottomBarWhenPushed = !viewModel.mode.isPreview
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        cleanupViewModelIfNeeded()
     }
 
     // MARK: - Lifecycle
@@ -171,35 +180,41 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         node.tableNode.view.showsVerticalScrollIndicator = false
         node.tableNode.automaticallyAdjustsContentOffset = false
 
-        let tap = UITapGestureRecognizer(target: self, action: #selector(tableTapped))
-        tap.cancelsTouchesInView = false
-        // Cells' ContextSourceNode installs a zero-duration long-press
-        // that would otherwise swallow the tap — recognize simultaneously.
-        tap.delegate = self
-        // Let the scroll pan take precedence: a flick that starts a scroll
-        // shouldn't also register as a dismissing tap.
-        tap.require(toFail: node.tableNode.view.panGestureRecognizer)
-        node.tableNode.view.addGestureRecognizer(tap)
+        if !isPreviewMode {
+            let tap = UITapGestureRecognizer(target: self, action: #selector(tableTapped))
+            tap.cancelsTouchesInView = false
+            // Cells' ContextSourceNode installs a zero-duration long-press
+            // that would otherwise swallow the tap — recognize simultaneously.
+            tap.delegate = self
+            // Let the scroll pan take precedence: a flick that starts a scroll
+            // shouldn't also register as a dismissing tap.
+            tap.require(toFail: node.tableNode.view.panGestureRecognizer)
+            node.tableNode.view.addGestureRecognizer(tap)
+        }
 
         setupNavigationBar()
         bindViewModel()
-        bindInput()
-        bindComposer()
+        if !isPreviewMode {
+            bindInput()
+            bindComposer()
+        }
 
         // Glass nav bar (replaces system nav bar)
-        glassNavBar.name = viewModel.roomName
-        glassNavBar.onBack = { [weak self] in self?.onBack?() }
-        glassNavBar.onCall = { [weak self] in self?.onCallTapped?() }
-        glassNavBar.onTitleTapped = { [weak self] in
-            guard let self else { return }
-            if let userId = self.viewModel.partnerUserId {
-                self.onTitleTapped?(userId)
-            } else {
-                self.onRoomDetailsTapped?()
+        if !isPreviewMode {
+            glassNavBar.name = viewModel.roomName
+            glassNavBar.onBack = { [weak self] in self?.onBack?() }
+            glassNavBar.onCall = { [weak self] in self?.onCallTapped?() }
+            glassNavBar.onTitleTapped = { [weak self] in
+                guard let self else { return }
+                if let userId = self.viewModel.partnerUserId {
+                    self.onTitleTapped?(userId)
+                } else {
+                    self.onRoomDetailsTapped?()
+                }
             }
+            node.addSubnode(glassNavBar)
+            node.glassNavBar = glassNavBar
         }
-        node.addSubnode(glassNavBar)
-        node.glassNavBar = glassNavBar
 
         // Search bar (hidden by default)
         searchBar.isHidden = true
@@ -217,19 +232,25 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         searchBar.onCancel = { [weak self] in
             self?.deactivateSearch()
         }
-        view.addSubview(searchBar)
+        if !isPreviewMode {
+            view.addSubview(searchBar)
+        }
 
         // Invite banner (hidden by default)
         inviteBanner.isHidden = !viewModel.isInvited
         inviteBanner.onAccept = { [weak self] in
             self?.viewModel.acceptInvite()
         }
-        view.addSubview(inviteBanner)
+        if !isPreviewMode {
+            view.addSubview(inviteBanner)
+        }
 
         // Glass input bar
-        glassInputBar.isHidden = viewModel.isInvited
-        node.addSubnode(glassInputBar)
-        node.glassInputBar = glassInputBar
+        if !isPreviewMode {
+            glassInputBar.isHidden = viewModel.isInvited
+            node.addSubnode(glassInputBar)
+            node.glassInputBar = glassInputBar
+        }
 
         // Scroll-to-live button — lives on node.view so its tap target
         // works when positioned above the input bar's bounds.
@@ -237,43 +258,66 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         scrollButtonIcon.contentMode = .center
         scrollButtonIcon.alpha = 0
         scrollButtonIcon.isUserInteractionEnabled = false
-        node.view.addSubview(scrollButtonIcon)
+        if !isPreviewMode {
+            node.view.addSubview(scrollButtonIcon)
+        }
 
         scrollButtonTap.alpha = 0
         scrollButtonTap.accessibilityLabel = "Scroll to bottom"
         scrollButtonTap.accessibilityTraits = .button
         scrollButtonTap.addTarget(self, action: #selector(scrollToLiveTapped), for: .touchUpInside)
-        node.view.addSubview(scrollButtonTap)
-        node.scrollButtonTap = scrollButtonTap
+        if !isPreviewMode {
+            node.view.addSubview(scrollButtonTap)
+            node.scrollButtonTap = scrollButtonTap
+        }
 
         scrollButtonBadgeBackground.backgroundColor = .systemRed
         scrollButtonBadgeBackground.alpha = 0
         scrollButtonBadgeBackground.isUserInteractionEnabled = false
-        node.view.addSubview(scrollButtonBadgeBackground)
+        if !isPreviewMode {
+            node.view.addSubview(scrollButtonBadgeBackground)
+        }
 
         scrollButtonBadgeLabel.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
         scrollButtonBadgeLabel.textColor = .white
         scrollButtonBadgeLabel.textAlignment = .center
         scrollButtonBadgeLabel.alpha = 0
         scrollButtonBadgeLabel.isUserInteractionEnabled = false
-        node.view.addSubview(scrollButtonBadgeLabel)
+        if !isPreviewMode {
+            node.view.addSubview(scrollButtonBadgeLabel)
+        }
 
-        refreshGlassSourceBinding()
+        if !isPreviewMode {
+            refreshGlassSourceBinding()
+        }
 
-        if Self.showGlassComparison {
+        if Self.showGlassComparison && !isPreviewMode {
             view.addSubview(glassComparison)
             view.addSubview(glassTuning)
         }
 
 
         // Pre-set inset
-        let estimatedBarHeight: CGFloat = 49 + DeviceInsets.bottom
-        node.tableNode.contentInset.top = estimatedBarHeight
-        node.tableNode.view.verticalScrollIndicatorInsets.top = estimatedBarHeight
+        if isPreviewMode {
+            let inset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+            node.tableNode.contentInset = inset
+            node.tableNode.view.verticalScrollIndicatorInsets = inset
+        } else {
+            let estimatedBarHeight: CGFloat = 49 + DeviceInsets.bottom
+            node.tableNode.contentInset.top = estimatedBarHeight
+            node.tableNode.view.verticalScrollIndicatorInsets.top = estimatedBarHeight
+        }
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
+        if isPreviewMode {
+            let inset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+            node.tableNode.contentInset = inset
+            node.tableNode.view.verticalScrollIndicatorInsets = inset
+            return
+        }
 
         glassNavBar.updateLayout(in: view)
         searchBar.frame = CGRect(
@@ -301,6 +345,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        guard !isPreviewMode else { return }
         // Pre-warm glass before the navigation transition starts so the
         // shared render loop is already active on the first animated frame.
         GlassService.shared.captureFor(duration: 0.5)
@@ -309,6 +354,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        guard !isPreviewMode else { return }
         // Force glass recapture after navigation push completes
         GlassService.shared.setNeedsCapture()
         if shouldPresentAttachmentPreviewAfterDismiss {
@@ -322,11 +368,24 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         super.viewWillDisappear(animated)
         visibleReadReceiptEvalWork?.cancel()
         redactionAnimationArmWork?.cancel()
-        if isMovingFromParent {
+
+        let shouldCleanup = isPreviewMode
+            || isMovingFromParent
+            || isBeingDismissed
+            || navigationController?.isBeingDismissed == true
+            || parent?.isBeingDismissed == true
+
+        if shouldCleanup {
             navigationController?.setNavigationBarHidden(false, animated: animated)
-            audioPlayer.stop()
-            viewModel.cleanup()
+            cleanupViewModelIfNeeded()
         }
+    }
+
+    private func cleanupViewModelIfNeeded() {
+        guard !didCleanupViewModel else { return }
+        didCleanupViewModel = true
+        audioPlayer.stop()
+        viewModel.cleanup()
     }
 
     // MARK: - Navigation
@@ -335,6 +394,13 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     /// changes how much space is covered at the bottom. The table is
     /// inverted, so that covered height lives in `contentInset.top`.
     private func updateTableInsetsForInputBar() {
+        guard !isPreviewMode else {
+            let inset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
+            node.tableNode.contentInset = inset
+            node.tableNode.view.verticalScrollIndicatorInsets = inset
+            return
+        }
+
         let newCoveredHeight = glassInputBar.coveredHeight
         let previousCoveredHeight = previousInputCoveredHeight
         let tableView = node.tableNode.view
@@ -417,6 +483,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func scheduleVisibleReadReceiptEvaluation(delay: TimeInterval = ReadReceipts.scrollDebounce) {
+        guard !isPreviewMode else { return }
         visibleReadReceiptEvalWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
             self?.updateVisibleReadReceiptCandidate()
@@ -426,7 +493,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func updateVisibleReadReceiptCandidate() {
-        guard !isTeleporting else { return }
+        guard !isPreviewMode, !isTeleporting else { return }
 
         node.tableNode.view.layoutIfNeeded()
         let candidate = currentVisibleReadReceiptCandidate()
@@ -560,6 +627,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func resetUnseenIncomingMessages() {
+        guard !isPreviewMode else { return }
         guard unseenIncomingMessageCount != 0 else { return }
         unseenIncomingMessageCount = 0
         updateScrollButtonAccessibilityLabel()
@@ -574,6 +642,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         insertions: [IndexPath],
         minimumVisibleRowBeforeUpdate: Int?
     ) {
+        guard !isPreviewMode else { return }
         guard let minimumVisibleRowBeforeUpdate else { return }
 
         var newUnseenIncoming = 0
@@ -590,6 +659,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func updateScrollToLiveVisibility() {
+        guard !isPreviewMode else { return }
         if isViewportPinnedToLiveEdge() {
             resetUnseenIncomingMessages()
         }
@@ -681,6 +751,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     // MARK: - Search
 
     func activateSearch() {
+        guard !isPreviewMode else { return }
         viewModel.activateSearch()
         searchBar.isHidden = false
         searchBar.activate()
@@ -729,7 +800,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         viewModel.$isInvited
             .receive(on: DispatchQueue.main)
             .sink { [weak self] invited in
-                guard let self else { return }
+                guard let self, !self.isPreviewMode else { return }
                 self.inviteBanner.isHidden = !invited
                 self.glassInputBar.isHidden = invited
             }
@@ -738,7 +809,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         viewModel.$replyingTo
             .receive(on: DispatchQueue.main)
             .sink { [weak self] message in
-                guard let self else { return }
+                guard let self, !self.isPreviewMode else { return }
                 self.glassInputBar.inputNode.setReplyPreview(
                     senderName: message?.senderDisplayName ?? message?.senderId,
                     body: message?.content.textPreview
@@ -749,7 +820,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         viewModel.$pendingForwardContent
             .receive(on: DispatchQueue.main)
             .sink { [weak self] forward in
-                guard let self else { return }
+                guard let self, !self.isPreviewMode else { return }
                 if let forward {
                     self.glassInputBar.inputNode.setForwardPreview(
                         senderName: forward.preview.senderDisplayName ?? forward.preview.senderId,
@@ -811,6 +882,8 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func bindInput() {
+        guard !isPreviewMode else { return }
+
         glassInputBar.inputNode.onSend = { [weak self] text, color in
             guard let self else { return }
             self.armPostSendPinToLive()
@@ -872,6 +945,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     @objc private func tableTapped() {
+        guard !isPreviewMode else { return }
         glassInputBar.inputNode.textInputNode.resignFirstResponder()
     }
 
@@ -889,6 +963,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         let message = messages[indexPath.row]
         let audioPlayer = self.audioPlayer
         let isGroup = self.isGroupChat
+        let isPreview = self.isPreviewMode
         
         // Ask ChatNode for the source view here on the main thread.
         // Texture may build the cell inside the returned block on a background thread,
@@ -911,22 +986,26 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
             if message.mediaGroupPresentation?.rendersCompositeBubble == true {
                 let groupCell = PhotoGroupMessageCellNode(message: message, isGroupChat: isGroup)
-                groupCell.onPhotoTapped = { [weak self, weak groupCell] index in
-                    guard let self, let groupCell else { return }
-                    self.presentImageViewer(for: groupCell, itemIndex: index)
+                if !isPreview {
+                    groupCell.onPhotoTapped = { [weak self, weak groupCell] index in
+                        guard let self, let groupCell else { return }
+                        self.presentImageViewer(for: groupCell, itemIndex: index)
+                    }
                 }
                 let cellNode = groupCell
                 cellNode.bubbleGradientSource = gradientSource
 
-                cellNode.onSenderTapped = { [weak self] userId in
-                    self?.onTitleTapped?(userId)
-                }
+                if !isPreview {
+                    cellNode.onSenderTapped = { [weak self] userId in
+                        self?.onTitleTapped?(userId)
+                    }
 
-                cellNode.onInteractionLockChanged = { [weak self] locked in
-                    if locked {
-                        self?.lockInteraction("contextMenu")
-                    } else {
-                        self?.unlockInteraction("contextMenu")
+                    cellNode.onInteractionLockChanged = { [weak self] locked in
+                        if locked {
+                            self?.lockInteraction("contextMenu")
+                        } else {
+                            self?.unlockInteraction("contextMenu")
+                        }
                     }
                 }
 
@@ -940,16 +1019,20 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 cellNode = VoiceMessageCellNode(message: message, audioPlayer: audioPlayer, isGroupChat: isGroup)
             case .image:
                 let imageCell = ImageMessageCellNode(message: message, isGroupChat: isGroup)
-                imageCell.onImageTapped = { [weak self, weak imageCell] in
-                    guard let self, let imageCell else { return }
-                    self.presentImageViewer(for: message, from: imageCell)
+                if !isPreview {
+                    imageCell.onImageTapped = { [weak self, weak imageCell] in
+                        guard let self, let imageCell else { return }
+                        self.presentImageViewer(for: message, from: imageCell)
+                    }
                 }
                 cellNode = imageCell
             case .file:
                 let fileCell = FileCellNode(message: message, isGroupChat: isGroup)
-                fileCell.onFileTapped = { [weak self] in
-                    guard let self else { return }
-                    self.handleFileTap(message: message, cellNode: fileCell)
+                if !isPreview {
+                    fileCell.onFileTapped = { [weak self] in
+                        guard let self else { return }
+                        self.handleFileTap(message: message, cellNode: fileCell)
+                    }
                 }
                 cellNode = fileCell
             case .systemEvent:
@@ -960,22 +1043,26 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
             cellNode.bubbleGradientSource = gradientSource
 
-            cellNode.onSenderTapped = { [weak self] userId in
-                self?.onTitleTapped?(userId)
-            }
+            if !isPreview {
+                cellNode.onSenderTapped = { [weak self] userId in
+                    self?.onTitleTapped?(userId)
+                }
 
-            cellNode.onInteractionLockChanged = { [weak self] locked in
-                if locked {
-                    self?.lockInteraction("contextMenu")
-                } else {
-                    self?.unlockInteraction("contextMenu")
+                cellNode.onInteractionLockChanged = { [weak self] locked in
+                    if locked {
+                        self?.lockInteraction("contextMenu")
+                    } else {
+                        self?.unlockInteraction("contextMenu")
+                    }
                 }
             }
 
             self?.configureMessageDrivenInteractions(for: cellNode, message: message)
 
-            cellNode.onReplyHeaderTapped = { [weak self] eventId in
-                self?.navigateToMessage(eventId: eventId)
+            if !isPreview {
+                cellNode.onReplyHeaderTapped = { [weak self] eventId in
+                    self?.navigateToMessage(eventId: eventId)
+                }
             }
 
             return cellNode
@@ -983,6 +1070,11 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func configureMessageDrivenInteractions(for cellNode: MessageCellNode, message: ChatMessage) {
+        guard !isPreviewMode else {
+            configurePreviewInteractions(for: cellNode)
+            return
+        }
+
         if message.isSyntheticIncomingAssembly {
             cellNode.onContextMenuActivated = nil
             cellNode.accessibilityActionsProvider = { [] }
@@ -997,6 +1089,28 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
         cellNode.onReactionTapped = { [weak self] key in
             self?.viewModel.toggleReaction(key, for: message)
+        }
+    }
+
+    private func configurePreviewInteractions(for cellNode: MessageCellNode) {
+        cellNode.allowsInteractiveActions = false
+        cellNode.contextSourceNode.isGestureEnabled = false
+        cellNode.contextSourceNode.onQuickTap = nil
+        cellNode.onContextMenuActivated = nil
+        cellNode.onDragChanged = nil
+        cellNode.onDragEnded = nil
+        cellNode.onInteractionLockChanged = nil
+        cellNode.onReactionTapped = nil
+        cellNode.onSenderTapped = nil
+        cellNode.onReplyHeaderTapped = nil
+        cellNode.accessibilityActionsProvider = { [] }
+
+        (cellNode as? PhotoGroupMessageCellNode)?.onPhotoTapped = nil
+        (cellNode as? ImageMessageCellNode)?.onImageTapped = nil
+        (cellNode as? FileCellNode)?.onFileTapped = nil
+
+        if Thread.isMainThread {
+            cellNode.refreshAccessibilityForwarding()
         }
     }
 
@@ -1394,7 +1508,9 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     // MARK: - Scroll
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        GlassService.shared.setNeedsCapture()
+        if !isPreviewMode {
+            GlassService.shared.setNeedsCapture()
+        }
         guard !isTeleporting else { return }
         let isRubberBanding = isTableRubberBanding(scrollView)
 
@@ -1403,9 +1519,11 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             viewModel.loadNewerMessages()
         }
 
-        updateScrollToLiveVisibility()
+        if !isPreviewMode {
+            updateScrollToLiveVisibility()
+        }
 
-        if !isRubberBanding {
+        if !isPreviewMode && !isRubberBanding {
             scheduleVisibleReadReceiptEvaluation()
         }
     }
@@ -1547,6 +1665,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                    withVelocity velocity: CGPoint,
                                    targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        guard !isPreviewMode else { return }
         // Deliberate flick only: fast AND far. `velocity` in pt/ms.
         let distance = abs(scrollView.contentOffset.y - dragStartOffsetY)
         if abs(velocity.y) > Self.keyboardDismissVelocity,

--- a/Zyna/Chat/ChatView.swift
+++ b/Zyna/Chat/ChatView.swift
@@ -104,6 +104,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private let scrollButtonTap = UIButton(type: .custom)
     private let scrollButtonBadgeBackground = UIView()
     private let scrollButtonBadgeLabel = UILabel()
+    private let dateHeaderOverlayManager = DateHeaderOverlayManager()
     
     /// Flip to `true` to show Apple vs Custom glass comparison overlay (iOS 26+)
     private static let showGlassComparison = false
@@ -291,6 +292,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             refreshGlassSourceBinding()
         }
 
+        if !isPreviewMode {
+            node.view.addSubview(dateHeaderOverlayManager.containerView)
+        }
+
         if Self.showGlassComparison && !isPreviewMode {
             view.addSubview(glassComparison)
             view.addSubview(glassTuning)
@@ -341,6 +346,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
         glassInputBar.updateLayout(in: view)
         updateTableInsetsForInputBar()
+        updateDateHeaderOverlay()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -515,12 +521,13 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
 
         let tableView = node.tableNode.view
-        let messages = viewModel.messages
+        let rows = viewModel.rows
 
         for indexPath in visibleRows.sorted(by: { $0.row < $1.row }) {
-            guard messages.indices.contains(indexPath.row) else { continue }
+            guard rows.indices.contains(indexPath.row),
+                  let message = rows[indexPath.row].message
+            else { continue }
 
-            let message = messages[indexPath.row]
             guard let eventId = message.eventId else { continue }
 
             let rowRect = tableView.convert(tableView.rectForRow(at: indexPath), to: view)
@@ -563,6 +570,30 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             width: tableFrame.width,
             height: bottomObstruction - topObstruction
         )
+    }
+
+    private func updateDateHeaderOverlay(animated: Bool = false) {
+        guard !isPreviewMode,
+              !isTeleporting,
+              let viewport = unobscuredTableViewportInView(),
+              !viewModel.rows.isEmpty
+        else {
+            dateHeaderOverlayManager.hide(animated: animated)
+            return
+        }
+
+        let tableView = node.tableNode.view
+        let isScrolling = tableView.isTracking || tableView.isDragging || tableView.isDecelerating
+        dateHeaderOverlayManager.update(
+            viewport: viewport,
+            rows: viewModel.rows,
+            visibleIndexPaths: node.tableNode.indexPathsForVisibleRows(),
+            tableView: tableView,
+            hostView: view,
+            isScrolling: isScrolling,
+            animated: animated || !isScrolling
+        )
+        node.view.bringSubviewToFront(dateHeaderOverlayManager.containerView)
     }
 
     private func pinTableToLiveEdge() {
@@ -647,8 +678,9 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
         var newUnseenIncoming = 0
         for indexPath in insertions where indexPath.row < minimumVisibleRowBeforeUpdate {
-            guard viewModel.messages.indices.contains(indexPath.row) else { continue }
-            let message = viewModel.messages[indexPath.row]
+            guard viewModel.rows.indices.contains(indexPath.row),
+                  let message = viewModel.rows[indexPath.row].message
+            else { continue }
             guard !message.isOutgoing, !message.content.isRedacted else { continue }
             newUnseenIncoming += 1
         }
@@ -837,6 +869,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         if isTeleporting {
             // During teleportation: silent reload, no animations
             node.tableNode.reloadData()
+            updateDateHeaderOverlay()
             return
         }
 
@@ -845,6 +878,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             node.tableNode.reloadData()
             finishPostSendPinToLive()
             updateScrollToLiveVisibility()
+            updateDateHeaderOverlay()
             scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
         case .batch(let deletions, let insertions, let moves, let updates, let animated):
             if deletions.isEmpty && insertions.isEmpty && moves.isEmpty && updates.isEmpty { return }
@@ -876,6 +910,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                     self?.pinTableToLiveEdge()
                 }
                 self?.updateScrollToLiveVisibility()
+                self?.updateDateHeaderOverlay()
                 self?.scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
             })
         }
@@ -952,15 +987,21 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     // MARK: - ASTableDataSource
 
     func tableNode(_ tableNode: ASTableNode, numberOfRowsInSection section: Int) -> Int {
-        viewModel.messages.count
+        viewModel.rows.count
     }
 
     func tableNode(_ tableNode: ASTableNode, nodeBlockForRowAt indexPath: IndexPath) -> ASCellNodeBlock {
-        let messages = viewModel.messages
-        guard indexPath.row < messages.count else {
+        let rows = viewModel.rows
+        guard indexPath.row < rows.count else {
             return { ASCellNode() }
         }
-        let message = messages[indexPath.row]
+        let row = rows[indexPath.row]
+        if case .dateDivider(let model) = row {
+            return { DateDividerCellNode(model: model) }
+        }
+        guard case .message(let message) = row else {
+            return { ASCellNode() }
+        }
         let audioPlayer = self.audioPlayer
         let isGroup = self.isGroupChat
         let isPreview = self.isPreviewMode
@@ -1521,6 +1562,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
         if !isPreviewMode {
             updateScrollToLiveVisibility()
+            updateDateHeaderOverlay()
         }
 
         if !isPreviewMode && !isRubberBanding {
@@ -1562,7 +1604,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private func highlightMessage(eventId: String, delay: TimeInterval) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self,
-                  let idx = self.viewModel.messages.firstIndex(where: { $0.eventId == eventId }),
+                  let idx = self.viewModel.indexOfMessage(eventId: eventId),
                   let cellNode = self.node.tableNode.nodeForRow(at: IndexPath(row: idx, section: 0))
                       as? MessageCellNode
             else { return }
@@ -1595,6 +1637,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         }
 
         isTeleporting = true
+        dateHeaderOverlayManager.hide()
         // Inverted table: jump-to-older → content slides DOWN (camera pans up)
         //                  jump-to-newer → content slides UP (camera pans down)
         let sign: CGFloat = direction == .up ? 1 : -1
@@ -1650,6 +1693,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         tableAnim.delegate = TeleportAnimationDelegate { [weak self, weak snapshotContainer] in
             snapshotContainer?.removeFromSuperview()
             self?.isTeleporting = false
+            self?.updateDateHeaderOverlay()
             self?.scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
         }
         tableLayer.add(tableAnim, forKey: "teleportIn")
@@ -1660,6 +1704,7 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         dragStartOffsetY = scrollView.contentOffset.y
+        updateDateHeaderOverlay(animated: true)
     }
 
     func scrollViewWillEndDragging(_ scrollView: UIScrollView,
@@ -1678,16 +1723,19 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
         if decelerate {
             fpsBooster.start()
         } else {
+            updateDateHeaderOverlay(animated: true)
             scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
         }
     }
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         fpsBooster.stop()
+        updateDateHeaderOverlay(animated: true)
         scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
     }
 
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        updateDateHeaderOverlay(animated: true)
         scheduleVisibleReadReceiptEvaluation(delay: ReadReceipts.contentUpdateDelay)
     }
 
@@ -1781,12 +1829,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
                 continue
             }
 
-            guard let row = viewModel.messages.firstIndex(where: { $0.id == messageId }) else {
+            guard let indexPath = indexPathForMessageId(messageId) else {
                 viewModel.hideMessage(messageId)
                 continue
             }
-
-            let indexPath = IndexPath(row: row, section: 0)
 
             // If cell is off-screen, hide immediately without animation
             guard let cellNode = node.tableNode.nodeForRow(at: indexPath) as? MessageCellNode,
@@ -1870,14 +1916,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     private func captureVisibleCompositeGroupSnapshotTarget(
         forGroupId groupId: String
     ) -> PaintSplashTrigger.SnapshotTarget? {
-        guard let row = viewModel.messages.firstIndex(where: { message in
-            message.mediaGroupPresentation?.rendersCompositeBubble == true
-                && message.mediaGroupPresentation?.id == groupId
-        }) else {
+        guard let indexPath = indexPathForCompositeGroup(groupId) else {
             return nil
         }
 
-        let indexPath = IndexPath(row: row, section: 0)
         guard let cellNode = node.tableNode.nodeForRow(at: indexPath) as? MessageCellNode,
               cellNode.isNodeLoaded
         else {
@@ -1893,14 +1935,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
 
     @discardableResult
     private func triggerPartialPaintSplashDelete(for messageId: String) -> Bool {
-        guard let compositeRow = viewModel.messages.firstIndex(where: { message in
-            message.mediaGroupPresentation?.rendersCompositeBubble == true
-                && message.mediaGroupPresentation?.items.contains(where: { $0.messageId == messageId }) == true
-        }) else {
+        guard let indexPath = indexPathForCompositeItem(messageId) else {
             return false
         }
 
-        let indexPath = IndexPath(row: compositeRow, section: 0)
         guard let groupCell = node.tableNode.nodeForRow(at: indexPath) as? PhotoGroupMessageCellNode,
               groupCell.isNodeLoaded,
               let target = groupCell.paintSplashTarget(for: messageId)
@@ -1931,14 +1969,10 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
             return true
         }
 
-        guard let row = viewModel.messages.firstIndex(where: { message in
-            message.mediaGroupPresentation?.rendersCompositeBubble == true
-                && message.mediaGroupPresentation?.id == groupId
-        }) else {
+        guard let indexPath = indexPathForCompositeGroup(groupId) else {
             return false
         }
 
-        let indexPath = IndexPath(row: row, section: 0)
         PaintSplashTrigger.trigger(in: node.tableNode, at: indexPath) { [weak self] in
             self?.viewModel.hideMessages(Array(pendingDelete.messageIds))
         }
@@ -2081,7 +2115,33 @@ final class ChatViewController: ASDKViewController<ChatNode>, ASTableDataSource,
     }
 
     private func indexPathForMessage(_ message: ChatMessage) -> IndexPath? {
-        guard let row = viewModel.messages.firstIndex(where: { $0.id == message.id }) else {
+        indexPathForMessageId(message.id)
+    }
+
+    private func indexPathForMessageId(_ messageId: String) -> IndexPath? {
+        guard let row = viewModel.rows.firstIndex(where: { $0.message?.id == messageId }) else {
+            return nil
+        }
+        return IndexPath(row: row, section: 0)
+    }
+
+    private func indexPathForCompositeGroup(_ groupId: String) -> IndexPath? {
+        guard let row = viewModel.rows.firstIndex(where: { row in
+            guard let message = row.message else { return false }
+            return message.mediaGroupPresentation?.rendersCompositeBubble == true
+                && message.mediaGroupPresentation?.id == groupId
+        }) else {
+            return nil
+        }
+        return IndexPath(row: row, section: 0)
+    }
+
+    private func indexPathForCompositeItem(_ messageId: String) -> IndexPath? {
+        guard let row = viewModel.rows.firstIndex(where: { row in
+            guard let message = row.message else { return false }
+            return message.mediaGroupPresentation?.rendersCompositeBubble == true
+                && message.mediaGroupPresentation?.items.contains(where: { $0.messageId == messageId }) == true
+        }) else {
             return nil
         }
         return IndexPath(row: row, section: 0)

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -788,16 +788,20 @@ final class ChatViewModel {
         for group: OutgoingEnvelopeSnapshot,
         in messages: [ChatMessage]
     ) -> PendingMediaGroupObservedState {
-        let eventIndexById = Dictionary(
-            uniqueKeysWithValues: group.items.compactMap { item in
-                item.eventId.map { ($0, item.itemIndex) }
+        var eventIndexById: [String: Int] = [:]
+        var transactionIndexById: [String: Int] = [:]
+        for item in group.items {
+            if let eventId = item.eventId,
+               !eventId.isEmpty,
+               eventIndexById[eventId] == nil {
+                eventIndexById[eventId] = item.itemIndex
             }
-        )
-        let transactionIndexById = Dictionary(
-            uniqueKeysWithValues: group.items.compactMap { item in
-                item.transactionId.map { ($0, item.itemIndex) }
+            if let transactionId = item.transactionId,
+               !transactionId.isEmpty,
+               transactionIndexById[transactionId] == nil {
+                transactionIndexById[transactionId] = item.itemIndex
             }
-        )
+        }
 
         var primaryMessageIndexByItemIndex: [Int: Int] = [:]
         var hiddenMessageIndices = Set<Int>()
@@ -915,12 +919,12 @@ final class ChatViewModel {
         rawMessages: [ChatMessage],
         currentUserId: String
     ) -> PendingRenderableEnvelope {
-        let primaryMessagesByItemIndex: [Int: ChatMessage] = Dictionary(
-            uniqueKeysWithValues: observedState.primaryMessageIndexByItemIndex.compactMap { itemIndex, messageIndex in
-                guard rawMessages.indices.contains(messageIndex) else { return nil }
-                return (itemIndex, rawMessages[messageIndex])
-            }
-        )
+        var primaryMessagesByItemIndex: [Int: ChatMessage] = [:]
+        primaryMessagesByItemIndex.reserveCapacity(observedState.primaryMessageIndexByItemIndex.count)
+        for (itemIndex, messageIndex) in observedState.primaryMessageIndexByItemIndex {
+            guard rawMessages.indices.contains(messageIndex) else { continue }
+            primaryMessagesByItemIndex[itemIndex] = rawMessages[messageIndex]
+        }
 
         let mediaItems = group.items.map { item -> MediaGroupItem in
             let primaryMessage = primaryMessagesByItemIndex[item.itemIndex]
@@ -1562,12 +1566,15 @@ final class ChatViewModel {
         messages = newMessages
         rows = Self.buildRows(from: newMessages, olderBoundary: olderBoundary)
 
-        // TODO: Find why the render window can contain duplicate Matrix events.
-        // Keep the first index for now to avoid crashing on repeated event ids.
+        // Matrix event_ids identify one event, but SDK/local-echo
+        // replacement can transiently surface the same event twice.
+        // Navigation/read receipts only need one visible target.
         var messageIndices: [String: Int] = [:]
         messageIndices.reserveCapacity(newMessages.count)
         for (index, message) in newMessages.enumerated() {
-            guard let eventId = message.eventId, messageIndices[eventId] == nil else {
+            guard let eventId = message.eventId,
+                  !eventId.isEmpty,
+                  messageIndices[eventId] == nil else {
                 continue
             }
             messageIndices[eventId] = index
@@ -1577,7 +1584,9 @@ final class ChatViewModel {
         var rowIndices: [String: Int] = [:]
         rowIndices.reserveCapacity(rows.count)
         for (index, row) in rows.enumerated() {
-            guard let eventId = row.message?.eventId, rowIndices[eventId] == nil else {
+            guard let eventId = row.message?.eventId,
+                  !eventId.isEmpty,
+                  rowIndices[eventId] == nil else {
                 continue
             }
             rowIndices[eventId] = index

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -60,6 +60,7 @@ final class ChatViewModel {
     // MARK: - State
 
     private(set) var messages: [ChatMessage] = []
+    private(set) var rows: [ChatTimelineRow] = []
     @Published private(set) var isPaginating: Bool = false
 
     /// True when SDK backward pagination returned no new visible
@@ -117,6 +118,7 @@ final class ChatViewModel {
     private var readReceiptBaselineTarget: VisibleReadReceiptTarget?
     private var lastBootstrapReadReceiptTarget: VisibleReadReceiptTarget?
     private var messageIndexByEventId: [String: Int] = [:]
+    private var rowIndexByEventId: [String: Int] = [:]
 
     /// Whether the window is at the live edge (newest messages visible).
     var isAtLiveEdge: Bool { window.isAtLiveEdge }
@@ -333,35 +335,39 @@ final class ChatViewModel {
                 "deleteReflow observation newlyRedacted=\(newlyRedactedIds.joined(separator: ",")) deletedGroups=\(deletedMediaGroupIds.sorted().joined(separator: ",")) hidden=\(hiddenIds.count)"
             )
         }
+        let olderBoundary = window.peekOlderNeighbor()
+        let newerBoundary = window.peekNewerNeighbor()
         let rawMessages = displayStored.compactMap { $0.toChatMessage() }
         let newMessages = buildRenderableMessages(
             from: rawMessages,
             deletedMediaGroupIds: deletedMediaGroupIds,
             partialReflowPreviewsByMessageId: partialReflowPreviewsByMessageId,
-            olderBoundary: window.peekOlderNeighbor(),
-            newerBoundary: window.peekNewerNeighbor()
+            olderBoundary: olderBoundary,
+            newerBoundary: newerBoundary
         )
 
         // 3. Prefetch images
         Self.prefetchImages(newMessages)
 
         // 4. Compute table update
-        let oldMessages = self.messages
-        setMessages(newMessages)
+        let oldRows = self.rows
+        setMessages(newMessages, olderBoundary: olderBoundary)
 
         let tableUpdate: TableUpdate
         var inPlaceUpdates: [(IndexPath, ChatMessage)] = []
         if prevStored == nil {
             tableUpdate = .reload
         } else {
-            (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldMessages, new: newMessages)
+            (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldRows, new: rows)
         }
         // 5. Emit (filter redacted from normal updates, send separately for animation)
         if !newlyRedactedIds.isEmpty {
             if case .batch(let del, let ins, let moves, let upd, let anim) = tableUpdate {
                 let filtered = upd.filter { ip in
-                    guard ip.row < newMessages.count else { return true }
-                    return !newMessages[ip.row].content.isRedacted
+                    guard rows.indices.contains(ip.row),
+                          let message = rows[ip.row].message
+                    else { return true }
+                    return !message.content.isRedacted
                 }
                 onTableUpdate?(.batch(
                     deletions: del,
@@ -409,6 +415,15 @@ final class ChatViewModel {
             }
         }
         return msg.transactionId ?? msg.eventId ?? msg.id
+    }
+
+    private static func stableKey(_ row: ChatTimelineRow) -> String {
+        switch row {
+        case .message(let message):
+            return "message:\(stableKey(message))"
+        case .dateDivider(let model):
+            return model.id
+        }
     }
 
     private func buildRenderableMessages(
@@ -525,6 +540,7 @@ final class ChatViewModel {
             }
         }
 
+        let oldRows = rows
         let oldMessages = messages
         let visibleRedactedIds = Set(
             oldMessages
@@ -543,17 +559,19 @@ final class ChatViewModel {
             return msg
         }
 
+        let olderBoundary = window.peekOlderNeighbor()
+        let newerBoundary = window.peekNewerNeighbor()
         let rawMessages = displayStored.compactMap { $0.toChatMessage() }
         let newMessages = buildRenderableMessages(
             from: rawMessages,
             deletedMediaGroupIds: Self.redactedMediaGroupIds(in: storedMessages),
             partialReflowPreviewsByMessageId: partialReflowPreviewsByMessageId,
-            olderBoundary: window.peekOlderNeighbor(),
-            newerBoundary: window.peekNewerNeighbor()
+            olderBoundary: olderBoundary,
+            newerBoundary: newerBoundary
         )
-        setMessages(newMessages)
+        setMessages(newMessages, olderBoundary: olderBoundary)
 
-        let (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldMessages, new: newMessages)
+        let (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldRows, new: rows)
         onTableUpdate?(tableUpdate)
         for (indexPath, message) in inPlaceUpdates {
             onInPlaceUpdate?(indexPath, message)
@@ -1304,7 +1322,7 @@ final class ChatViewModel {
         return result
     }
 
-    private static func computeTableUpdate(old: [ChatMessage], new: [ChatMessage]) -> (TableUpdate, [(IndexPath, ChatMessage)]) {
+    private static func computeTableUpdate(old: [ChatTimelineRow], new: [ChatTimelineRow]) -> (TableUpdate, [(IndexPath, ChatMessage)]) {
         let oldKeys = old.map { stableKey($0) }
         let newKeys = new.map { stableKey($0) }
         let keyDiff = newKeys.difference(from: oldKeys)
@@ -1332,11 +1350,14 @@ final class ChatViewModel {
         var fullUpdates: [IndexPath] = []
         var inPlaceUpdates: [(IndexPath, ChatMessage)] = []
 
-        for (oldIdx, oldMsg) in old.enumerated() {
+        for (oldIdx, oldRow) in old.enumerated() {
             guard !removedOldOffsets.contains(oldIdx) else { continue }
-            guard let newIdx = newByKey[stableKey(oldMsg)], old[oldIdx] != new[newIdx] else { continue }
-            if MessageCellNode.canUpdateInPlace(old: old[oldIdx], new: new[newIdx]) {
-                inPlaceUpdates.append((IndexPath(row: newIdx, section: 0), new[newIdx]))
+            guard let newIdx = newByKey[stableKey(oldRow)], oldRow != new[newIdx] else { continue }
+
+            if case .message(let oldMessage) = oldRow,
+               case .message(let newMessage) = new[newIdx],
+               MessageCellNode.canUpdateInPlace(old: oldMessage, new: newMessage) {
+                inPlaceUpdates.append((IndexPath(row: newIdx, section: 0), newMessage))
             } else {
                 fullUpdates.append(IndexPath(row: oldIdx, section: 0))
             }
@@ -1404,6 +1425,10 @@ final class ChatViewModel {
     }
 
     func indexOfMessage(eventId: String) -> Int? {
+        rowIndexByEventId[eventId]
+    }
+
+    private func messageIndex(eventId: String) -> Int? {
         messageIndexByEventId[eventId]
     }
 
@@ -1500,8 +1525,8 @@ final class ChatViewModel {
             return false
         }
 
-        let lhsIndex = indexOfMessage(eventId: lhs.eventId)
-        let rhsIndex = indexOfMessage(eventId: rhs.eventId)
+        let lhsIndex = messageIndex(eventId: lhs.eventId)
+        let rhsIndex = messageIndex(eventId: rhs.eventId)
 
         switch (lhsIndex, rhsIndex) {
         case let (.some(lhsIndex), .some(rhsIndex)):
@@ -1533,13 +1558,52 @@ final class ChatViewModel {
         }
     }
 
-    private func setMessages(_ newMessages: [ChatMessage]) {
+    private func setMessages(_ newMessages: [ChatMessage], olderBoundary: ClusterNeighbor?) {
         messages = newMessages
+        rows = Self.buildRows(from: newMessages, olderBoundary: olderBoundary)
         messageIndexByEventId = Dictionary(
             uniqueKeysWithValues: newMessages.enumerated().compactMap { index, message in
                 message.eventId.map { ($0, index) }
             }
         )
+        rowIndexByEventId = Dictionary(
+            uniqueKeysWithValues: rows.enumerated().compactMap { index, row in
+                row.message?.eventId.map { ($0, index) }
+            }
+        )
+    }
+
+    private static func buildRows(
+        from messages: [ChatMessage],
+        olderBoundary: ClusterNeighbor?
+    ) -> [ChatTimelineRow] {
+        guard !messages.isEmpty else { return [] }
+
+        let calendar = Calendar.current
+        var result: [ChatTimelineRow] = []
+        result.reserveCapacity(messages.count + min(messages.count, 16))
+
+        for index in messages.indices {
+            let message = messages[index]
+            result.append(.message(message))
+
+            let olderTimestamp: Date?
+            if index + 1 < messages.count {
+                olderTimestamp = messages[index + 1].timestamp
+            } else {
+                olderTimestamp = olderBoundary?.timestamp
+            }
+
+            let endsVisibleDayGroup = olderTimestamp.map {
+                !calendar.isDate(message.timestamp, inSameDayAs: $0)
+            } ?? true
+
+            if endsVisibleDayGroup {
+                result.append(.dateDivider(DateDividerModel.make(for: message.timestamp, calendar: calendar)))
+            }
+        }
+
+        return result
     }
 
     // MARK: - Reply
@@ -2301,6 +2365,7 @@ final class ChatViewModel {
             pendingPartialRedactions.removeValue(forKey: messageId)
             partialReflowPreviewsByMessageId.removeValue(forKey: messageId)
         }
+        let oldRows = rows
         let oldMessages = messages
         var visibleRedactedIds = Set(
             oldMessages
@@ -2319,17 +2384,19 @@ final class ChatViewModel {
         logMediaGroup(
             "deleteReflow hide messageIds=\(idsToHide.sorted().joined(separator: ",")) visibleRedacted=\(visibleRedactedIds.sorted().joined(separator: ",")) deletedGroups=\(deletedMediaGroupIds.sorted().joined(separator: ","))"
         )
+        let olderBoundary = window.peekOlderNeighbor()
+        let newerBoundary = window.peekNewerNeighbor()
         let rawMessages = displayStored.compactMap { $0.toChatMessage() }
         let newMessages = buildRenderableMessages(
             from: rawMessages,
             deletedMediaGroupIds: deletedMediaGroupIds,
             partialReflowPreviewsByMessageId: partialReflowPreviewsByMessageId,
-            olderBoundary: window.peekOlderNeighbor(),
-            newerBoundary: window.peekNewerNeighbor()
+            olderBoundary: olderBoundary,
+            newerBoundary: newerBoundary
         )
-        setMessages(newMessages)
+        setMessages(newMessages, olderBoundary: olderBoundary)
 
-        let (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldMessages, new: newMessages)
+        let (tableUpdate, inPlaceUpdates) = Self.computeTableUpdate(old: oldRows, new: rows)
         onTableUpdate?(tableUpdate)
         for (indexPath, message) in inPlaceUpdates {
             onInPlaceUpdate?(indexPath, message)
@@ -2482,6 +2549,7 @@ final class ChatViewModel {
         guard let neighbor else { return true }
         if neighbor.isStandaloneEvent { return true }
         if neighbor.senderId != current.senderId { return true }
+        if !Calendar.current.isDate(current.timestamp, inSameDayAs: neighbor.timestamp) { return true }
         let gap = abs(current.timestamp.timeIntervalSince(neighbor.timestamp))
         return gap > clusterGap
     }

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -11,6 +11,16 @@ import MatrixRustSDK
 
 private let logMediaGroup = ScopedLog(.media, prefix: "[MediaGroup]")
 
+enum ChatPresentationMode {
+    case normal
+    case preview
+
+    var isPreview: Bool {
+        if case .preview = self { return true }
+        return false
+    }
+}
+
 final class ChatViewModel {
 
     struct DetectedRedactedMediaGroup {
@@ -76,6 +86,7 @@ final class ChatViewModel {
     var onRedactionFailed: ((String, Error, PendingRedactionFailureDisposition) -> Void)?
 
     let roomName: String
+    let mode: ChatPresentationMode
     @Published private(set) var partnerPresence: UserPresence?
     @Published private(set) var partnerUserId: String?
     @Published private(set) var memberCount: Int?
@@ -111,10 +122,11 @@ final class ChatViewModel {
     var isAtLiveEdge: Bool { window.isAtLiveEdge }
     var hasOlderInDB: Bool { window.hasOlderInDB }
 
-    init(room: Room) {
+    init(room: Room, mode: ChatPresentationMode = .normal) {
         let roomId = room.id()
         self.room = room
         self.roomId = roomId
+        self.mode = mode
         self.roomName = room.displayName() ?? "Chat"
         self.isInvited = room.membership() == .invited
         self.timelineService = TimelineService(room: room)
@@ -176,7 +188,9 @@ final class ChatViewModel {
                     self.directUserId = userId
                     self.partnerUserId = userId
                 }
-                PresenceTracker.shared.register(userIds: [userId], for: "chat")
+                if !self.mode.isPreview {
+                    PresenceTracker.shared.register(userIds: [userId], for: "chat")
+                }
                 PresenceTracker.shared.$statuses
                     .map { $0[userId] }
                     .receive(on: DispatchQueue.main)
@@ -199,7 +213,8 @@ final class ChatViewModel {
 
         Task { [weak self] in
             guard let self else { return }
-            await self.timelineService.startListening()
+            await self.timelineService.startListening(subscribeForSync: !self.mode.isPreview)
+            guard !self.mode.isPreview else { return }
             let terminalFailures = await self.pendingRedactions.retryPendingRedactions(
                 roomId: self.roomId,
                 timelineService: self.timelineService
@@ -217,6 +232,7 @@ final class ChatViewModel {
             }
         }
 
+        guard !mode.isPreview else { return }
         historySyncTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(1))
             await self?.syncFullHistory()
@@ -1401,6 +1417,7 @@ final class ChatViewModel {
         eventId: String?,
         canEstablishBaseline: Bool
     ) {
+        guard !mode.isPreview else { return }
         guard let eventId else {
             readReceiptWork?.cancel()
             pendingReadReceiptSend = nil
@@ -2373,7 +2390,9 @@ final class ChatViewModel {
         historySyncTask?.cancel()
         readReceiptWork?.cancel()
         pendingReadReceiptSend = nil
-        PresenceTracker.shared.unregister(for: "chat")
+        if !mode.isPreview {
+            PresenceTracker.shared.unregister(for: "chat")
+        }
         timelineService.onDiffs = nil
         timelineService.onOwnFullyReadMarker = nil
         timelineService.onSendQueueUpdate = nil

--- a/Zyna/Chat/ChatViewModel.swift
+++ b/Zyna/Chat/ChatViewModel.swift
@@ -1561,16 +1561,28 @@ final class ChatViewModel {
     private func setMessages(_ newMessages: [ChatMessage], olderBoundary: ClusterNeighbor?) {
         messages = newMessages
         rows = Self.buildRows(from: newMessages, olderBoundary: olderBoundary)
-        messageIndexByEventId = Dictionary(
-            uniqueKeysWithValues: newMessages.enumerated().compactMap { index, message in
-                message.eventId.map { ($0, index) }
+
+        // TODO: Find why the render window can contain duplicate Matrix events.
+        // Keep the first index for now to avoid crashing on repeated event ids.
+        var messageIndices: [String: Int] = [:]
+        messageIndices.reserveCapacity(newMessages.count)
+        for (index, message) in newMessages.enumerated() {
+            guard let eventId = message.eventId, messageIndices[eventId] == nil else {
+                continue
             }
-        )
-        rowIndexByEventId = Dictionary(
-            uniqueKeysWithValues: rows.enumerated().compactMap { index, row in
-                row.message?.eventId.map { ($0, index) }
+            messageIndices[eventId] = index
+        }
+        messageIndexByEventId = messageIndices
+
+        var rowIndices: [String: Int] = [:]
+        rowIndices.reserveCapacity(rows.count)
+        for (index, row) in rows.enumerated() {
+            guard let eventId = row.message?.eventId, rowIndices[eventId] == nil else {
+                continue
             }
-        )
+            rowIndices[eventId] = index
+        }
+        rowIndexByEventId = rowIndices
     }
 
     private static func buildRows(

--- a/Zyna/Chat/DateHeaderOverlayManager.swift
+++ b/Zyna/Chat/DateHeaderOverlayManager.swift
@@ -1,0 +1,513 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+private enum DateHeaderOverlay {
+    static let topMargin: CGFloat = 8
+    static let horizontalMargin: CGFloat = 16
+    static let maxWidth: CGFloat = 220
+    static let pushSpacing: CGFloat = 4
+    static let revealDuration: TimeInterval = 0.16
+    static let settleHideDelay: TimeInterval = 0.24
+    static let settleHideDuration: TimeInterval = 0.32
+    static let preHidePulseLead: TimeInterval = 0.14
+    static let backgroundPulseUpDuration: TimeInterval = 0.12
+    static let backgroundPulseDownDuration: TimeInterval = 0.28
+    static let anchorOverscan: CGFloat = 72
+
+    static let baseBackgroundColor = AppColor.systemEventBackground
+    static let highlightedBackgroundColor = UIColor.dynamic(
+        light: UIColor(hex: 0xFFFFFF),
+        dark: UIColor(hex: 0x242424)
+    )
+}
+
+private final class DateHeaderOverlayView: UIView {
+    private enum Metrics {
+        static let horizontalPadding: CGFloat = 10
+        static let verticalPadding: CGFloat = 4
+    }
+
+    private let label = UILabel()
+    private var modelId: String?
+    private var backgroundPulseGeneration = 0
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        isAccessibilityElement = false
+        backgroundColor = DateHeaderOverlay.baseBackgroundColor
+        layer.cornerRadius = 10
+        layer.masksToBounds = true
+        alpha = 0
+
+        label.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        addSubview(label)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(model: DateDividerModel) {
+        guard model.id != modelId else { return }
+        modelId = model.id
+        label.text = model.title
+    }
+
+    func pulseBackground() {
+        backgroundPulseGeneration += 1
+        let generation = backgroundPulseGeneration
+        layer.removeAnimation(forKey: "backgroundColor")
+
+        UIView.animate(
+            withDuration: DateHeaderOverlay.backgroundPulseUpDuration,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseOut]
+        ) {
+            self.backgroundColor = DateHeaderOverlay.highlightedBackgroundColor
+        } completion: { [weak self] _ in
+            guard let self,
+                  self.backgroundPulseGeneration == generation
+            else { return }
+
+            UIView.animate(
+                withDuration: DateHeaderOverlay.backgroundPulseDownDuration,
+                delay: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut]
+            ) {
+                self.backgroundColor = DateHeaderOverlay.baseBackgroundColor
+            }
+        }
+    }
+
+    func prepareHighlightedBackground() {
+        backgroundPulseGeneration += 1
+        layer.removeAnimation(forKey: "backgroundColor")
+        backgroundColor = DateHeaderOverlay.highlightedBackgroundColor
+    }
+
+    func settleBackground() {
+        backgroundPulseGeneration += 1
+        let generation = backgroundPulseGeneration
+        layer.removeAnimation(forKey: "backgroundColor")
+
+        UIView.animate(
+            withDuration: DateHeaderOverlay.backgroundPulseDownDuration,
+            delay: 0,
+            options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut]
+        ) {
+            self.backgroundColor = DateHeaderOverlay.baseBackgroundColor
+        } completion: { [weak self] _ in
+            guard let self,
+                  self.backgroundPulseGeneration == generation
+            else { return }
+            self.backgroundColor = DateHeaderOverlay.baseBackgroundColor
+        }
+    }
+
+    func resetBackground() {
+        backgroundPulseGeneration += 1
+        layer.removeAnimation(forKey: "backgroundColor")
+        backgroundColor = DateHeaderOverlay.baseBackgroundColor
+    }
+
+    func fittingSize(maxWidth: CGFloat) -> CGSize {
+        let labelMaxWidth = max(0, maxWidth - Metrics.horizontalPadding * 2)
+        let labelSize = label.sizeThatFits(
+            CGSize(width: labelMaxWidth, height: .greatestFiniteMagnitude)
+        )
+        return CGSize(
+            width: min(maxWidth, ceil(labelSize.width) + Metrics.horizontalPadding * 2),
+            height: ceil(labelSize.height) + Metrics.verticalPadding * 2
+        )
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        label.frame = bounds.insetBy(
+            dx: Metrics.horizontalPadding,
+            dy: Metrics.verticalPadding
+        )
+    }
+}
+
+final class DateHeaderOverlayManager {
+    private struct Anchor {
+        let model: DateDividerModel
+        let rect: CGRect
+    }
+
+    private enum HeaderRole {
+        case sticky
+        case inline
+    }
+
+    private struct DesiredHeader {
+        let model: DateDividerModel
+        let frame: CGRect
+        let alpha: CGFloat
+        let role: HeaderRole
+    }
+
+    let containerView = UIView()
+    private var visibleViews: [String: DateHeaderOverlayView] = [:]
+    private var reusableViews: [DateHeaderOverlayView] = []
+    private var targetAlphaById: [String: CGFloat] = [:]
+    private var roleById: [String: HeaderRole] = [:]
+    private var delayedFadeOutById: [String: DispatchWorkItem] = [:]
+
+    init() {
+        containerView.clipsToBounds = true
+        containerView.backgroundColor = .clear
+        containerView.isUserInteractionEnabled = false
+        containerView.alpha = 0
+    }
+
+    func hide(animated: Bool = false) {
+        cancelDelayedFadeOuts()
+        for id in visibleViews.keys {
+            targetAlphaById[id] = 0
+        }
+
+        guard containerView.alpha > 0 || visibleViews.values.contains(where: { $0.alpha > 0 }) else {
+            return
+        }
+        let updates = {
+            self.containerView.alpha = 0
+            for view in self.visibleViews.values {
+                view.alpha = 0
+                view.resetBackground()
+            }
+        }
+        if animated {
+            UIView.animate(
+                withDuration: DateHeaderOverlay.settleHideDuration,
+                delay: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut],
+                animations: updates
+            )
+        } else {
+            containerView.layer.removeAnimation(forKey: "opacity")
+            for view in visibleViews.values {
+                view.layer.removeAnimation(forKey: "opacity")
+            }
+            updates()
+        }
+    }
+
+    func update(
+        viewport: CGRect,
+        rows: [ChatTimelineRow],
+        visibleIndexPaths: [IndexPath],
+        tableView: UITableView,
+        hostView: UIView,
+        isScrolling: Bool,
+        animated: Bool
+    ) {
+        var anchors: [Anchor] = []
+        var activeTimestamp: Date?
+        var activeMinY = CGFloat.greatestFiniteMagnitude
+
+        for indexPath in visibleIndexPaths {
+            guard rows.indices.contains(indexPath.row) else { continue }
+
+            let rowRect = tableView.convert(tableView.rectForRow(at: indexPath), to: hostView)
+            switch rows[indexPath.row] {
+            case .message(let message):
+                let visibleRect = rowRect.intersection(viewport)
+                guard !visibleRect.isNull, visibleRect.height > 0 else { continue }
+                if visibleRect.minY < activeMinY {
+                    activeMinY = visibleRect.minY
+                    activeTimestamp = message.timestamp
+                }
+            case .dateDivider(let model):
+                if rowRect.maxY > viewport.minY - DateHeaderOverlay.anchorOverscan
+                    && rowRect.minY < viewport.maxY {
+                    anchors.append(Anchor(
+                        model: model,
+                        rect: rowRect.offsetBy(dx: -viewport.minX, dy: -viewport.minY)
+                    ))
+                }
+            }
+        }
+
+        guard activeTimestamp != nil || !anchors.isEmpty else {
+            hide(animated: animated)
+            return
+        }
+
+        containerView.layer.removeAnimation(forKey: "opacity")
+        containerView.frame = viewport
+        containerView.alpha = 1
+
+        let maxWidth = min(
+            DateHeaderOverlay.maxWidth,
+            max(0, viewport.width - DateHeaderOverlay.horizontalMargin * 2)
+        )
+
+        var desired: [String: DesiredHeader] = [:]
+        var desiredOrder: [String] = []
+
+        func headerSize(for model: DateDividerModel) -> CGSize {
+            let view = viewForHeader(id: model.id)
+            view.update(model: model)
+            return view.fittingSize(maxWidth: maxWidth)
+        }
+
+        func naturalFrame(for model: DateDividerModel, anchorRect: CGRect) -> CGRect {
+            let size = headerSize(for: model)
+            return CGRect(
+                x: (viewport.width - size.width) / 2,
+                y: anchorRect.minY + (anchorRect.height - size.height) / 2,
+                width: size.width,
+                height: size.height
+            )
+        }
+
+        var anchorFramesById: [String: CGRect] = [:]
+        for anchor in anchors {
+            let frame = naturalFrame(for: anchor.model, anchorRect: anchor.rect)
+            anchorFramesById[anchor.model.id] = frame
+        }
+
+        let activeModel = activeTimestamp.map { DateDividerModel.make(for: $0) }
+        func handoffFrame(for id: String, frame: CGRect) -> CGRect {
+            guard id != activeModel?.id,
+                  frame.maxY > 0,
+                  frame.minY < DateHeaderOverlay.topMargin
+            else {
+                return frame
+            }
+
+            var adjusted = frame
+            adjusted.origin.y = DateHeaderOverlay.topMargin
+            return adjusted
+        }
+
+        if let activeModel {
+            let size = headerSize(for: activeModel)
+            let naturalY = anchorFramesById[activeModel.id]?.minY
+            let stickyY = DateHeaderOverlay.topMargin
+            var y = max(naturalY ?? (-size.height - DateHeaderOverlay.pushSpacing), stickyY)
+            let unclampedY = y
+
+            for (id, frame) in anchorFramesById where id != activeModel.id {
+                let collisionFrame = handoffFrame(for: id, frame: frame)
+                guard collisionFrame.maxY > 0,
+                      collisionFrame.minY <= y + size.height + DateHeaderOverlay.pushSpacing
+                else { continue }
+                y = min(y, collisionFrame.minY - size.height - DateHeaderOverlay.pushSpacing)
+            }
+
+            y = max(-size.height - DateHeaderOverlay.pushSpacing, y)
+            let isNatural = naturalY.map { abs(unclampedY - $0) < 0.5 && abs(y - $0) < 0.5 } ?? false
+            desired[activeModel.id] = DesiredHeader(
+                model: activeModel,
+                frame: CGRect(
+                    x: (viewport.width - size.width) / 2,
+                    y: y,
+                    width: size.width,
+                    height: size.height
+                ),
+                alpha: isNatural || isScrolling ? 1 : 0,
+                role: isNatural ? .inline : .sticky
+            )
+            desiredOrder.append(activeModel.id)
+        }
+
+        for anchor in anchors {
+            if anchor.model.id == activeModel?.id {
+                continue
+            }
+            let frame = handoffFrame(
+                for: anchor.model.id,
+                frame: anchorFramesById[anchor.model.id] ?? naturalFrame(for: anchor.model, anchorRect: anchor.rect)
+            )
+            guard frame.maxY > 0, frame.minY < viewport.height else { continue }
+            desired[anchor.model.id] = DesiredHeader(
+                model: anchor.model,
+                frame: frame,
+                alpha: 1,
+                role: frame.minY <= DateHeaderOverlay.topMargin + 0.5 ? .sticky : .inline
+            )
+            desiredOrder.append(anchor.model.id)
+        }
+
+        apply(desired: desired, order: desiredOrder, animated: animated)
+    }
+
+    private func viewForHeader(id: String) -> DateHeaderOverlayView {
+        if let view = visibleViews[id] {
+            return view
+        }
+        let view = reusableViews.popLast() ?? DateHeaderOverlayView()
+        visibleViews[id] = view
+        containerView.addSubview(view)
+        return view
+    }
+
+    private func apply(
+        desired: [String: DesiredHeader],
+        order: [String],
+        animated: Bool
+    ) {
+        let desiredIds = Set(desired.keys)
+        for id in Array(visibleViews.keys) where !desiredIds.contains(id) {
+            guard let view = visibleViews.removeValue(forKey: id) else { continue }
+            cancelDelayedFadeOut(id: id)
+            targetAlphaById.removeValue(forKey: id)
+            roleById.removeValue(forKey: id)
+            view.layer.removeAllAnimations()
+            view.alpha = 0
+            view.resetBackground()
+            view.removeFromSuperview()
+            reusableViews.append(view)
+        }
+
+        guard !desired.isEmpty else {
+            hide(animated: animated)
+            return
+        }
+
+        for (id, header) in desired {
+            let view = viewForHeader(id: id)
+            view.update(model: header.model)
+            view.frame = header.frame
+            applyAlpha(
+                header.alpha,
+                to: view,
+                id: id,
+                role: header.role,
+                animated: animated
+            )
+        }
+
+        for id in order {
+            if let view = visibleViews[id] {
+                containerView.bringSubviewToFront(view)
+            }
+        }
+    }
+
+    private func applyAlpha(
+        _ alpha: CGFloat,
+        to view: DateHeaderOverlayView,
+        id: String,
+        role: HeaderRole,
+        animated: Bool
+    ) {
+        let targetAlpha: CGFloat = alpha > 0.01 ? 1 : 0
+        let previousTargetAlpha = targetAlphaById[id] ?? view.alpha
+        let previousRole = roleById[id]
+        roleById[id] = role
+
+        guard abs(previousTargetAlpha - targetAlpha) > 0.01 else {
+            if role == .inline, previousRole != .inline {
+                view.resetBackground()
+            }
+            return
+        }
+
+        targetAlphaById[id] = targetAlpha
+
+        if targetAlpha > 0 {
+            cancelDelayedFadeOut(id: id)
+            guard role == .sticky else {
+                view.layer.removeAnimation(forKey: "opacity")
+                view.alpha = 1
+                view.resetBackground()
+                return
+            }
+
+            view.prepareHighlightedBackground()
+            UIView.animate(
+                withDuration: DateHeaderOverlay.revealDuration,
+                delay: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseOut]
+            ) {
+                view.alpha = targetAlpha
+            } completion: { [weak self, weak view] _ in
+                guard let self,
+                      let view,
+                      self.targetAlphaById[id] == 1,
+                      self.visibleViews[id] === view
+                else { return }
+                view.settleBackground()
+            }
+        } else if animated && role == .sticky {
+            scheduleDelayedFadeOut(for: view, id: id)
+        } else {
+            cancelDelayedFadeOut(id: id)
+            view.layer.removeAnimation(forKey: "opacity")
+            view.alpha = 0
+            view.resetBackground()
+        }
+    }
+
+    private func scheduleDelayedFadeOut(for view: DateHeaderOverlayView, id: String) {
+        cancelDelayedFadeOut(id: id)
+
+        let workItem = DispatchWorkItem { [weak self, weak view] in
+            guard let self,
+                  let view,
+                  self.targetAlphaById[id] == 0,
+                  self.visibleViews[id] === view
+            else { return }
+
+            view.pulseBackground()
+            let fadeWorkItem = DispatchWorkItem { [weak self, weak view] in
+                guard let self,
+                      let view,
+                      self.targetAlphaById[id] == 0,
+                      self.visibleViews[id] === view
+                else { return }
+
+                UIView.animate(
+                    withDuration: DateHeaderOverlay.settleHideDuration,
+                    delay: 0,
+                    options: [.beginFromCurrentState, .allowUserInteraction, .curveEaseInOut]
+                ) {
+                    view.alpha = 0
+                } completion: { [weak self, weak view] _ in
+                    guard let self,
+                          let view,
+                          self.targetAlphaById[id] == 0,
+                          self.visibleViews[id] === view
+                    else { return }
+                    view.resetBackground()
+                }
+
+                self.delayedFadeOutById[id] = nil
+            }
+
+            self.delayedFadeOutById[id] = fadeWorkItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + DateHeaderOverlay.preHidePulseLead,
+                execute: fadeWorkItem
+            )
+        }
+
+        delayedFadeOutById[id] = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + DateHeaderOverlay.settleHideDelay,
+            execute: workItem
+        )
+    }
+
+    private func cancelDelayedFadeOut(id: String) {
+        delayedFadeOutById.removeValue(forKey: id)?.cancel()
+    }
+
+    private func cancelDelayedFadeOuts() {
+        for workItem in delayedFadeOutById.values {
+            workItem.cancel()
+        }
+        delayedFadeOutById.removeAll()
+    }
+}

--- a/Zyna/Chat/Nodes/BubbleGradientSource.swift
+++ b/Zyna/Chat/Nodes/BubbleGradientSource.swift
@@ -70,7 +70,6 @@ private final class BubbleGradientCanvasView: UIView {
         backgroundColor = .clear
         gradientLayer.startPoint = start
         gradientLayer.endPoint = end
-        gradientLayer.locations = [0.0, 0.48, 1.0]
         layer.addSublayer(gradientLayer)
         updateGradientColors()
     }
@@ -93,9 +92,11 @@ private final class BubbleGradientCanvasView: UIView {
     }
 
     private func updateGradientColors() {
-        gradientLayer.colors = colorProvider(traitCollection).map {
+        let colors = colorProvider(traitCollection)
+        gradientLayer.colors = colors.map {
             $0.resolvedColor(with: traitCollection).cgColor
         }
+        gradientLayer.locations = BubbleGradientStops.layerLocations(for: colors.count)
     }
 }
 
@@ -170,14 +171,10 @@ enum BubbleGradientRole: CaseIterable, Hashable {
     case incoming
     case outgoing
 
-    func colors(traits: UITraitCollection) -> [UIColor] {
+    func colors(traits: UITraitCollection, outgoingTheme: ChatBubbleTheme) -> [UIColor] {
         switch self {
         case .outgoing:
-            return [
-                UIColor(hex: 0x8AB8FF),
-                UIColor(hex: 0x5C8EFA),
-                UIColor(hex: 0x3954D6)
-            ]
+            return outgoingTheme.outgoingGradientColors
         case .incoming:
             let surface = AppColor.bubbleBackgroundIncoming.resolvedColor(with: traits)
             let isDark = traits.userInterfaceStyle == .dark

--- a/Zyna/Chat/Nodes/ChatNode.swift
+++ b/Zyna/Chat/Nodes/ChatNode.swift
@@ -8,15 +8,7 @@ import AsyncDisplayKit
 final class ChatNode: ASDisplayNode {
     let tableNode = ASTableNode()
     private let bubbleGradientHostView = UIView()
-    private let bubbleGradientSources: [BubbleGradientRole: BubbleGradientSource] = {
-        var sources: [BubbleGradientRole: BubbleGradientSource] = [:]
-        for role in BubbleGradientRole.allCases {
-            sources[role] = BubbleGradientSource { traits in
-                role.colors(traits: traits)
-            }
-        }
-        return sources
-    }()
+    private let bubbleGradientSources: [BubbleGradientRole: BubbleGradientSource]
 
     /// Set by ChatViewController. Used to put glass bars first in the
     /// accessibility tree so VoiceOver hit-tests the bars before the
@@ -30,6 +22,18 @@ final class ChatNode: ASDisplayNode {
     weak var scrollButtonTap: UIView?
 
     override init() {
+        let theme = ChatBubbleThemeStore.shared.selectedTheme
+        var sources: [BubbleGradientRole: BubbleGradientSource] = [:]
+        for role in BubbleGradientRole.allCases {
+            sources[role] = BubbleGradientSource(
+                colorProvider: { traits in
+                    role.colors(traits: traits, outgoingTheme: theme)
+                },
+                start: role == .outgoing ? theme.startPoint : CGPoint(x: 0.0, y: 0.0),
+                end: role == .outgoing ? theme.endPoint : CGPoint(x: 1.0, y: 1.0)
+            )
+        }
+        self.bubbleGradientSources = sources
         super.init()
         addSubnode(tableNode)
         tableNode.inverted = true

--- a/Zyna/Components/ContextMenu/ContextSourceNode.swift
+++ b/Zyna/Components/ContextMenu/ContextSourceNode.swift
@@ -27,6 +27,15 @@ final class ContextSourceNode: ASDisplayNode {
     private var touchStartLocation: CGPoint = .zero
     private var latestLocation: CGPoint = .zero
 
+    var isGestureEnabled: Bool = true {
+        didSet {
+            if !isGestureEnabled {
+                cancelShrink()
+                didActivate = false
+            }
+        }
+    }
+
     /// Horizontal pan distance (pt) past which we treat the touch as
     /// a back-swipe and bow out so the navigation pan can take over.
     private static let horizontalSwipeCancelThreshold: CGFloat = 8
@@ -80,6 +89,8 @@ final class ContextSourceNode: ASDisplayNode {
     // MARK: - Gesture
 
     @objc private func handleGesture(_ gesture: UILongPressGestureRecognizer) {
+        guard isGestureEnabled else { return }
+
         let location = gesture.location(in: view)
         latestLocation = location
 
@@ -224,6 +235,7 @@ final class ContextSourceNode: ASDisplayNode {
 
 extension ContextSourceNode: UIGestureRecognizerDelegate {
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard isGestureEnabled else { return true }
         // VoiceOver double-tap triggers long press; disable to prevent
         // accidental context menu activation.
         if UIAccessibility.isVoiceOverRunning { return false }

--- a/Zyna/Core/Theme/AppIcon.swift
+++ b/Zyna/Core/Theme/AppIcon.swift
@@ -31,6 +31,7 @@ enum AppIcon {
     case personSlash
     case noSign
     case magnifyingGlass
+    case settings
 
     var systemName: String {
         switch self {
@@ -59,6 +60,7 @@ enum AppIcon {
         case .personSlash:      return "person.slash"
         case .noSign:           return "nosign"
         case .magnifyingGlass:  return "magnifyingglass"
+        case .settings:         return "gearshape.fill"
         }
     }
 

--- a/Zyna/Glass/GlassService.swift
+++ b/Zyna/Glass/GlassService.swift
@@ -367,8 +367,10 @@ final class GlassService {
 
             let wantsLiquid = anchor.extendsCaptureToScreenBottom
 
-            // Skip if nothing to do
-            guard shouldCapture || (shouldRender && (wantsLiquid || anchor.hasBars || anchor.hasScrollButton)) else { continue }
+            // Shared renderer clears the whole drawable at the start of a
+            // batch, so render-only frames must redraw every cached glass item
+            // in that container, not only the item whose animation is active.
+            guard shouldCapture || shouldRender else { continue }
 
             if shouldCapture {
                 // ── Capture new frame ──
@@ -492,12 +494,12 @@ final class GlassService {
                     renderItemsByContainer[key] = group
                 }
 
-            } else if (wantsLiquid || (anchor.hasBars && reg.lastBarData != nil)),
+            } else if shouldRender,
                       let texture = reg.lastTexture,
                       let shapes = reg.lastShapes,
                       let captureFrame = reg.lastCaptureFrame {
                 // ── Render-only: reuse cached texture, update wave animation ──
-                var lz = reg.lastLiquidZone
+                var lz = wantsLiquid ? reg.lastLiquidZone : nil
                 lz?.waveEnergy = waveEnergy
                 let destinationFrame = renderDestinationFrame(
                     for: captureFrame,
@@ -522,7 +524,7 @@ final class GlassService {
                             isHDR: reg.lastIsHDR,
                             liquidZone: lz,
                             time: waveTime,
-                            barData: reg.lastBarData
+                            barData: anchor.hasBars ? reg.lastBarData : nil
                         )
                     )
                     renderItemsByContainer[key] = group
@@ -607,6 +609,8 @@ final class GlassService {
         let slots: [CaptureSlot]
         let width: Int
         let height: Int
+        let byteCost: Int
+        var lastUsedTick: Int
         var current: Int = 0
 
         mutating func next() -> CaptureSlot {
@@ -616,6 +620,9 @@ final class GlassService {
         }
     }
     private var captureCaches: [String: CaptureCache] = [:]
+    // Keyboard/liquid animation can produce many one-frame capture sizes.
+    // Keep stable nav/input caches hot while evicting transient buffers.
+    private let maxCaptureCacheBytes = 96 * 1024 * 1024
 
     /// Align bytesPerRow to 256 for MTLBuffer.makeTexture() requirement.
     private static func alignedBytesPerRow(_ width: Int) -> Int {
@@ -708,11 +715,20 @@ final class GlassService {
                                          bytesPerRow: alignedBPR, zeroCopy: zeroCopy))
             }
 
-            captureCaches[key] = CaptureCache(slots: slots, width: w, height: h)
+            let byteCost = slots.reduce(0) { $0 + $1.bytesPerRow * h }
+            captureCaches[key] = CaptureCache(
+                slots: slots,
+                width: w,
+                height: h,
+                byteCost: byteCost,
+                lastUsedTick: tickCount
+            )
+            pruneCaptureCachesIfNeeded()
         }
 
         let slot: CaptureSlot = {
             var cache = captureCaches[key]!
+            cache.lastUsedTick = tickCount
             let s = cache.next()
             captureCaches[key] = cache
             return s
@@ -811,6 +827,25 @@ final class GlassService {
         }
 
         return slot.texture
+    }
+
+    private func pruneCaptureCachesIfNeeded() {
+        var totalBytes = captureCaches.values.reduce(0) { $0 + $1.byteCost }
+        guard totalBytes > maxCaptureCacheBytes else { return }
+
+        let keysByAge = captureCaches.keys.sorted {
+            let lhs = captureCaches[$0]?.lastUsedTick ?? 0
+            let rhs = captureCaches[$1]?.lastUsedTick ?? 0
+            if lhs == rhs { return $0 < $1 }
+            return lhs < rhs
+        }
+
+        for key in keysByAge {
+            guard totalBytes > maxCaptureCacheBytes, captureCaches.count > 1 else { break }
+            guard let cache = captureCaches[key], cache.lastUsedTick < tickCount else { continue }
+            totalBytes -= cache.byteCost
+            captureCaches.removeValue(forKey: key)
+        }
     }
 
     private func renderLayerForCapture(

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -18,6 +18,9 @@ final class ChatsCoordinator {
         vc.onChatSelected = { [weak self] room in
             self?.showChat(room)
         }
+        vc.onChatPreviewRequested = { [weak self] room, sourceFrame in
+            self?.showChatPreview(room, sourceFrame: sourceFrame)
+        }
         vc.onComposeTapped = { [weak self] in
             self?.showStartChat()
         }
@@ -90,6 +93,18 @@ final class ChatsCoordinator {
     func showChat(_ room: Room, animated: Bool) {
         let (vc, _) = makeChatScreen(room: room)
         navigationController.push(vc, animated: animated)
+    }
+
+    private func showChatPreview(_ room: Room, sourceFrame: CGRect?) {
+        guard navigationController.presentedViewController == nil else { return }
+
+        let viewModel = ChatViewModel(room: room, mode: .preview)
+        let chatController = ChatViewController(viewModel: viewModel)
+        let overlay = ChatPeekOverlayController(
+            chatController: chatController,
+            sourceFrameInScreen: sourceFrame
+        )
+        navigationController.present(overlay, animated: false)
     }
 
     private func showForwardPicker(message: ChatMessage, timelineService: TimelineService) {

--- a/Zyna/Navigation/ChatsCoordinator.swift
+++ b/Zyna/Navigation/ChatsCoordinator.swift
@@ -18,8 +18,12 @@ final class ChatsCoordinator {
         vc.onChatSelected = { [weak self] room in
             self?.showChat(room)
         }
-        vc.onChatPreviewRequested = { [weak self] room, sourceFrame in
-            self?.showChatPreview(room, sourceFrame: sourceFrame)
+        vc.onChatPreviewRequested = { [weak self] room, sourceFrame, backgroundSourceView in
+            self?.showChatPreview(
+                room,
+                sourceFrame: sourceFrame,
+                backgroundSourceView: backgroundSourceView
+            )
         }
         vc.onComposeTapped = { [weak self] in
             self?.showStartChat()
@@ -95,14 +99,22 @@ final class ChatsCoordinator {
         navigationController.push(vc, animated: animated)
     }
 
-    private func showChatPreview(_ room: Room, sourceFrame: CGRect?) {
+    private func showChatPreview(
+        _ room: Room,
+        sourceFrame: CGRect?,
+        backgroundSourceView: UIView?
+    ) {
         guard navigationController.presentedViewController == nil else { return }
 
         let viewModel = ChatViewModel(room: room, mode: .preview)
         let chatController = ChatViewController(viewModel: viewModel)
+        let resolvedBackgroundSourceView = navigationController.parent?.view
+            ?? backgroundSourceView
+            ?? navigationController.view
         let overlay = ChatPeekOverlayController(
             chatController: chatController,
-            sourceFrameInScreen: sourceFrame
+            sourceFrameInScreen: sourceFrame,
+            backgroundSourceView: resolvedBackgroundSourceView
         )
         navigationController.present(overlay, animated: false)
     }

--- a/Zyna/Navigation/ProfileCoordinator.swift
+++ b/Zyna/Navigation/ProfileCoordinator.swift
@@ -15,6 +15,28 @@ final class ProfileCoordinator {
         vc.onLogout = { [weak self] in
             self?.onLogout?()
         }
+        vc.onSettingsTapped = { [weak self] in
+            self?.showSettings()
+        }
         navigationController.setStack([vc], animated: false)
+    }
+
+    private func showSettings() {
+        let vc = SettingsViewController()
+        vc.onBack = { [weak self] in
+            _ = self?.navigationController.pop()
+        }
+        vc.onThemeTapped = { [weak self] in
+            self?.showChatThemeSettings()
+        }
+        navigationController.push(vc)
+    }
+
+    private func showChatThemeSettings() {
+        let vc = ChatThemeSettingsViewController()
+        vc.onBack = { [weak self] in
+            _ = self?.navigationController.pop()
+        }
+        navigationController.push(vc)
     }
 }

--- a/Zyna/Resources/Localizable.xcstrings
+++ b/Zyna/Resources/Localizable.xcstrings
@@ -1731,6 +1731,16 @@
         }
       }
     },
+    "Today" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сегодня"
+          }
+        }
+      }
+    },
     "Topic (optional)" : {
       "localizations" : {
         "ru" : {
@@ -1797,6 +1807,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Без этого ключа вы потеряете доступ к зашифрованным сообщениям при входе на другом устройстве."
+          }
+        }
+      }
+    },
+    "Yesterday" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вчера"
           }
         }
       }

--- a/Zyna/Resources/Localizable.xcstrings
+++ b/Zyna/Resources/Localizable.xcstrings
@@ -545,12 +545,32 @@
         }
       }
     },
+    "Appearance" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оформление"
+          }
+        }
+      }
+    },
     "Are you sure?" : {
       "localizations" : {
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вы уверены?"
+          }
+        }
+      }
+    },
+    "Aurora Lime" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аврора Лайм"
           }
         }
       }
@@ -671,6 +691,16 @@
     "Changes member role" : {
 
     },
+    "Chat Theme" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тема чата"
+          }
+        }
+      }
+    },
     "Chats" : {
       "localizations" : {
         "ru" : {
@@ -687,6 +717,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Проверка аккаунта…"
+          }
+        }
+      }
+    },
+    "Clean. Keep it." : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чисто. Оставляем."
           }
         }
       }
@@ -810,6 +850,16 @@
     "emoji" : {
 
     },
+    "Ember Rose" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розовый жар"
+          }
+        }
+      }
+    },
     "Encryption enabled" : {
       "localizations" : {
         "ru" : {
@@ -850,6 +900,16 @@
         }
       }
     },
+    "Forest" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лес"
+          }
+        }
+      }
+    },
     "Forwarded from %@" : {
       "localizations" : {
         "ru" : {
@@ -880,6 +940,16 @@
         }
       }
     },
+    "Graphite Cyan" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Графитовый циан"
+          }
+        }
+      }
+    },
     "Group Name" : {
       "localizations" : {
         "ru" : {
@@ -896,6 +966,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сервер"
+          }
+        }
+      }
+    },
+    "How does this look?" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Как выглядит?"
           }
         }
       }
@@ -956,6 +1036,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Исключить из группы?"
+          }
+        }
+      }
+    },
+    "Lagoon Teal" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бирюзовая лагуна"
           }
         }
       }
@@ -1081,6 +1171,16 @@
         }
       }
     },
+    "Mango" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Манго"
+          }
+        }
+      }
+    },
     "Member" : {
       "localizations" : {
         "ru" : {
@@ -1154,6 +1254,16 @@
         }
       }
     },
+    "Next Theme" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Следующая тема"
+          }
+        }
+      }
+    },
     "No emoji found." : {
 
     },
@@ -1192,6 +1302,16 @@
     "Opens this emoji category" : {
 
     },
+    "Outgoing Bubbles" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свои сообщения"
+          }
+        }
+      }
+    },
     "Owner" : {
       "localizations" : {
         "ru" : {
@@ -1228,6 +1348,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фото"
+          }
+        }
+      }
+    },
+    "Previous Theme" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предыдущая тема"
           }
         }
       }
@@ -1314,6 +1444,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Событие комнаты"
+          }
+        }
+      }
+    },
+    "Ruby Plum" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рубиновая слива"
           }
         }
       }
@@ -1530,6 +1670,16 @@
         }
       }
     },
+    "Solar Coral" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Солнечный коралл"
+          }
+        }
+      }
+    },
     "Syncing encryption keys…" : {
       "localizations" : {
         "ru" : {
@@ -1617,6 +1767,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Верифицировать устройство"
+          }
+        }
+      }
+    },
+    "Violet Blue" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сине-фиолетовый"
           }
         }
       }
@@ -1958,6 +2118,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ваш ключ восстановления"
+          }
+        }
+      }
+    },
+    "Zyna Blue" : {
+      "localizations" : {
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zyna Blue"
           }
         }
       }

--- a/Zyna/Screens/CreateGroup/ChipsStripNode.swift
+++ b/Zyna/Screens/CreateGroup/ChipsStripNode.swift
@@ -27,7 +27,10 @@ final class ChipsStripNode: ASScrollNode {
     }
 
     func setUsers(_ users: [UserProfile], onRemove: @escaping (UserProfile) -> Void) {
-        let existing = Dictionary(uniqueKeysWithValues: chipNodes.map { ($0.userId, $0) })
+        let existing = Dictionary(
+            chipNodes.map { ($0.userId, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         chipNodes = users.map { user in
             let chip = existing[user.userId] ?? SelectedUserChipNode(user: user)
             chip.onRemove = { onRemove(user) }

--- a/Zyna/Screens/Profile/ProfileNode.swift
+++ b/Zyna/Screens/Profile/ProfileNode.swift
@@ -110,6 +110,8 @@ final class ProfileNode: ScreenNode {
         editAvatarOverlayNode.clipsToBounds = true
         messageButtonNode.cornerRadius = 12
         messageButtonNode.clipsToBounds = true
+        settingsButtonNode.cornerRadius = 12
+        settingsButtonNode.clipsToBounds = true
         logoutButtonNode.cornerRadius = 12
         logoutButtonNode.clipsToBounds = true
 
@@ -280,10 +282,17 @@ final class ProfileNode: ScreenNode {
         searchButtonNode.addTarget(self, action: #selector(searchTapped), forControlEvents: .touchUpInside)
 
         // Settings (own only)
+        let settingsIcon = AppIcon.settings.rendered(size: 17, weight: .medium, color: AppColor.accent)
+        settingsButtonNode.setImage(settingsIcon, for: .normal)
         settingsButtonNode.setAttributedTitle(NSAttributedString(
-            string: String(localized: "Settings"),
-            attributes: [.font: UIFont.systemFont(ofSize: 17), .foregroundColor: UIColor.label]
+            string: "  " + String(localized: "Settings"),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 17, weight: .medium),
+                .foregroundColor: UIColor.label
+            ]
         ), for: .normal)
+        settingsButtonNode.backgroundColor = .secondarySystemBackground
+        settingsButtonNode.contentEdgeInsets = UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
         settingsButtonNode.contentHorizontalAlignment = .left
         settingsButtonNode.addTarget(self, action: #selector(settingsTapped), forControlEvents: .touchUpInside)
 

--- a/Zyna/Screens/Profile/ProfileView.swift
+++ b/Zyna/Screens/Profile/ProfileView.swift
@@ -12,6 +12,7 @@ final class ProfileViewController: ASDKViewController<ProfileScreenNode> {
     var onLogout: (() -> Void)?
     var onBack: (() -> Void)?
     var onSearchTapped: (() -> Void)?
+    var onSettingsTapped: (() -> Void)?
     var onMessageTapped: (() -> Void)? {
         didSet { node.content.onMessageTapped = onMessageTapped }
     }
@@ -167,8 +168,8 @@ final class ProfileViewController: ASDKViewController<ProfileScreenNode> {
         node.content.onLogoutTapped = { [weak self] in
             self?.confirmLogout()
         }
-        node.content.onSettingsTapped = {
-            print("[profile] Settings tapped")
+        node.content.onSettingsTapped = { [weak self] in
+            self?.onSettingsTapped?()
         }
         node.content.onAvatarTapped = { [weak self] in
             self?.presentAvatarPicker()

--- a/Zyna/Screens/Rooms/ChatPeek/ChatPeekLensShader.metal
+++ b/Zyna/Screens/Rooms/ChatPeek/ChatPeekLensShader.metal
@@ -1,0 +1,291 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct ChatPeekLensVertex {
+    float2 position;
+    float2 uv;
+};
+
+struct ChatPeekLensVertexOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+struct ChatPeekLensUniforms {
+    float2 resolution;
+    float2 viewSize;
+    float4 cardRect;
+    float cornerRadius;
+    float progress;
+    float time;
+    float impulse;
+    float4 effectParams;
+};
+
+constant sampler lensSampler(filter::linear, address::clamp_to_edge);
+
+vertex ChatPeekLensVertexOut chatPeekLensVertex(
+    const device ChatPeekLensVertex *vertices [[buffer(0)]],
+    uint vid [[vertex_id]]
+) {
+    ChatPeekLensVertexOut out;
+    out.position = float4(vertices[vid].position, 0.0, 1.0);
+    out.uv = vertices[vid].uv;
+    return out;
+}
+
+inline float sdRoundedRect(float2 p, float2 halfSize, float radius) {
+    float2 q = abs(p) - halfSize + radius;
+    return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
+}
+
+inline float2 roundedRectNormal(float2 p, float2 halfSize, float radius) {
+    float2 signP = select(float2(1.0), float2(-1.0), p < 0.0);
+    float2 ap = abs(p);
+    float2 q = ap - halfSize + radius;
+    float2 outside = max(q, 0.0);
+    float outsideLen = length(outside);
+
+    float2 n;
+    if (q.x > 0.0 && q.y > 0.0) {
+        n = outside / max(outsideLen, 0.0001);
+    } else if (q.x > q.y) {
+        n = float2(1.0, 0.0);
+    } else {
+        n = float2(0.0, 1.0);
+    }
+    return normalize(n * signP);
+}
+
+inline float gaussian(float x, float width) {
+    float v = x / max(width, 0.0001);
+    return exp(-v * v);
+}
+
+inline float gaussianCentered(float x, float center, float width) {
+    float v = (x - center) / max(width, 0.0001);
+    return exp(-v * v);
+}
+
+inline float angularGaussian(float angle, float center, float width) {
+    float delta = atan2(sin(angle - center), cos(angle - center));
+    return gaussian(delta, width);
+}
+
+inline float hash11(float value) {
+    return fract(sin(value * 127.1) * 43758.5453123);
+}
+
+inline float particleLayerShaped(
+    float theta,
+    float outsidePx,
+    float time,
+    float seed,
+    float cellCount,
+    float speed,
+    float radialStart,
+    float radialSpan,
+    float radialWidth,
+    float angularScale
+) {
+    float stream = fract(theta + time * (0.010 + seed * 0.002));
+    float cellPosition = stream * cellCount;
+    float cell = floor(cellPosition);
+    float local = fract(cellPosition);
+    float rndA = hash11(cell + seed * 31.7);
+    float rndB = hash11(cell + seed * 53.1);
+    float rndC = hash11(cell + seed * 79.9);
+
+    float center = 0.22 + rndA * 0.56;
+    float angular = gaussian(local - center, (0.034 + rndB * 0.026) * angularScale);
+    float travel = fract(time * speed + rndA + seed * 0.37);
+    float radial = radialStart + travel * radialSpan + rndB * 8.0;
+    float fade = smoothstep(0.02, 0.18, travel) * (1.0 - smoothstep(0.58, 1.0, travel));
+    float active = smoothstep(0.34, 0.78, rndC);
+
+    return angular * gaussianCentered(outsidePx, radial, radialWidth + rndB * 1.6) * fade * active;
+}
+
+inline float particleLayer(
+    float theta,
+    float outsidePx,
+    float time,
+    float seed,
+    float cellCount,
+    float speed,
+    float radialStart,
+    float radialSpan,
+    float radialWidth
+) {
+    return particleLayerShaped(
+        theta,
+        outsidePx,
+        time,
+        seed,
+        cellCount,
+        speed,
+        radialStart,
+        radialSpan,
+        radialWidth,
+        1.0
+    );
+}
+
+inline float3 sampleLensTexture(texture2d<float> texture, float2 uv) {
+    return texture.sample(lensSampler, clamp(uv, 0.0, 1.0)).rgb;
+}
+
+fragment float4 chatPeekLensFragment(
+    ChatPeekLensVertexOut in [[stage_in]],
+    constant ChatPeekLensUniforms& u [[buffer(0)]],
+    texture2d<float> sourceTexture [[texture(0)]]
+) {
+    float2 uv = in.uv;
+    float aspect = u.viewSize.x / max(u.viewSize.y, 1.0);
+    float2 p = float2(uv.x * aspect, uv.y);
+
+    float2 cardOrigin = u.cardRect.xy;
+    float2 cardSize = u.cardRect.zw;
+    float2 cardCenter = cardOrigin + cardSize * 0.5;
+    float2 cardCenterP = float2(cardCenter.x * aspect, cardCenter.y);
+    float2 halfSize = float2(cardSize.x * aspect * 0.5, cardSize.y * 0.5);
+    float cornerRadius = min(u.cornerRadius, min(halfSize.x, halfSize.y));
+    float2 local = p - cardCenterP;
+    float sdf = sdRoundedRect(local, halfSize, cornerRadius);
+    float2 normalP = roundedRectNormal(local, halfSize, cornerRadius);
+    float2 normalUv = normalize(float2(normalP.x / aspect, normalP.y));
+    float2 tangentUv = float2(-normalUv.y, normalUv.x);
+
+    float px = 1.0 / max(u.resolution.y, 1.0);
+    float progress = smoothstep(0.0, 1.0, u.progress);
+    float distanceFromRim = abs(sdf);
+    float outsideDistance = max(sdf, 0.0);
+
+    float horizon = gaussian(distanceFromRim, 30.0 * px);
+    float rim = gaussian(distanceFromRim, 52.0 * px);
+    float lensRing = gaussianCentered(outsideDistance, 74.0 * px, 64.0 * px);
+    float outerRing = gaussianCentered(outsideDistance, 142.0 * px, 72.0 * px);
+    float release = gaussianCentered(outsideDistance, 178.0 * px, 62.0 * px);
+    float influence = 1.0 - smoothstep(0.0, 260.0 * px, distanceFromRim);
+    float angle = atan2(local.y, local.x);
+    float impulse = u.impulse;
+    float theta = fract(angle / (2.0 * M_PI_F) + 0.5);
+    float outsidePx = outsideDistance / max(px, 0.00001);
+    float outsideMask = smoothstep(2.0, 12.0, outsidePx) * (1.0 - smoothstep(190.0, 270.0, outsidePx));
+    float particleCore =
+        particleLayer(theta, outsidePx, u.time, 1.0, 92.0, 0.18, 4.0, 104.0, 1.6) * 1.02 +
+        particleLayer(theta, outsidePx, u.time, 2.0, 68.0, 0.12, 10.0, 146.0, 2.1) * 0.76 +
+        particleLayer(theta, outsidePx, u.time, 3.0, 118.0, 0.24, 2.0, 74.0, 1.1) * 0.66 +
+        particleLayer(theta, outsidePx, u.time, 4.0, 44.0, 0.085, 20.0, 176.0, 2.6) * 0.54;
+    float particleGlow =
+        particleLayer(theta, outsidePx, u.time, 5.0, 62.0, 0.16, 0.0, 132.0, 4.8) * 0.50 +
+        particleLayer(theta, outsidePx, u.time, 6.0, 38.0, 0.10, 18.0, 190.0, 7.0) * 0.34;
+    float particles = (particleCore + particleGlow) * outsideMask * progress;
+    float particleWarp =
+        particleLayerShaped(theta, outsidePx, u.time, 1.0, 92.0, 0.18, 4.0, 104.0, 6.4, 7.5) * 0.90 +
+        particleLayerShaped(theta, outsidePx, u.time, 2.0, 68.0, 0.12, 10.0, 146.0, 8.2, 8.5) * 0.72 +
+        particleLayerShaped(theta, outsidePx, u.time, 3.0, 118.0, 0.24, 2.0, 74.0, 5.2, 6.5) * 0.58 +
+        particleLayerShaped(theta, outsidePx, u.time, 4.0, 44.0, 0.085, 20.0, 176.0, 10.0, 9.0) * 0.48;
+    float particleLens = clamp(particleCore * 0.65 + particleGlow * 0.20 + particleWarp * 1.30, 0.0, 2.35)
+        * outsideMask;
+
+    float normalPx =
+        54.0 * horizon +
+        34.0 * lensRing +
+        18.0 * outerRing * impulse -
+        12.0 * release +
+        24.0 * particleLens;
+    float tangentPx =
+        6.0 * lensRing * sin(angle * 2.0 + u.time * 0.8) +
+        3.5 * outerRing * sin(angle * 4.0 + 0.35) * impulse +
+        38.0 * particleLens * sin(angle * 6.0 + outsidePx * 0.035 + u.time * 1.6);
+
+    float2 offset =
+        normalUv * normalPx * px * influence * progress +
+        tangentUv * tangentPx * px * influence * progress;
+
+    float chroma = 2.4 * px * (rim + lensRing * 0.6) * progress;
+    float2 redUv = uv + offset + normalUv * chroma;
+    float2 greenUv = uv + offset;
+    float2 blueUv = uv + offset - normalUv * chroma;
+
+    float3 color;
+    color.r = sampleLensTexture(sourceTexture, redUv).r;
+    color.g = sampleLensTexture(sourceTexture, greenUv).g;
+    color.b = sampleLensTexture(sourceTexture, blueUv).b;
+
+    float darkRimStrength = u.effectParams.x;
+    float darkRim = (0.40 * horizon + 0.13 * lensRing + 0.05 * outerRing)
+        * darkRimStrength
+        * progress;
+    color *= (1.0 - clamp(darkRim, 0.0, 0.68));
+
+    float3 warmDisk = float3(1.0, 0.72, 0.34);
+    float3 coldEdge = float3(0.46, 0.68, 1.0);
+
+    float arcNoise =
+        (0.50 + 0.50 * sin(angle * 5.3 + u.time * 0.18)) *
+        (0.55 + 0.45 * sin(angle * 13.0 - u.time * 0.31)) +
+        0.18 * sin(angle * 29.0 + 1.7);
+    float brokenArc = smoothstep(0.23, 0.74, arcNoise);
+    float heroTop = angularGaussian(angle, -1.52, 1.05);
+    float heroBottom = angularGaussian(angle, 1.38, 0.76) * 0.28;
+    float heroSide = angularGaussian(angle, -0.10, 0.42) * 0.16;
+    float arcEnvelope = clamp(heroTop * 0.72 + heroBottom + heroSide, 0.0, 1.0);
+    float chaoticArc = arcEnvelope * brokenArc;
+    float softBand = gaussianCentered(outsideDistance, 70.0 * px, 13.0 * px) * chaoticArc;
+    float wideBloom = gaussianCentered(outsideDistance, 88.0 * px, 31.0 * px) * chaoticArc;
+
+    float horizontalDisk = pow(abs(cos(angle)), 2.55);
+    float upperBend = pow(max(-sin(angle), 0.0), 0.46);
+    float lowerBend = pow(max(sin(angle), 0.0), 0.64);
+    float causticBias = 0.22 + horizontalDisk * 0.82 + upperBend * 0.46 + lowerBend * 0.18;
+    float causticA = gaussianCentered(outsideDistance, 39.0 * px, 3.8 * px)
+        * smoothstep(0.76, 1.0, sin(angle * 9.0 + u.time * 0.26 + 0.45));
+    float causticB = gaussianCentered(outsideDistance, 61.0 * px, 3.0 * px)
+        * smoothstep(0.78, 1.0, sin(angle * 14.0 - u.time * 0.34 - 1.8));
+    float causticC = gaussianCentered(outsideDistance, 96.0 * px, 5.2 * px)
+        * smoothstep(0.80, 1.0, sin(angle * 18.0 + u.time * 0.22 + 2.35));
+    float causticD = gaussianCentered(outsideDistance, 137.0 * px, 7.0 * px)
+        * smoothstep(0.84, 1.0, sin(angle * 23.0 - u.time * 0.18 - 0.65));
+    float caustics = (causticA * 0.82 + causticB + causticC * 0.68 + causticD * 0.42)
+        * causticBias
+        * progress;
+
+    float photonBreaks = smoothstep(0.79, 1.0, sin(angle * 12.0 + u.time * 0.19 + 0.6))
+        + 0.42 * smoothstep(0.88, 1.0, sin(angle * 21.0 - u.time * 0.27 - 1.1));
+    float photonRing = gaussianCentered(distanceFromRim, 14.0 * px, 3.5 * px)
+        * clamp(photonBreaks, 0.0, 1.0)
+        * progress;
+
+    float3 arcColor = mix(warmDisk, coldEdge, smoothstep(0.16, 0.96, heroTop));
+    color += arcColor * softBand * 0.24 * progress;
+    color += warmDisk * wideBloom * 0.08 * progress;
+    color += mix(warmDisk, coldEdge, smoothstep(-0.35, 0.85, sin(angle + 0.45)))
+        * caustics
+        * 0.25;
+    color += float3(1.0, 0.91, 0.72) * photonRing * 0.18;
+
+    float hue = u.time * 1.9 + angle * 2.6 + outsidePx * 0.021;
+    float3 iridescent = 0.52 + 0.48 * cos(float3(0.0, 2.1, 4.2) + hue);
+    float3 particleColor = mix(float3(1.0, 0.82, 0.54), iridescent, 0.64);
+    color += particleColor * particles * 0.58;
+    color += iridescent * pow(clamp(particles, 0.0, 1.0), 1.45) * 0.34;
+
+    float sweep = gaussianCentered(
+        fract((angle / (2.0 * M_PI_F)) + u.time * 0.42),
+        0.5,
+        0.045
+    ) * lensRing * impulse;
+    color += float3(1.0, 0.86, 0.56) * sweep * 0.18 * progress;
+
+    float settleGlow = outerRing * impulse * 0.035 * progress;
+    color += float3(0.72, 0.82, 1.0) * settleGlow;
+
+    return float4(color, 1.0);
+}

--- a/Zyna/Screens/Rooms/ChatPeek/ChatPeekMetalBackgroundView.swift
+++ b/Zyna/Screens/Rooms/ChatPeek/ChatPeekMetalBackgroundView.swift
@@ -1,0 +1,734 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import Metal
+import os.log
+import UIKit
+
+final class ChatPeekMetalBackgroundView: UIView {
+
+    override class var layerClass: AnyClass { CAMetalLayer.self }
+
+    weak var sourceView: UIView? {
+        didSet {
+            debugLog(
+                "sourceView set hasSource=\(sourceView != nil) sourceBounds=\(sourceView?.bounds.debugDescription ?? "nil") sourceWindow=\(sourceView?.window != nil)"
+            )
+            sourceTexture = nil
+            guard window != nil else { return }
+            setNeedsRender()
+        }
+    }
+
+    var sourceCaptureRect: CGRect? {
+        didSet {
+            let oldRect = oldValue ?? .null
+            let newRect = sourceCaptureRect ?? .null
+            guard !oldRect.equalTo(newRect) else { return }
+
+            debugLog("sourceCaptureRect set rect=\(newRect.debugDescription)")
+            sourceTexture = nil
+            guard window != nil else { return }
+            setNeedsRender()
+        }
+    }
+
+    var cardFrame: CGRect = .zero {
+        didSet {
+            guard !cardFrame.equalTo(oldValue) else { return }
+            setNeedsRender()
+        }
+    }
+
+    var cardCornerRadius: CGFloat = 24 {
+        didSet {
+            guard cardCornerRadius != oldValue else { return }
+            setNeedsRender()
+        }
+    }
+
+    var progress: CGFloat {
+        get { lensProgress }
+        set {
+            let clamped = min(max(newValue, 0), 1)
+            guard abs(lensProgress - clamped) > 0.001 else { return }
+            lensProgress = clamped
+            setNeedsRender()
+            updateDisplayLinkSubscription()
+        }
+    }
+
+    private var metalLayer: CAMetalLayer {
+        // swiftlint:disable:next force_cast
+        layer as! CAMetalLayer
+    }
+
+    private struct QuadVertex {
+        var position: SIMD2<Float>
+        var uv: SIMD2<Float>
+    }
+
+    private struct Uniforms {
+        var resolution: SIMD2<Float>
+        var viewSize: SIMD2<Float>
+        var cardRect: SIMD4<Float>
+        var cornerRadius: Float
+        var progress: Float
+        var time: Float
+        var impulse: Float
+        var effectParams: SIMD4<Float>
+    }
+
+    private struct ProgressAnimation {
+        let from: CGFloat
+        let to: CGFloat
+        let startTime: CFTimeInterval
+        let duration: TimeInterval
+        let curve: ProgressCurve
+        let completion: (() -> Void)?
+    }
+
+    private struct RenderPayload {
+        let pipelineState: MTLRenderPipelineState
+        let sourceTexture: MTLTexture
+        let metalLayer: CAMetalLayer
+        let vertices: [QuadVertex]
+        let uniforms: Uniforms
+        let renderAttempt: Int
+        let renderStart: CFTimeInterval
+    }
+
+    private enum RenderEvent {
+        case noCommandBuffer
+        case noDrawable(CFTimeInterval)
+        case noEncoder
+        case slowDrawable(CFTimeInterval)
+        case committed(CFTimeInterval)
+        case completed
+    }
+
+    enum ProgressCurve {
+        case easeIn
+        case easeOut
+        case easeInOut
+
+        func value(at progress: CGFloat) -> CGFloat {
+            let t = min(max(progress, 0), 1)
+            switch self {
+            case .easeIn:
+                return t * t * t
+            case .easeOut:
+                let inverse = 1 - t
+                return 1 - inverse * inverse * inverse
+            case .easeInOut:
+                return t * t * (3 - 2 * t)
+            }
+        }
+    }
+
+    private static let pipelineState: MTLRenderPipelineState? = {
+        let ctx = MetalContext.shared
+        guard let vertexFunction = ctx.library.makeFunction(name: "chatPeekLensVertex"),
+              let fragmentFunction = ctx.library.makeFunction(name: "chatPeekLensFragment")
+        else {
+#if DEBUG
+            os_log(
+                "%{public}@",
+                log: .default,
+                type: .debug,
+                "[ChatPeekLens] pipeline missing vertex/fragment function"
+            )
+#endif
+            return nil
+        }
+
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.vertexFunction = vertexFunction
+        descriptor.fragmentFunction = fragmentFunction
+        descriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+        descriptor.colorAttachments[0].isBlendingEnabled = false
+        do {
+            return try ctx.device.makeRenderPipelineState(descriptor: descriptor)
+        } catch {
+#if DEBUG
+            os_log(
+                "%{public}@",
+                log: .default,
+                type: .debug,
+                "[ChatPeekLens] pipeline creation failed: \(String(describing: error))"
+            )
+#endif
+            return nil
+        }
+    }()
+
+    private var sourceTexture: MTLTexture?
+    private var lensProgress: CGFloat = 0
+    private var displayLinkToken: DisplayLinkToken?
+    private var progressAnimation: ProgressAnimation?
+    private let renderQueue = DispatchQueue(label: "chat.peek.lens.render", qos: .userInteractive)
+    private var startTime = CACurrentMediaTime()
+    private var frameInFlight = false
+    private var needsRender = false
+    private var renderRetryScheduled = false
+
+    private static var debugNextID = 0
+    private let debugID: Int
+    private var debugLastLogTimes: [String: CFTimeInterval] = [:]
+    private var debugRenderAttemptCount = 0
+    private var debugRenderedFrameCount = 0
+    private var debugRetryCount = 0
+    private var debugCaptureCount = 0
+
+    override init(frame: CGRect) {
+        Self.debugNextID += 1
+        debugID = Self.debugNextID
+        super.init(frame: frame)
+
+        backgroundColor = .clear
+        isUserInteractionEnabled = false
+        isOpaque = false
+
+        metalLayer.device = MetalContext.shared.device
+        metalLayer.pixelFormat = .bgra8Unorm
+        metalLayer.framebufferOnly = true
+        metalLayer.isOpaque = false
+        metalLayer.maximumDrawableCount = 3
+        metalLayer.presentsWithTransaction = false
+        if #available(iOS 16, *) {
+            metalLayer.allowsNextDrawableTimeout = false
+        }
+
+        debugLog("init")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        debugLog(
+            "deinit renderedFrames=\(debugRenderedFrameCount) retries=\(debugRetryCount) captures=\(debugCaptureCount)"
+        )
+        displayLinkToken?.invalidate()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        debugLog("didMoveToWindow hasWindow=\(window != nil) bounds=\(bounds.debugDescription)")
+        if window == nil {
+            sourceTexture = nil
+            displayLinkToken?.invalidate()
+            displayLinkToken = nil
+        }
+        setNeedsRender()
+        updateDisplayLinkSubscription()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            debugLog("trait style changed to \(traitCollection.userInterfaceStyle.rawValue)")
+            setNeedsRender()
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let scale = window?.screen.scale ?? UIScreen.main.scale
+        metalLayer.contentsScale = scale
+        metalLayer.drawableSize = CGSize(
+            width: max(1, bounds.width * scale),
+            height: max(1, bounds.height * scale)
+        )
+        debugLog(
+            "layout bounds=\(bounds.debugDescription) drawable=\(metalLayer.drawableSize.debugDescription)",
+            throttleKey: "layout",
+            interval: 0.35
+        )
+        setNeedsRender()
+    }
+
+    func animateProgress(
+        to targetProgress: CGFloat,
+        duration: TimeInterval,
+        curve: ProgressCurve,
+        completion: (() -> Void)? = nil
+    ) {
+        let targetProgress = min(max(targetProgress, 0), 1)
+        guard duration > 0, abs(lensProgress - targetProgress) > 0.001 else {
+            debugLog("animateProgress immediate target=\(targetProgress)")
+            progress = targetProgress
+            completion?()
+            return
+        }
+
+        debugLog("animateProgress from=\(lensProgress) to=\(targetProgress) duration=\(duration)")
+
+        progressAnimation = ProgressAnimation(
+            from: lensProgress,
+            to: targetProgress,
+            startTime: CACurrentMediaTime(),
+            duration: duration,
+            curve: curve,
+            completion: completion
+        )
+
+        setNeedsRender()
+        updateDisplayLinkSubscription()
+    }
+
+    private func handleDisplayLinkTick() {
+        guard window != nil else {
+            displayLinkToken?.invalidate()
+            displayLinkToken = nil
+            return
+        }
+
+        let completion = updateProgressAnimation()
+        let shouldRender = needsRender || lensProgress > 0.001 || completion != nil
+        if shouldRender {
+            if frameInFlight {
+                needsRender = true
+            } else {
+                needsRender = false
+                render()
+            }
+        }
+
+        updateDisplayLinkSubscription()
+        completion?()
+    }
+
+    private func updateProgressAnimation() -> (() -> Void)? {
+        guard let progressAnimation else { return nil }
+
+        let elapsed = CACurrentMediaTime() - progressAnimation.startTime
+        let linearProgress = min(max(elapsed / max(progressAnimation.duration, 0.001), 0), 1)
+        let curvedProgress = progressAnimation.curve.value(at: CGFloat(linearProgress))
+        lensProgress = progressAnimation.from + (progressAnimation.to - progressAnimation.from) * curvedProgress
+
+        guard linearProgress >= 1 else { return nil }
+
+        lensProgress = progressAnimation.to
+        self.progressAnimation = nil
+        return progressAnimation.completion
+    }
+
+    private func setNeedsRender() {
+        needsRender = true
+        updateDisplayLinkSubscription()
+        if displayLinkToken == nil {
+            needsRender = false
+            render()
+        }
+    }
+
+    private func updateDisplayLinkSubscription() {
+        let shouldRun = window != nil && (progressAnimation != nil || lensProgress > 0.001)
+
+        guard shouldRun else {
+            if displayLinkToken != nil {
+                debugLog("displayLink stop progress=\(lensProgress)")
+                displayLinkToken?.invalidate()
+                displayLinkToken = nil
+            }
+            return
+        }
+
+        guard displayLinkToken == nil else { return }
+
+        debugLog("displayLink start progress=\(lensProgress) animation=\(progressAnimation != nil)")
+        displayLinkToken = DisplayLinkDriver.shared.subscribe(rate: .max) { [weak self] _ in
+            self?.handleDisplayLinkTick()
+        }
+    }
+
+    private func debugLog(
+        _ message: @autoclosure () -> String,
+        throttleKey: String? = nil,
+        interval: CFTimeInterval = 0
+    ) {
+#if DEBUG
+        if let throttleKey {
+            let now = CACurrentMediaTime()
+            if let lastTime = debugLastLogTimes[throttleKey],
+               now - lastTime < interval {
+                return
+            }
+            debugLastLogTimes[throttleKey] = now
+        }
+
+        os_log(
+            "%{public}@",
+            log: .default,
+            type: .debug,
+            "[ChatPeekLens#\(debugID)] \(message())"
+        )
+#endif
+    }
+
+    @discardableResult
+    private func captureSourceTexture(afterScreenUpdates: Bool = false, reason: String) -> Bool {
+        guard sourceTexture == nil else {
+            debugLog("capture skip already-has-texture reason=\(reason)", throttleKey: "capture-has-texture", interval: 0.5)
+            return true
+        }
+
+        guard let sourceView else {
+            debugLog("capture skip no-source reason=\(reason)", throttleKey: "capture-no-source", interval: 0.5)
+            return false
+        }
+
+        guard sourceView.bounds.width > 1,
+              sourceView.bounds.height > 1
+        else {
+            debugLog(
+                "capture skip invalid-source-bounds reason=\(reason) bounds=\(sourceView.bounds.debugDescription)",
+                throttleKey: "capture-invalid-bounds",
+                interval: 0.5
+            )
+            return false
+        }
+
+        let captureRect = resolvedSourceCaptureRect(in: sourceView)
+        guard captureRect.width > 1, captureRect.height > 1 else {
+            debugLog(
+                "capture skip invalid-capture-rect reason=\(reason) rect=\(captureRect.debugDescription)",
+                throttleKey: "capture-invalid-rect",
+                interval: 0.5
+            )
+            return false
+        }
+
+        let scale = sourceView.window?.screen.scale ?? UIScreen.main.scale
+        let captureStart = CACurrentMediaTime()
+        let result = makeTextureByRenderingLayer(sourceView.layer, captureRect: captureRect, scale: scale)
+        let renderMs = (result.renderFinishedAt - captureStart) * 1000
+        let textureMs = (CACurrentMediaTime() - result.renderFinishedAt) * 1000
+        let texture = result.texture
+        sourceTexture = texture
+
+        debugCaptureCount += 1
+        debugLog(
+            "capture \(texture == nil ? "failed" : "ok") #\(debugCaptureCount) strategy=layer.render.direct reason=\(reason) afterUpdates=\(afterScreenUpdates) src=\(sourceView.bounds.size.debugDescription) rect=\(captureRect.debugDescription) px=\(result.pixelWidth)x\(result.pixelHeight) scale=\(String(format: "%.1f", scale)) renderMs=\(String(format: "%.1f", renderMs)) textureMs=\(String(format: "%.1f", textureMs))",
+            throttleKey: texture == nil ? "capture-fail" : nil,
+            interval: 0.5
+        )
+        return texture != nil
+    }
+
+    private func resolvedSourceCaptureRect(in sourceView: UIView) -> CGRect {
+        let requestedRect = sourceCaptureRect ?? sourceView.bounds
+        return requestedRect
+            .standardized
+            .intersection(sourceView.bounds)
+    }
+
+    private func makeTextureByRenderingLayer(
+        _ layer: CALayer,
+        captureRect: CGRect,
+        scale: CGFloat
+    ) -> (texture: MTLTexture?, pixelWidth: Int, pixelHeight: Int, renderFinishedAt: CFTimeInterval) {
+        let width = max(1, Int(ceil(captureRect.width * scale)))
+        let height = max(1, Int(ceil(captureRect.height * scale)))
+        guard width > 0, height > 0 else {
+            debugLog("texture failed invalid-size \(width)x\(height)")
+            return (nil, width, height, CACurrentMediaTime())
+        }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+            | CGBitmapInfo.byteOrder32Little.rawValue
+
+        let drewImage = pixels.withUnsafeMutableBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress,
+                  let context = CGContext(
+                    data: baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: bitmapInfo
+                  )
+            else { return false }
+
+            context.interpolationQuality = .high
+            context.translateBy(x: 0, y: CGFloat(height))
+            context.scaleBy(x: scale, y: -scale)
+            context.translateBy(x: -captureRect.minX, y: -captureRect.minY)
+            layer.render(in: context)
+            return true
+        }
+        let renderFinishedAt = CACurrentMediaTime()
+
+        guard drewImage else {
+            debugLog("texture failed bitmap-context width=\(width) height=\(height) bytesPerRow=\(bytesPerRow)")
+            return (nil, width, height, renderFinishedAt)
+        }
+
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        descriptor.usage = [.shaderRead]
+        descriptor.storageMode = .shared
+
+        guard let texture = MetalContext.shared.device.makeTexture(descriptor: descriptor) else {
+            debugLog("texture failed makeTexture width=\(width) height=\(height)")
+            return (nil, width, height, renderFinishedAt)
+        }
+
+        texture.replace(
+            region: MTLRegionMake2D(0, 0, width, height),
+            mipmapLevel: 0,
+            withBytes: pixels,
+            bytesPerRow: bytesPerRow
+        )
+        return (texture, width, height, renderFinishedAt)
+    }
+
+    private func scheduleRenderRetry(reason: String) {
+        guard window != nil else {
+            debugLog("retry skip no-window reason=\(reason)", throttleKey: "retry-no-window", interval: 0.5)
+            return
+        }
+
+        guard !renderRetryScheduled else {
+            debugLog("retry already scheduled reason=\(reason)", throttleKey: "retry-already", interval: 0.5)
+            return
+        }
+
+        renderRetryScheduled = true
+        debugRetryCount += 1
+        debugLog(
+            "retry scheduled #\(debugRetryCount) reason=\(reason) progress=\(lensProgress)",
+            throttleKey: "retry-\(reason)",
+            interval: 0.35
+        )
+        let delay: TimeInterval = reason == "no-source-texture" ? 0.12 : 0.016
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self else { return }
+
+            self.renderRetryScheduled = false
+            self.debugLog("retry fired reason=\(reason)", throttleKey: "retry-fired-\(reason)", interval: 0.35)
+            self.setNeedsRender()
+        }
+    }
+
+    private func render() {
+        debugRenderAttemptCount += 1
+        let renderAttempt = debugRenderAttemptCount
+        let renderStart = CACurrentMediaTime()
+
+        guard bounds.width > 1,
+              bounds.height > 1
+        else {
+            debugLog(
+                "render skip #\(renderAttempt) invalid-bounds bounds=\(bounds.debugDescription)",
+                throttleKey: "render-invalid-bounds",
+                interval: 0.5
+            )
+            scheduleRenderRetry(reason: "invalid-bounds")
+            return
+        }
+
+        guard let pipelineState = Self.pipelineState else {
+            debugLog("render abort #\(renderAttempt) missing-pipeline", throttleKey: "render-missing-pipeline", interval: 5)
+            return
+        }
+
+        guard !frameInFlight else {
+            needsRender = true
+            debugLog(
+                "render defer #\(renderAttempt) frameInFlight progress=\(lensProgress)",
+                throttleKey: "render-frame-in-flight",
+                interval: 0.35
+            )
+            return
+        }
+
+        if sourceTexture == nil {
+            captureSourceTexture(reason: "render")
+        }
+
+        guard let sourceTexture else {
+            debugLog(
+                "render skip #\(renderAttempt) no-source-texture progress=\(lensProgress)",
+                throttleKey: "render-no-source-texture",
+                interval: 0.35
+            )
+            scheduleRenderRetry(reason: "no-source-texture")
+            return
+        }
+
+        frameInFlight = true
+        renderAsync(RenderPayload(
+            pipelineState: pipelineState,
+            sourceTexture: sourceTexture,
+            metalLayer: metalLayer,
+            vertices: makeVertices(),
+            uniforms: makeUniforms(),
+            renderAttempt: renderAttempt,
+            renderStart: renderStart
+        ))
+    }
+
+    private func renderAsync(_ payload: RenderPayload) {
+        let handleEvent: (RenderEvent) -> Void = { [weak self] event in
+            DispatchQueue.main.async {
+                guard let self else { return }
+
+                switch event {
+                case let .noDrawable(drawableMs):
+                    self.frameInFlight = false
+                    self.debugLog(
+                        "render skip #\(payload.renderAttempt) no-drawable drawableMs=\(String(format: "%.1f", drawableMs)) drawableSize=\(payload.metalLayer.drawableSize.debugDescription)",
+                        throttleKey: "render-no-drawable",
+                        interval: 0.35
+                    )
+                    self.setNeedsRender()
+                case .noCommandBuffer:
+                    self.frameInFlight = false
+                    self.debugLog(
+                        "render skip #\(payload.renderAttempt) no-command-buffer",
+                        throttleKey: "render-no-command-buffer",
+                        interval: 0.5
+                    )
+                    self.scheduleRenderRetry(reason: "no-command-buffer")
+                case .noEncoder:
+                    self.frameInFlight = false
+                    self.debugLog(
+                        "render skip #\(payload.renderAttempt) no-encoder",
+                        throttleKey: "render-no-encoder",
+                        interval: 0.5
+                    )
+                    self.setNeedsRender()
+                case let .slowDrawable(drawableMs):
+                    self.debugLog(
+                        "render slow nextDrawable #\(payload.renderAttempt) drawableMs=\(String(format: "%.1f", drawableMs))",
+                        throttleKey: "render-slow-drawable",
+                        interval: 0.25
+                    )
+                case let .committed(drawableMs):
+                    self.debugRenderedFrameCount += 1
+                    let totalMs = (CACurrentMediaTime() - payload.renderStart) * 1000
+                    let shouldForceLog = self.debugRenderedFrameCount <= 3 || totalMs > 8 || drawableMs > 4
+                    self.debugLog(
+                        "render ok frame=\(self.debugRenderedFrameCount) attempt=\(payload.renderAttempt) progress=\(String(format: "%.3f", payload.uniforms.progress)) totalMs=\(String(format: "%.1f", totalMs)) drawableMs=\(String(format: "%.1f", drawableMs)) texture=\(payload.sourceTexture.width)x\(payload.sourceTexture.height)",
+                        throttleKey: shouldForceLog ? nil : "render-ok",
+                        interval: 1.0
+                    )
+                case .completed:
+                    self.frameInFlight = false
+                    if self.needsRender, self.displayLinkToken == nil {
+                        self.needsRender = false
+                        self.render()
+                    }
+                }
+            }
+        }
+
+        renderQueue.async {
+            guard let commandBuffer = MetalContext.shared.commandQueue.makeCommandBuffer() else {
+                handleEvent(.noCommandBuffer)
+                return
+            }
+
+            let drawableStart = CACurrentMediaTime()
+            guard let drawable = payload.metalLayer.nextDrawable() else {
+                handleEvent(.noDrawable((CACurrentMediaTime() - drawableStart) * 1000))
+                return
+            }
+
+            let drawableMs = (CACurrentMediaTime() - drawableStart) * 1000
+            if drawableMs > 4 {
+                handleEvent(.slowDrawable(drawableMs))
+            }
+
+            let descriptor = MTLRenderPassDescriptor()
+            descriptor.colorAttachments[0].texture = drawable.texture
+            descriptor.colorAttachments[0].loadAction = .clear
+            descriptor.colorAttachments[0].storeAction = .store
+            descriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+            guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else {
+                commandBuffer.commit()
+                handleEvent(.noEncoder)
+                return
+            }
+
+            var vertices = payload.vertices
+            var uniforms = payload.uniforms
+            encoder.setRenderPipelineState(payload.pipelineState)
+            encoder.setVertexBytes(
+                &vertices,
+                length: MemoryLayout<QuadVertex>.stride * vertices.count,
+                index: 0
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 0)
+            encoder.setFragmentTexture(payload.sourceTexture, index: 0)
+            encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: vertices.count)
+            encoder.endEncoding()
+
+            commandBuffer.addCompletedHandler { _ in
+                handleEvent(.completed)
+            }
+            commandBuffer.present(drawable)
+            commandBuffer.commit()
+            handleEvent(.committed(drawableMs))
+        }
+    }
+
+    private func makeVertices() -> [QuadVertex] {
+        [
+            QuadVertex(position: SIMD2<Float>(-1, -1), uv: SIMD2<Float>(0, 1)),
+            QuadVertex(position: SIMD2<Float>(1, -1), uv: SIMD2<Float>(1, 1)),
+            QuadVertex(position: SIMD2<Float>(-1, 1), uv: SIMD2<Float>(0, 0)),
+            QuadVertex(position: SIMD2<Float>(1, 1), uv: SIMD2<Float>(1, 0))
+        ]
+    }
+
+    private func makeUniforms() -> Uniforms {
+        let width = max(bounds.width, 1)
+        let height = max(bounds.height, 1)
+        let drawableSize = metalLayer.drawableSize
+        let darkRimStrength: Float
+        switch traitCollection.userInterfaceStyle {
+        case .dark:
+            darkRimStrength = 1.0
+        case .light:
+            darkRimStrength = 0.52
+        default:
+            darkRimStrength = 0.72
+        }
+        let rect = SIMD4<Float>(
+            Float(cardFrame.minX / width),
+            Float(cardFrame.minY / height),
+            Float(cardFrame.width / width),
+            Float(cardFrame.height / height)
+        )
+        return Uniforms(
+            resolution: SIMD2<Float>(
+                Float(max(drawableSize.width, 1)),
+                Float(max(drawableSize.height, 1))
+            ),
+            viewSize: SIMD2<Float>(Float(width), Float(height)),
+            cardRect: rect,
+            cornerRadius: Float(cardCornerRadius / height),
+            progress: Float(lensProgress),
+            time: Float(CACurrentMediaTime() - startTime),
+            impulse: Float(sin(lensProgress * .pi)),
+            effectParams: SIMD4<Float>(darkRimStrength, 0, 0, 0)
+        )
+    }
+}

--- a/Zyna/Screens/Rooms/ChatPeek/ChatPeekOverlayController.swift
+++ b/Zyna/Screens/Rooms/ChatPeek/ChatPeekOverlayController.swift
@@ -9,7 +9,10 @@ final class ChatPeekOverlayController: UIViewController {
 
     private let chatController: ChatViewController
     private let sourceFrameInScreen: CGRect?
+    private weak var backgroundSourceView: UIView?
+    private let backgroundLensView = ChatPeekMetalBackgroundView()
     private let dimmingView = UIView()
+    private let pressureRimView = ChatPeekPressureRimView()
     private let shadowView = UIView()
     private let clippingView = UIView()
     private var didApplyInitialState = false
@@ -17,9 +20,14 @@ final class ChatPeekOverlayController: UIViewController {
     private var isDismissingOverlay = false
     private var currentTargetFrame: CGRect = .zero
 
-    init(chatController: ChatViewController, sourceFrameInScreen: CGRect?) {
+    init(
+        chatController: ChatViewController,
+        sourceFrameInScreen: CGRect?,
+        backgroundSourceView: UIView?
+    ) {
         self.chatController = chatController
         self.sourceFrameInScreen = sourceFrameInScreen
+        self.backgroundSourceView = backgroundSourceView
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
         modalTransitionStyle = .crossDissolve
@@ -34,12 +42,21 @@ final class ChatPeekOverlayController: UIViewController {
 
         view.backgroundColor = .clear
 
+        backgroundLensView.alpha = 0
+        backgroundLensView.progress = 0
+        backgroundLensView.sourceView = backgroundSourceView
+        view.addSubview(backgroundLensView)
+
         dimmingView.backgroundColor = UIColor.black.withAlphaComponent(0.28)
         dimmingView.alpha = 0
         view.addSubview(dimmingView)
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
         dimmingView.addGestureRecognizer(tap)
+
+        pressureRimView.alpha = 0
+        pressureRimView.isHidden = true
+        view.addSubview(pressureRimView)
 
         shadowView.backgroundColor = .clear
         shadowView.layer.shadowColor = UIColor.black.cgColor
@@ -63,10 +80,18 @@ final class ChatPeekOverlayController: UIViewController {
         super.viewDidLayoutSubviews()
 
         dimmingView.frame = view.bounds
+        let lensFrame = backgroundLensFrame()
+        backgroundLensView.frame = lensFrame
+        backgroundLensView.sourceCaptureRect = sourceCaptureRect(for: lensFrame)
+        pressureRimView.frame = view.bounds
         guard !isDismissingOverlay else { return }
 
         let frame = targetFrame()
         currentTargetFrame = frame
+        backgroundLensView.cardFrame = view.convert(frame, to: backgroundLensView)
+        backgroundLensView.cardCornerRadius = clippingView.layer.cornerRadius
+        pressureRimView.cardFrame = frame
+        pressureRimView.cornerRadius = clippingView.layer.cornerRadius
         shadowView.frame = frame
         clippingView.frame = shadowView.bounds
         chatController.view.frame = clippingView.bounds
@@ -78,6 +103,36 @@ final class ChatPeekOverlayController: UIViewController {
         if !didApplyInitialState {
             applyInitialState(targetFrame: frame)
         }
+    }
+
+    private func backgroundLensFrame() -> CGRect {
+        var frame = view.bounds
+        guard let tabBarFrame = tabBarFrameInOverlay(),
+              tabBarFrame.minY > frame.minY,
+              tabBarFrame.minY < frame.maxY
+        else { return frame }
+
+        frame.size.height = max(1, tabBarFrame.minY - frame.minY)
+        return frame
+    }
+
+    private func sourceCaptureRect(for lensFrame: CGRect) -> CGRect? {
+        guard let backgroundSourceView else { return nil }
+        return backgroundSourceView
+            .convert(lensFrame, from: view)
+            .standardized
+            .intersection(backgroundSourceView.bounds)
+    }
+
+    private func tabBarFrameInOverlay() -> CGRect? {
+        guard let tabBar = backgroundSourceView?
+            .subviews
+            .first(where: { $0 is ZynaTabBar && !$0.isHidden && $0.alpha > 0.01 })
+        else { return nil }
+
+        let frame = view.convert(tabBar.bounds, from: tabBar)
+        guard frame.width > 1, frame.height > 1 else { return nil }
+        return frame
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -148,6 +203,11 @@ final class ChatPeekOverlayController: UIViewController {
         guard !didAnimateIn else { return }
         didAnimateIn = true
 
+        backgroundLensView.animateProgress(
+            to: 1,
+            duration: 0.24,
+            curve: .easeOut
+        )
         UIView.animate(
             withDuration: 0.24,
             delay: 0,
@@ -155,7 +215,9 @@ final class ChatPeekOverlayController: UIViewController {
             initialSpringVelocity: 0,
             options: [.beginFromCurrentState, .allowUserInteraction]
         ) {
+            self.backgroundLensView.alpha = 1
             self.dimmingView.alpha = 1
+            self.pressureRimView.alpha = 1
             self.shadowView.alpha = 1
             self.shadowView.center = CGPoint(x: self.currentTargetFrame.midX, y: self.currentTargetFrame.midY)
             self.shadowView.transform = .identity
@@ -167,13 +229,26 @@ final class ChatPeekOverlayController: UIViewController {
         isDismissingOverlay = true
 
         let sourceState = sourceState(targetFrame: currentTargetFrame)
+        let closeDuration: TimeInterval = 0.26
 
+        backgroundLensView.alpha = 1
+        backgroundLensView.animateProgress(
+            to: 0,
+            duration: closeDuration,
+            curve: .easeOut,
+            completion: { [weak self] in
+                guard let self else { return }
+                self.backgroundLensView.progress = 0
+                self.dismiss(animated: false)
+            }
+        )
         UIView.animate(
-            withDuration: 0.2,
+            withDuration: closeDuration,
             delay: 0,
-            options: [.beginFromCurrentState, .curveEaseIn]
+            options: [.beginFromCurrentState, .curveEaseInOut]
         ) {
             self.dimmingView.alpha = 0
+            self.pressureRimView.alpha = 0
             self.shadowView.alpha = 0
             if let sourceState {
                 self.shadowView.center = sourceState.center
@@ -181,8 +256,6 @@ final class ChatPeekOverlayController: UIViewController {
             } else {
                 self.shadowView.transform = CGAffineTransform(scaleX: 0.94, y: 0.94)
             }
-        } completion: { _ in
-            self.dismiss(animated: false)
         }
     }
 }

--- a/Zyna/Screens/Rooms/ChatPeek/ChatPeekPressureRimView.swift
+++ b/Zyna/Screens/Rooms/ChatPeek/ChatPeekPressureRimView.swift
@@ -1,0 +1,100 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import UIKit
+
+final class ChatPeekPressureRimView: UIView {
+
+    var cardFrame: CGRect = .zero {
+        didSet {
+            guard !cardFrame.equalTo(oldValue) else { return }
+            updatePaths()
+        }
+    }
+
+    var cornerRadius: CGFloat = 24 {
+        didSet {
+            guard cornerRadius != oldValue else { return }
+            updatePaths()
+        }
+    }
+
+    private let outerShadowLayer = CAShapeLayer()
+    private let highlightLayer = CAShapeLayer()
+    private let innerShadeLayer = CAShapeLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+
+        outerShadowLayer.fillColor = UIColor.clear.cgColor
+        outerShadowLayer.lineJoin = .round
+        outerShadowLayer.lineCap = .round
+        outerShadowLayer.shadowColor = UIColor.black.cgColor
+        outerShadowLayer.strokeColor = UIColor.black.withAlphaComponent(0.18).cgColor
+        outerShadowLayer.lineWidth = 16
+        outerShadowLayer.opacity = 0.48
+        outerShadowLayer.shadowOpacity = 0.16
+        outerShadowLayer.shadowRadius = 18
+        outerShadowLayer.shadowOffset = CGSize(width: 0, height: 10)
+        layer.addSublayer(outerShadowLayer)
+
+        innerShadeLayer.fillColor = UIColor.clear.cgColor
+        innerShadeLayer.strokeColor = UIColor.black.withAlphaComponent(0.18).cgColor
+        innerShadeLayer.lineWidth = 3
+        innerShadeLayer.opacity = 0.42
+        layer.addSublayer(innerShadeLayer)
+
+        highlightLayer.fillColor = UIColor.clear.cgColor
+        highlightLayer.strokeColor = UIColor.white.withAlphaComponent(0.34).cgColor
+        highlightLayer.lineWidth = 1.2
+        highlightLayer.opacity = 0.72
+        highlightLayer.shadowColor = UIColor.white.cgColor
+        highlightLayer.shadowOpacity = 0.22
+        highlightLayer.shadowRadius = 5
+        highlightLayer.shadowOffset = CGSize(width: 0, height: -1)
+        layer.addSublayer(highlightLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        outerShadowLayer.frame = bounds
+        highlightLayer.frame = bounds
+        innerShadeLayer.frame = bounds
+        updatePaths()
+    }
+
+    private func updatePaths() {
+        guard bounds.width > 0,
+              bounds.height > 0,
+              !cardFrame.isEmpty
+        else { return }
+
+        let outerInset: CGFloat = -5
+        let innerInset: CGFloat = 1.5
+        let highlightInset: CGFloat = -1.5
+        let outerRect = cardFrame.insetBy(dx: outerInset, dy: outerInset)
+        let innerRect = cardFrame.insetBy(dx: innerInset, dy: innerInset)
+        let highlightRect = cardFrame.insetBy(dx: highlightInset, dy: highlightInset)
+        outerShadowLayer.path = UIBezierPath(
+            roundedRect: outerRect,
+            cornerRadius: cornerRadius - outerInset
+        ).cgPath
+        innerShadeLayer.path = UIBezierPath(
+            roundedRect: innerRect,
+            cornerRadius: max(0, cornerRadius - innerInset)
+        ).cgPath
+        highlightLayer.path = UIBezierPath(
+            roundedRect: highlightRect,
+            cornerRadius: cornerRadius - highlightInset
+        ).cgPath
+    }
+}

--- a/Zyna/Screens/Rooms/RoomsController.swift
+++ b/Zyna/Screens/Rooms/RoomsController.swift
@@ -19,7 +19,7 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
         set { viewModel.onChatSelected = newValue }
     }
 
-    var onChatPreviewRequested: ((Room, CGRect?) -> Void)?
+    var onChatPreviewRequested: ((Room, CGRect?, UIView?) -> Void)?
     var onComposeTapped: (() -> Void)?
 
     private weak var previewPressRecognizer: UILongPressGestureRecognizer?
@@ -182,8 +182,23 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
                   self.pendingPreviewResolutionGeneration == generation
             else { return }
             self.pendingPreviewResolutionGeneration = nil
-            self.onChatPreviewRequested?(room, sourceFrame)
+            self.onChatPreviewRequested?(room, sourceFrame, self.backgroundPreviewSourceView())
         }
+    }
+
+    private func backgroundPreviewSourceView() -> UIView {
+        var current: UIViewController? = self
+        while let controller = current {
+            if controller is ZynaTabBarController {
+                return controller.view
+            }
+            current = controller.parent
+        }
+
+        return navigationController?.parent?.view
+            ?? navigationController?.view
+            ?? view.superview
+            ?? view
     }
 
     private func clearSelectionSuppressionSoon() {

--- a/Zyna/Screens/Rooms/RoomsController.swift
+++ b/Zyna/Screens/Rooms/RoomsController.swift
@@ -19,7 +19,14 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
         set { viewModel.onChatSelected = newValue }
     }
 
+    var onChatPreviewRequested: ((Room, CGRect?) -> Void)?
     var onComposeTapped: (() -> Void)?
+
+    private weak var previewPressRecognizer: UILongPressGestureRecognizer?
+    private lazy var previewPressInteraction = RoomsPreviewPressInteraction(tableNode: tableNode)
+    private var suppressSelectionIndexPath: IndexPath?
+    private var previewResolutionGeneration = 0
+    private var pendingPreviewResolutionGeneration: Int?
 
     override init() {
         super.init(node: RoomsScreenNode())
@@ -73,6 +80,8 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
     }
 
     private func applyTableUpdate(_ update: RoomsTableUpdate) {
+        previewPressInteraction.cancel(animated: false)
+
         switch update {
         case .none:
             break
@@ -102,6 +111,7 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        previewPressInteraction.cancel(animated: false)
         viewModel.unregisterPresence()
     }
 
@@ -114,11 +124,74 @@ class RoomsViewController: ASDKViewController<ASDisplayNode> {
         tap.cancelsTouchesInView = false
         tableNode.view.addGestureRecognizer(tap)
 
+        previewPressInteraction.onActivate = { [weak self] indexPath, sourceFrame in
+            self?.activateChatPreview(at: indexPath, sourceFrame: sourceFrame)
+        }
+
+        let previewPress = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(chatPreviewLongPressed(_:))
+        )
+        previewPress.minimumPressDuration = 0
+        previewPress.cancelsTouchesInView = false
+        previewPress.delegate = self
+        tableNode.view.addGestureRecognizer(previewPress)
+        previewPressRecognizer = previewPress
+
         setupHeaderBar()
     }
 
     @objc private func dismissKeyboard() {
         view.endEditing(true)
+    }
+
+    @objc private func chatPreviewLongPressed(_ gesture: UILongPressGestureRecognizer) {
+        let point = gesture.location(in: tableNode.view)
+
+        switch gesture.state {
+        case .began:
+            previewPressInteraction.begin(at: point)
+        case .changed:
+            previewPressInteraction.update(to: point)
+        case .cancelled, .failed, .ended:
+            previewPressInteraction.cancel()
+            clearSelectionSuppressionSoon()
+        default:
+            break
+        }
+    }
+
+    private func activateChatPreview(at indexPath: IndexPath, sourceFrame: CGRect?) {
+        guard viewModel.chats.indices.contains(indexPath.row) else { return }
+
+        previewResolutionGeneration += 1
+        let generation = previewResolutionGeneration
+        pendingPreviewResolutionGeneration = generation
+        suppressSelectionIndexPath = indexPath
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+            guard let self else { return }
+            if self.pendingPreviewResolutionGeneration == generation {
+                self.pendingPreviewResolutionGeneration = nil
+            }
+        }
+
+        viewModel.resolveChat(at: indexPath.row) { [weak self] room in
+            guard let self,
+                  self.pendingPreviewResolutionGeneration == generation
+            else { return }
+            self.pendingPreviewResolutionGeneration = nil
+            self.onChatPreviewRequested?(room, sourceFrame)
+        }
+    }
+
+    private func clearSelectionSuppressionSoon() {
+        guard let indexPath = suppressSelectionIndexPath else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            guard self?.suppressSelectionIndexPath == indexPath else { return }
+            self?.suppressSelectionIndexPath = nil
+        }
     }
 
     // MARK: - Glass Top Bar
@@ -177,6 +250,10 @@ extension RoomsViewController: ASTableDataSource, ASTableDelegate {
 
     func tableNode(_ tableNode: ASTableNode, didSelectRowAt indexPath: IndexPath) {
         tableNode.deselectRow(at: indexPath, animated: true)
+        if suppressSelectionIndexPath == indexPath {
+            suppressSelectionIndexPath = nil
+            return
+        }
         view.endEditing(true)
         viewModel.selectChat(at: indexPath.row)
     }
@@ -199,6 +276,7 @@ extension RoomsViewController {
 
 extension RoomsViewController {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        previewPressInteraction.cancelForScroll()
         GlassService.shared.setNeedsCapture()
     }
 
@@ -210,6 +288,217 @@ extension RoomsViewController {
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         fpsBooster.stop()
+    }
+}
+
+extension RoomsViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let previewPressRecognizer, gestureRecognizer === previewPressRecognizer else { return true }
+        guard !tableNode.view.isDragging, !tableNode.view.isDecelerating else { return false }
+
+        let point = gestureRecognizer.location(in: tableNode.view)
+        guard let indexPath = tableNode.indexPathForRow(at: point),
+              viewModel.chats.indices.contains(indexPath.row)
+        else { return false }
+
+        return true
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+    ) -> Bool {
+        guard let previewPressRecognizer, gestureRecognizer === previewPressRecognizer else { return false }
+        return other === tableNode.view.panGestureRecognizer
+    }
+}
+
+private final class RoomsPreviewPressInteraction {
+    private enum Metrics {
+        static let feedbackDelay: TimeInterval = 0.06
+        static let activationDelay: TimeInterval = 0.34
+        static let movementCancelDistance: CGFloat = 10
+        static let allowedCellExitInset: CGFloat = 24
+        static let pressedScale: CGFloat = 0.965
+        static let pressDuration: TimeInterval = 0.12
+        static let restoreDuration: TimeInterval = 0.16
+    }
+
+    private weak var tableNode: ASTableNode?
+    private weak var activeCellNode: ASCellNode?
+    private var activeIndexPath: IndexPath?
+    private var startPoint: CGPoint = .zero
+    private var feedbackWork: DispatchWorkItem?
+    private var activationWork: DispatchWorkItem?
+    private var animator: UIViewPropertyAnimator?
+    private weak var suspendedScrollView: UIScrollView?
+    private var suspendedScrollWasEnabled = true
+
+    var onActivate: ((IndexPath, CGRect?) -> Void)?
+
+    init(tableNode: ASTableNode) {
+        self.tableNode = tableNode
+    }
+
+    func begin(at point: CGPoint) {
+        cancel(animated: false)
+
+        guard let tableNode,
+              let indexPath = tableNode.indexPathForRow(at: point),
+              let cellNode = tableNode.nodeForRow(at: indexPath)
+        else { return }
+
+        activeIndexPath = indexPath
+        activeCellNode = cellNode
+        startPoint = point
+
+        let feedbackWork = DispatchWorkItem { [weak self, weak cellNode] in
+            guard let self,
+                  self.activeIndexPath == indexPath,
+                  let cellNode
+            else { return }
+            self.animate(
+                cellNode.view,
+                to: CGAffineTransform(scaleX: Metrics.pressedScale, y: Metrics.pressedScale),
+                duration: Metrics.pressDuration
+            )
+        }
+        self.feedbackWork = feedbackWork
+        DispatchQueue.main.asyncAfter(deadline: .now() + Metrics.feedbackDelay, execute: feedbackWork)
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.activate()
+        }
+        activationWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Metrics.activationDelay, execute: work)
+    }
+
+    func update(to point: CGPoint) {
+        guard activeIndexPath != nil else { return }
+        guard let tableNode else {
+            cancel()
+            return
+        }
+
+        let dx = point.x - startPoint.x
+        let dy = point.y - startPoint.y
+        let didMoveTowardScroll = hypot(dx, dy) > Metrics.movementCancelDistance && abs(dy) > abs(dx)
+        if tableNode.view.isDragging || tableNode.view.isDecelerating || didMoveTowardScroll {
+            cancel()
+            return
+        }
+
+        if let cellView = activeCellNode?.view {
+            let pointInCell = tableNode.view.convert(point, to: cellView)
+            let allowedBounds = cellView.bounds.insetBy(
+                dx: -Metrics.allowedCellExitInset,
+                dy: -Metrics.allowedCellExitInset
+            )
+            if !allowedBounds.contains(pointInCell) {
+                cancel()
+            }
+        }
+    }
+
+    func cancelForScroll() {
+        guard activeIndexPath != nil,
+              tableNode?.view.isDragging == true
+        else { return }
+        cancel()
+    }
+
+    func cancel(animated: Bool = true) {
+        releaseScrollSuspension()
+        feedbackWork?.cancel()
+        feedbackWork = nil
+        activationWork?.cancel()
+        activationWork = nil
+
+        if let cellView = activeCellNode?.view {
+            restore(cellView, animated: animated)
+        }
+
+        activeIndexPath = nil
+        activeCellNode = nil
+    }
+
+    private func activate() {
+        feedbackWork?.cancel()
+        feedbackWork = nil
+        activationWork = nil
+
+        guard let tableNode,
+              let indexPath = activeIndexPath,
+              tableNode.view.isDragging == false,
+              tableNode.view.isDecelerating == false
+        else {
+            cancel()
+            return
+        }
+
+        let sourceFrame = previewSourceFrame(for: indexPath)
+        suspendScrollForActiveTouch()
+        if let cellView = activeCellNode?.view {
+            restore(cellView, animated: true)
+        }
+
+        activeIndexPath = nil
+        activeCellNode = nil
+        onActivate?(indexPath, sourceFrame)
+    }
+
+    private func previewSourceFrame(for indexPath: IndexPath) -> CGRect? {
+        guard let tableNode else { return nil }
+
+        if let cellNode = tableNode.nodeForRow(at: indexPath), cellNode.isNodeLoaded {
+            return cellNode.view.convert(cellNode.view.bounds, to: nil)
+        }
+
+        let rect = tableNode.view.rectForRow(at: indexPath)
+        guard !rect.isNull, !rect.isEmpty else { return nil }
+        return tableNode.view.convert(rect, to: nil)
+    }
+
+    private func suspendScrollForActiveTouch() {
+        guard suspendedScrollView == nil,
+              let scrollView = tableNode?.view
+        else { return }
+
+        suspendedScrollView = scrollView
+        suspendedScrollWasEnabled = scrollView.isScrollEnabled
+        scrollView.panGestureRecognizer.isEnabled = false
+        scrollView.panGestureRecognizer.isEnabled = true
+        scrollView.isScrollEnabled = false
+    }
+
+    private func releaseScrollSuspension() {
+        guard let scrollView = suspendedScrollView else { return }
+        scrollView.isScrollEnabled = suspendedScrollWasEnabled
+        suspendedScrollView = nil
+        suspendedScrollWasEnabled = true
+    }
+
+    private func restore(_ view: UIView, animated: Bool) {
+        if animated {
+            animate(view, to: .identity, duration: Metrics.restoreDuration)
+        } else {
+            animator?.stopAnimation(true)
+            animator = nil
+            view.transform = .identity
+        }
+    }
+
+    private func animate(_ view: UIView, to transform: CGAffineTransform, duration: TimeInterval) {
+        animator?.stopAnimation(true)
+        let animator = UIViewPropertyAnimator(duration: duration, curve: .easeOut) {
+            view.transform = transform
+        }
+        self.animator = animator
+        animator.addCompletion { [weak self, weak animator] _ in
+            guard let self, self.animator === animator else { return }
+            self.animator = nil
+        }
+        animator.startAnimation()
     }
 }
 

--- a/Zyna/Screens/Rooms/RoomsViewModel.swift
+++ b/Zyna/Screens/Rooms/RoomsViewModel.swift
@@ -148,10 +148,20 @@ final class RoomsViewModel {
     // MARK: - Actions
 
     func selectChat(at index: Int) {
-        guard index < chats.count else { return }
+        resolveChat(at: index) { [weak self] room in
+            self?.onChatSelected?(room)
+        }
+    }
+
+    func resolveChat(at index: Int, completion: @escaping (Room) -> Void) {
+        guard chats.indices.contains(index) else { return }
         let roomId = chats[index].id
+        resolveChat(roomId: roomId, completion: completion)
+    }
+
+    private func resolveChat(roomId: String, completion: @escaping (Room) -> Void) {
         if let room = roomListService.room(for: roomId) {
-            onChatSelected?(room)
+            completion(room)
             return
         }
         // SDK not ready yet (rooms visible from GRDB cache).
@@ -160,7 +170,7 @@ final class RoomsViewModel {
             for _ in 0..<20 {
                 try? await Task.sleep(for: .milliseconds(500))
                 if let room = self.roomListService.room(for: roomId) {
-                    self.onChatSelected?(room)
+                    completion(room)
                     return
                 }
             }

--- a/Zyna/Screens/Settings/ChatThemeSettingsView.swift
+++ b/Zyna/Screens/Settings/ChatThemeSettingsView.swift
@@ -1,0 +1,520 @@
+//
+// Copyright 2026 Dmitry Markovsky
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AsyncDisplayKit
+
+final class ChatThemeSettingsViewController: ASDKViewController<SettingsScreenNode> {
+
+    var onBack: (() -> Void)?
+
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private let glassTopBar = GlassTopBar()
+    private let previewHeaderView = UIView()
+    private let previousThemeButton = UIButton(type: .system)
+    private let nextThemeButton = UIButton(type: .system)
+    private let themeTitleLabel = UILabel()
+    private let previewView: ChatThemePreviewView
+    private var selectedTheme: ChatBubbleTheme
+    private var selectedThemeIndex: Int
+
+    override init() {
+        let theme = ChatBubbleThemeStore.shared.selectedTheme
+        self.selectedTheme = theme
+        self.selectedThemeIndex = ChatBubbleTheme.all.firstIndex(of: theme) ?? 0
+        self.previewView = ChatThemePreviewView(theme: theme)
+        super.init(node: SettingsScreenNode())
+        hidesBottomBarWhenPushed = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+        setupGlassTopBar()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        GlassService.shared.setNeedsCapture()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.frame = view.bounds
+        glassTopBar.updateLayout(in: view)
+        updateTableInsets()
+        updatePreviewHeaderLayout()
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = .appBG
+        tableView.separatorStyle = .singleLine
+        tableView.contentInsetAdjustmentBehavior = .never
+        tableView.rowHeight = 56
+        setupPreviewControls()
+        previewHeaderView.addSubview(previewView)
+        tableView.tableHeaderView = previewHeaderView
+        view.addSubview(tableView)
+        node.tableView = tableView
+    }
+
+    private func setupPreviewControls() {
+        themeTitleLabel.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        themeTitleLabel.textColor = .label
+        themeTitleLabel.textAlignment = .center
+        themeTitleLabel.adjustsFontSizeToFitWidth = true
+        themeTitleLabel.minimumScaleFactor = 0.8
+        previewHeaderView.addSubview(themeTitleLabel)
+
+        configureThemeStepButton(
+            previousThemeButton,
+            icon: AppIcon.chevronBackward.rendered(size: 17, weight: .semibold, color: AppColor.accent),
+            accessibilityLabel: String(localized: "Previous Theme"),
+            action: #selector(previousThemeTapped)
+        )
+        configureThemeStepButton(
+            nextThemeButton,
+            icon: AppIcon.chevronForward.rendered(size: 17, weight: .semibold, color: AppColor.accent),
+            accessibilityLabel: String(localized: "Next Theme"),
+            action: #selector(nextThemeTapped)
+        )
+        updateThemeControls()
+    }
+
+    private func configureThemeStepButton(
+        _ button: UIButton,
+        icon: UIImage,
+        accessibilityLabel: String,
+        action: Selector
+    ) {
+        button.setImage(icon, for: .normal)
+        button.backgroundColor = .secondarySystemGroupedBackground
+        button.layer.cornerRadius = 17
+        button.clipsToBounds = true
+        button.accessibilityLabel = accessibilityLabel
+        button.addTarget(self, action: action, for: .touchUpInside)
+        previewHeaderView.addSubview(button)
+    }
+
+    private func setupGlassTopBar() {
+        glassTopBar.backdropClearColor = .appBG
+        glassTopBar.sourceView = tableView
+        node.addSubnode(glassTopBar)
+        node.glassTopBar = glassTopBar
+
+        let backIcon = AppIcon.chevronBackward.rendered(
+            size: 17,
+            weight: .semibold,
+            color: AppColor.accent
+        )
+        glassTopBar.items = [
+            .circleButton(
+                icon: backIcon,
+                accessibilityLabel: String(localized: "Back"),
+                action: { [weak self] in self?.onBack?() }
+            ),
+            .title(text: String(localized: "Chat Theme"), subtitle: nil)
+        ]
+    }
+
+    private func updateTableInsets() {
+        let top = glassTopBar.coveredHeight
+        if abs(tableView.contentInset.top - top) > 0.5 {
+            tableView.contentInset.top = top
+            tableView.verticalScrollIndicatorInsets.top = top
+        }
+        let bottom = max(view.safeAreaInsets.bottom + 16, 16)
+        if abs(tableView.contentInset.bottom - bottom) > 0.5 {
+            tableView.contentInset.bottom = bottom
+            tableView.verticalScrollIndicatorInsets.bottom = bottom
+        }
+    }
+
+    private func updatePreviewHeaderLayout() {
+        guard tableView.bounds.width > 0 else { return }
+        let height: CGFloat = 260
+        let horizontalInset: CGFloat = 20
+        let buttonSize: CGFloat = 34
+        let controlsY: CGFloat = 14
+        previousThemeButton.frame = CGRect(
+            x: horizontalInset,
+            y: controlsY,
+            width: buttonSize,
+            height: buttonSize
+        )
+        nextThemeButton.frame = CGRect(
+            x: tableView.bounds.width - horizontalInset - buttonSize,
+            y: controlsY,
+            width: buttonSize,
+            height: buttonSize
+        )
+        themeTitleLabel.frame = CGRect(
+            x: horizontalInset + buttonSize + 12,
+            y: controlsY - 2,
+            width: max(0, tableView.bounds.width - (horizontalInset + buttonSize + 12) * 2),
+            height: buttonSize + 4
+        )
+        let previewFrame = CGRect(
+            x: horizontalInset,
+            y: 58,
+            width: tableView.bounds.width - horizontalInset * 2,
+            height: 186
+        )
+        if previewHeaderView.frame.width != tableView.bounds.width ||
+            previewHeaderView.frame.height != height {
+            previewHeaderView.frame = CGRect(
+                x: 0,
+                y: 0,
+                width: tableView.bounds.width,
+                height: height
+            )
+            tableView.tableHeaderView = previewHeaderView
+        }
+        previewView.frame = previewFrame
+    }
+
+    private func selectTheme(at index: Int) {
+        let themes = ChatBubbleTheme.all
+        guard !themes.isEmpty else { return }
+        let normalizedIndex = (index % themes.count + themes.count) % themes.count
+        let theme = themes[normalizedIndex]
+        guard theme != selectedTheme else {
+            selectedThemeIndex = normalizedIndex
+            updateThemeControls()
+            return
+        }
+
+        selectedThemeIndex = normalizedIndex
+        selectedTheme = theme
+        ChatBubbleThemeStore.shared.setSelectedTheme(id: theme.id)
+        previewView.theme = theme
+        updateThemeControls()
+        tableView.reloadData()
+    }
+
+    private func updateThemeControls() {
+        themeTitleLabel.text = selectedTheme.title
+        let hasMultipleThemes = ChatBubbleTheme.all.count > 1
+        previousThemeButton.isEnabled = hasMultipleThemes
+        nextThemeButton.isEnabled = hasMultipleThemes
+        previousThemeButton.alpha = hasMultipleThemes ? 1.0 : 0.45
+        nextThemeButton.alpha = hasMultipleThemes ? 1.0 : 0.45
+    }
+
+    @objc private func previousThemeTapped() {
+        selectTheme(at: selectedThemeIndex - 1)
+    }
+
+    @objc private func nextThemeTapped() {
+        selectTheme(at: selectedThemeIndex + 1)
+    }
+}
+
+extension ChatThemeSettingsViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        ChatBubbleTheme.all.count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        String(localized: "Outgoing Bubbles")
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let identifier = "themeCell"
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier)
+            ?? UITableViewCell(style: .default, reuseIdentifier: identifier)
+        let theme = ChatBubbleTheme.all[indexPath.row]
+
+        cell.textLabel?.text = theme.title
+        cell.textLabel?.font = UIFont.systemFont(ofSize: 17)
+        cell.imageView?.image = ChatThemeSwatchImage.make(theme: theme)
+        cell.accessoryType = theme == selectedTheme ? .checkmark : .none
+        cell.tintColor = AppColor.accent
+        cell.selectionStyle = .default
+        cell.backgroundColor = .secondarySystemGroupedBackground
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        selectTheme(at: indexPath.row)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        GlassService.shared.setNeedsCapture()
+    }
+}
+
+private enum ChatThemeSwatchImage {
+    static func make(theme: ChatBubbleTheme, size: CGFloat = 34) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size))
+        return renderer.image { context in
+            let rect = CGRect(x: 0, y: 0, width: size, height: size)
+            context.cgContext.addEllipse(in: rect.insetBy(dx: 1, dy: 1))
+            context.cgContext.clip()
+
+            let colors = theme.outgoingGradientColors
+            if colors.count <= 1 {
+                context.cgContext.setFillColor((colors.first ?? .clear).cgColor)
+                context.cgContext.fill(rect)
+            }
+            let cgColors = colors.map { $0.cgColor } as CFArray
+            let locations = BubbleGradientStops.cgLocations(for: colors.count)
+            if let gradient = CGGradient(
+                colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                colors: cgColors,
+                locations: locations
+            ) {
+                let start = CGPoint(
+                    x: theme.startPoint.x * size,
+                    y: theme.startPoint.y * size
+                )
+                let end = CGPoint(
+                    x: theme.endPoint.x * size,
+                    y: theme.endPoint.y * size
+                )
+                context.cgContext.drawLinearGradient(
+                    gradient,
+                    start: start,
+                    end: end,
+                    options: []
+                )
+            }
+
+            context.cgContext.resetClip()
+            context.cgContext.setStrokeColor(UIColor.separator.cgColor)
+            context.cgContext.setLineWidth(1)
+            context.cgContext.strokeEllipse(in: rect.insetBy(dx: 0.5, dy: 0.5))
+        }
+    }
+}
+
+private final class ChatThemePreviewView: UIView {
+
+    var theme: ChatBubbleTheme {
+        didSet { applyTheme() }
+    }
+
+    private let outgoingGradientLayer = CAGradientLayer()
+    private let outgoingMaskLayer = CAShapeLayer()
+    private let incomingBubble = PreviewBubbleView(
+        text: String(localized: "How does this look?"),
+        time: "12:41",
+        style: .incoming
+    )
+    private let outgoingBubble = PreviewBubbleView(
+        text: String(localized: "Clean. Keep it."),
+        time: "12:42",
+        style: .outgoing
+    )
+    private let shortOutgoingBubble = PreviewBubbleView(
+        text: String(localized: "Done"),
+        time: "12:43",
+        style: .outgoing
+    )
+
+    init(theme: ChatBubbleTheme) {
+        self.theme = theme
+        super.init(frame: .zero)
+        backgroundColor = AppColor.chatBackground
+        layer.cornerRadius = 8
+        layer.cornerCurve = .continuous
+        clipsToBounds = true
+        outgoingGradientLayer.mask = outgoingMaskLayer
+        layer.addSublayer(outgoingGradientLayer)
+        addSubview(incomingBubble)
+        addSubview(outgoingBubble)
+        addSubview(shortOutgoingBubble)
+        applyTheme()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        outgoingGradientLayer.frame = bounds
+        let width = bounds.width
+        let horizontalInset: CGFloat = 16
+
+        let incomingWidth = min(width * 0.72, 230)
+        incomingBubble.frame = CGRect(
+            x: horizontalInset,
+            y: 18,
+            width: incomingWidth,
+            height: 44
+        )
+
+        let outgoingWidth = min(width * 0.76, 246)
+        outgoingBubble.frame = CGRect(
+            x: width - horizontalInset - outgoingWidth,
+            y: 76,
+            width: outgoingWidth,
+            height: 52
+        )
+
+        let shortWidth = min(width * 0.48, 150)
+        shortOutgoingBubble.frame = CGRect(
+            x: width - horizontalInset - shortWidth,
+            y: 142,
+            width: shortWidth,
+            height: 36
+        )
+        updateOutgoingMask()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) != false else {
+            return
+        }
+        backgroundColor = AppColor.chatBackground
+        applyTheme()
+    }
+
+    private func applyTheme() {
+        incomingBubble.colors = BubbleGradientRole.incoming.colors(
+            traits: traitCollection,
+            outgoingTheme: theme
+        )
+        outgoingGradientLayer.colors = theme.outgoingGradientColors.map {
+            $0.resolvedColor(with: traitCollection).cgColor
+        }
+        outgoingGradientLayer.locations = BubbleGradientStops.layerLocations(
+            for: theme.outgoingGradientColors.count
+        )
+        outgoingGradientLayer.startPoint = theme.startPoint
+        outgoingGradientLayer.endPoint = theme.endPoint
+    }
+
+    private func updateOutgoingMask() {
+        let path = UIBezierPath()
+        path.append(bubblePath(for: outgoingBubble.frame))
+        path.append(bubblePath(for: shortOutgoingBubble.frame))
+        outgoingMaskLayer.frame = bounds
+        outgoingMaskLayer.path = path.cgPath
+    }
+
+    private func bubblePath(for frame: CGRect) -> UIBezierPath {
+        UIBezierPath(
+            roundedRect: frame,
+            cornerRadius: MessageCellHelpers.bubbleCornerRadius
+        )
+    }
+}
+
+private final class PreviewBubbleView: UIView {
+
+    enum Style {
+        case incoming
+        case outgoing
+    }
+
+    var colors: [UIColor] = [] {
+        didSet { updateGradientColors() }
+    }
+
+    private let gradientLayer = CAGradientLayer()
+    private let textLabel = UILabel()
+    private let timeLabel = UILabel()
+    private let style: Style
+
+    init(text: String, time: String, style: Style) {
+        self.style = style
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+        layer.cornerRadius = MessageCellHelpers.bubbleCornerRadius
+        layer.cornerCurve = .continuous
+        layer.masksToBounds = true
+
+        gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 1.0, y: 1.0)
+        if style == .incoming {
+            layer.insertSublayer(gradientLayer, at: 0)
+        }
+
+        textLabel.text = text
+        textLabel.font = UIFont.systemFont(ofSize: 15)
+        textLabel.numberOfLines = 1
+        textLabel.lineBreakMode = .byTruncatingTail
+        addSubview(textLabel)
+
+        timeLabel.text = time
+        timeLabel.font = UIFont.systemFont(ofSize: 11)
+        timeLabel.textAlignment = .right
+        addSubview(timeLabel)
+
+        applyTextColors()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if style == .incoming {
+            gradientLayer.frame = bounds
+        }
+
+        let horizontalInset: CGFloat = 12
+        let verticalInset: CGFloat = 7
+        let timeWidth: CGFloat = 42
+        let timeHeight: CGFloat = 14
+        let textWidth = max(0, bounds.width - horizontalInset * 2 - timeWidth - 4)
+
+        textLabel.frame = CGRect(
+            x: horizontalInset,
+            y: verticalInset,
+            width: textWidth,
+            height: bounds.height - verticalInset * 2
+        )
+        timeLabel.frame = CGRect(
+            x: bounds.width - horizontalInset - timeWidth,
+            y: bounds.height - verticalInset - timeHeight + 1,
+            width: timeWidth,
+            height: timeHeight
+        )
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) != false else {
+            return
+        }
+        applyTextColors()
+        updateGradientColors()
+    }
+
+    private func applyTextColors() {
+        switch style {
+        case .incoming:
+            textLabel.textColor = AppColor.bubbleForegroundIncoming
+            timeLabel.textColor = AppColor.bubbleTimestampIncoming
+        case .outgoing:
+            textLabel.textColor = AppColor.bubbleForegroundOutgoing
+            timeLabel.textColor = AppColor.bubbleTimestampOutgoing
+        }
+    }
+
+    private func updateGradientColors() {
+        guard style == .incoming else { return }
+        gradientLayer.colors = colors.map {
+            $0.resolvedColor(with: traitCollection).cgColor
+        }
+        gradientLayer.locations = BubbleGradientStops.layerLocations(for: colors.count)
+    }
+}

--- a/Zyna/Screens/Settings/SettingsView.swift
+++ b/Zyna/Screens/Settings/SettingsView.swift
@@ -5,32 +5,143 @@
 
 import AsyncDisplayKit
 
-final class SettingsViewController: ASDKViewController<ASDisplayNode> {
-
-    private let textNode = ASTextNode()
+final class SettingsScreenNode: ASDisplayNode {
+    weak var glassTopBar: GlassTopBar?
+    weak var tableView: UITableView?
 
     override init() {
-        super.init(node: ScreenNode())
+        super.init()
+        backgroundColor = .appBG
+    }
 
-        textNode.attributedText = NSAttributedString(
-            string: String(localized: "Settings"),
-            attributes: [
-                .font: UIFont.boldSystemFont(ofSize: 24),
-                .foregroundColor: UIColor.black
-            ]
-        )
-
-        node.layoutSpecBlock = { [weak self] _, _ in
-            guard let self = self else { return ASLayoutSpec() }
-            return ASCenterLayoutSpec(
-                centeringOptions: .XY,
-                sizingOptions: [],
-                child: self.textNode
-            )
+    override var accessibilityElements: [Any]? {
+        get {
+            var elements: [Any] = []
+            if let glassTopBar, glassTopBar.view.superview === view {
+                elements.append(contentsOf: glassTopBar.accessibilityElementsInOrder)
+            }
+            if let tableView, tableView.superview === view {
+                elements.append(tableView)
+            }
+            return elements
         }
+        set { }
+    }
+}
+
+final class SettingsViewController: ASDKViewController<SettingsScreenNode> {
+
+    var onBack: (() -> Void)?
+    var onThemeTapped: (() -> Void)?
+
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private let glassTopBar = GlassTopBar()
+
+    override init() {
+        super.init(node: SettingsScreenNode())
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+        setupGlassTopBar()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        tableView.reloadData()
+        GlassService.shared.setNeedsCapture()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.frame = view.bounds
+        glassTopBar.updateLayout(in: view)
+        updateTableInsets()
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = .appBG
+        tableView.separatorStyle = .singleLine
+        tableView.contentInsetAdjustmentBehavior = .never
+        view.addSubview(tableView)
+        node.tableView = tableView
+    }
+
+    private func setupGlassTopBar() {
+        glassTopBar.backdropClearColor = .appBG
+        glassTopBar.sourceView = tableView
+        node.addSubnode(glassTopBar)
+        node.glassTopBar = glassTopBar
+
+        let backIcon = AppIcon.chevronBackward.rendered(
+            size: 17,
+            weight: .semibold,
+            color: AppColor.accent
+        )
+        glassTopBar.items = [
+            .circleButton(
+                icon: backIcon,
+                accessibilityLabel: String(localized: "Back"),
+                action: { [weak self] in self?.onBack?() }
+            ),
+            .title(text: String(localized: "Settings"), subtitle: nil)
+        ]
+    }
+
+    private func updateTableInsets() {
+        let top = glassTopBar.coveredHeight
+        if abs(tableView.contentInset.top - top) > 0.5 {
+            tableView.contentInset.top = top
+            tableView.verticalScrollIndicatorInsets.top = top
+        }
+        let bottom = max(view.safeAreaInsets.bottom + 16, 16)
+        if abs(tableView.contentInset.bottom - bottom) > 0.5 {
+            tableView.contentInset.bottom = bottom
+            tableView.verticalScrollIndicatorInsets.bottom = bottom
+        }
+    }
+}
+
+extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        1
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        String(localized: "Appearance")
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let identifier = "valueCell"
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier)
+            ?? UITableViewCell(style: .value1, reuseIdentifier: identifier)
+        cell.textLabel?.text = String(localized: "Chat Theme")
+        cell.detailTextLabel?.text = ChatBubbleThemeStore.shared.selectedTheme.title
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.backgroundColor = .secondarySystemGroupedBackground
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        onThemeTapped?()
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        GlassService.shared.setNeedsCapture()
     }
 }

--- a/Zyna/Services/Database/DatabaseService.swift
+++ b/Zyna/Services/Database/DatabaseService.swift
@@ -281,10 +281,93 @@ final class DatabaseService {
                             identifierValue
                         )
                     WHERE identifierValue IS NULL
+                """
+            )
+        }
+
+        migrator.registerMigration("v9_uniqueStoredMessageEventId") { db in
+            try Self.pruneStoredMessageEventIdDuplicates(in: db)
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_storedMessage_eventId")
+            try db.execute(
+                sql: """
+                    CREATE UNIQUE INDEX idx_storedMessage_eventId
+                    ON storedMessage(roomId, eventId)
+                    WHERE eventId IS NOT NULL
                     """
             )
         }
 
         return migrator
+    }
+
+    private struct StoredMessageEventKey: Hashable {
+        let roomId: String
+        let eventId: String
+    }
+
+    private static func pruneStoredMessageEventIdDuplicates(in db: Database) throws {
+        try db.execute(sql: "UPDATE storedMessage SET eventId = NULL WHERE eventId = ''")
+
+        let messages = try StoredMessage
+            .filter(Column("eventId") != nil)
+            .fetchAll(db)
+
+        guard messages.count > 1 else { return }
+
+        var bestByKey: [StoredMessageEventKey: StoredMessage] = [:]
+        for message in messages {
+            guard let eventId = message.eventId, !eventId.isEmpty else { continue }
+            let key = StoredMessageEventKey(roomId: message.roomId, eventId: eventId)
+            if let existing = bestByKey[key] {
+                bestByKey[key] = preferredStoredMessage(existing, message)
+            } else {
+                bestByKey[key] = message
+            }
+        }
+
+        for message in messages {
+            guard let eventId = message.eventId, !eventId.isEmpty else { continue }
+            let key = StoredMessageEventKey(roomId: message.roomId, eventId: eventId)
+            guard bestByKey[key]?.id != message.id else { continue }
+            try StoredMessage.deleteOne(db, key: message.id)
+        }
+    }
+
+    private static func preferredStoredMessage(
+        _ lhs: StoredMessage,
+        _ rhs: StoredMessage
+    ) -> StoredMessage {
+        let lhsScore = storedMessageDedupScore(lhs)
+        let rhsScore = storedMessageDedupScore(rhs)
+        if lhsScore != rhsScore {
+            return lhsScore > rhsScore ? lhs : rhs
+        }
+        if lhs.timestamp != rhs.timestamp {
+            return lhs.timestamp > rhs.timestamp ? lhs : rhs
+        }
+        return lhs.id > rhs.id ? lhs : rhs
+    }
+
+    private static func storedMessageDedupScore(_ message: StoredMessage) -> Int {
+        var score = 0
+        if message.contentType == "redacted" { score += 1_000 }
+        if message.eventId != nil { score += 100 }
+        if message.transactionId != nil { score += 20 }
+        switch message.sendStatus {
+        case "read":
+            score += 12
+        case "synced":
+            score += 10
+        case "sent":
+            score += 8
+        case "sending":
+            score += 2
+        default:
+            score += 4
+        }
+        if !(message.zynaAttributesJSON ?? "").isEmpty {
+            score += 1
+        }
+        return score
     }
 }

--- a/Zyna/Services/Database/MessageWindow.swift
+++ b/Zyna/Services/Database/MessageWindow.swift
@@ -458,6 +458,7 @@ final class MessageWindow {
 
     private func messageScore(_ message: StoredMessage) -> Int {
         var score = 0
+        if message.contentType == "redacted" { score += 1_000 }
         if message.eventId != nil { score += 100 }
         if message.transactionId != nil { score += 20 }
         switch message.sendStatus {

--- a/Zyna/Services/RoomListService.swift
+++ b/Zyna/Services/RoomListService.swift
@@ -70,7 +70,10 @@ final class ZynaRoomListService: NSObject {
         }), !stored.isEmpty else { return }
 
         let summaries = stored.map { $0.toRoomSummary() }
-        publishedSummariesByRoomId = Dictionary(uniqueKeysWithValues: summaries.map { ($0.id, $0) })
+        publishedSummariesByRoomId = Dictionary(
+            summaries.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
         roomsSubject.send(summaries)
         logRooms("Loaded \(summaries.count) cached rooms from GRDB")
     }
@@ -215,7 +218,8 @@ final class ZynaRoomListService: NSObject {
             guard !Task.isCancelled, self.rebuildRevision == revision else { return }
 
             self.publishedSummariesByRoomId = Dictionary(
-                uniqueKeysWithValues: summaries.map { ($0.id, $0) }
+                summaries.map { ($0.id, $0) },
+                uniquingKeysWith: { _, latest in latest }
             )
             Self.writeRoomsToGRDB(summaries)
 

--- a/Zyna/Services/TimelineService.swift
+++ b/Zyna/Services/TimelineService.swift
@@ -60,10 +60,12 @@ final class TimelineService {
 
     // MARK: - Start
 
-    func startListening() async {
+    func startListening(subscribeForSync: Bool = true) async {
         do {
             // Subscribe room for full sliding sync delivery (live events)
-            try? await MatrixClientService.shared.roomListService?.subscribeToRooms(roomIds: [room.id()])
+            if subscribeForSync {
+                try? await MatrixClientService.shared.roomListService?.subscribeToRooms(roomIds: [room.id()])
+            }
 
             let timeline = try await room.timeline()
             self.timeline = timeline


### PR DESCRIPTION
## Summary
- Added long-press chat peek previews from the rooms list, letting users read a chat without marking messages as read.
- Added sticky date headers and date divider rows in chat, including accessibility support.
- Added Profile → Settings → Chat Theme with 10 localized outgoing bubble themes and live previews.
- Hardened Matrix event deduplication with duplicate pruning and a unique `(roomId, eventId)` database index.
- Improved glass rendering stability during keyboard/navigation redraws and capped capture cache memory.
- Bumped app version to 2.2 (13).